### PR TITLE
🐛 FIX: ignore duplicate key filename on python binary

### DIFF
--- a/app/common/adapter/binary/NodeBinary.ts
+++ b/app/common/adapter/binary/NodeBinary.ts
@@ -20,6 +20,8 @@ export class NodeBinary extends AbstractBinary {
       const date = m[2];
       const size = m[3];
       if (size === '0') continue;
+      if (this.binaryConfig.ignoreFiles?.includes(`${dir}${name}`)) continue;
+
       items.push({
         name,
         isDir,

--- a/app/port/binary.html
+++ b/app/port/binary.html
@@ -176,7 +176,19 @@
           var item = files[i];
           var link = item.url;
           var filename = item.name;
-          var size = item.size / 1024 / 1024;
+          var sizeUnit = '';
+          var size = item.size;
+          if (size > 1024) {
+            sizeUnit = 'KB';
+            size = size / 1024;
+            if (size > 1024) {
+              sizeUnit = 'MB';
+              size = size / 1024;
+            }
+          }
+          if (sizeUnit !== '') {
+            size = size.toFixed(2) + sizeUnit;
+          }
           var lastModified = item.date;          
           // Remove the entries we don't want to show.
           if (filename == '') {
@@ -193,7 +205,7 @@
           document.write('<td><a href="' + link + '">' + filename +
                          '</a></td>');
           document.write('<td align="right">' + lastModified + '</td>');
-          document.write('<td align="right">' + size.toFixed(2) + 'MB</td>');
+          document.write('<td align="right">' + size + '</td>');
           document.write('</tr>');
         }
  

--- a/config/binaries.ts
+++ b/config/binaries.ts
@@ -18,6 +18,7 @@ export type BinaryTaskConfig = {
   repo: string;
   distUrl: string;
   ignoreDirs?: string[];
+  ignoreFiles?: string[];
   options?: {
     nodePlatforms?: string[],
     nodeArchs?: {
@@ -84,6 +85,9 @@ const binaries: {
     syncer: SyncerClass.NodeBinary,
     repo: 'python/cpython',
     distUrl: 'https://www.python.org/ftp/python',
+    ignoreFiles: [
+      '/src/Python-1.6.tar.gz',
+    ],
   },
   // CypressBinary
   cypress: {

--- a/test/common/adapter/binary/NodeBinary.test.ts
+++ b/test/common/adapter/binary/NodeBinary.test.ts
@@ -229,6 +229,11 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
       assert(matchDir1);
       assert(matchDir2);
       assert(matchFile);
+
+      result = await binary.fetch('/src/');
+      assert(result);
+      assert(result.items.length > 0);
+      assert(!result.items.find(item => item.name === 'Python-1.6.tar.gz'));
     });
   });
 });


### PR DESCRIPTION
log: https://r.cnpmjs.org/-/binary/python/syncs/61ffced0bb8a154e465993a7/log