### PR TITLE
🐛 FIX: dists table should not has path unique key

### DIFF
--- a/sql/init.sql
+++ b/sql/init.sql
@@ -112,8 +112,7 @@ CREATE TABLE IF NOT EXISTS `dists` (
   `shasum` varchar(512) NOT NULL COMMENT 'dist shasum',
   `integrity` varchar(512) NOT NULL COMMENT 'dist integrity',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `uk_dist_id` (`dist_id`),
-  UNIQUE KEY `uk_path` (`path`)
+  UNIQUE KEY `uk_dist_id` (`dist_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci COMMENT='dist info';
 
 CREATE TABLE IF NOT EXISTS `total` (


### PR DESCRIPTION
sqlMessage: "Duplicate entry '/packages/koa-middlewares/abbreviated_manifests.json' for key 'uk_path'"
sqlState: "23000"
index: 0
sql: "INSERT INTO `dists` (`gmt_create`, `gmt_modified`, `dist_id`, `name`, `path`, `size`, `shasum`, `integrity`) VALUES ('2021-12-18 21:47:14.766', '2021-12-18 21:47:14.766', '61bde662a6f1dd2f7de4173b', 'abbreviated_manifests.json', '/packages/koa-middlewares/abbreviated_manifests.json', 31687, 'db5874f05972871f3b21e356e7ce03f0b73c1802', 'sha512-vwNzCjJK/EI1jeZ4rXWcHpSqdTmK37JTEWQTZXobD/QiPzczQXeJHVee+JDiWnQYbmg8S/NJX979mzouObAP1Q==')"
name: "ER_DUP_ENTRYError"
pid: 143227