### PR TITLE
🐛 FIX: mozjpeg-bin should use mozjpeg for npm package name

### DIFF
--- a/app/common/adapter/binary/ImageminBinary.ts
+++ b/app/common/adapter/binary/ImageminBinary.ts
@@ -8,7 +8,8 @@ export class ImageminBinary extends AbstractBinary {
   async fetch(dir: string): Promise<FetchResult | undefined> {
     if (!this.dirItems) {
       this.dirItems = {};
-      const pkgUrl = `https://registry.npmjs.com/${this.binaryConfig.category}`;
+      const npmPacakgeName = this.binaryConfig.options?.npmPacakgeName ?? this.binaryConfig.category;
+      const pkgUrl = `https://registry.npmjs.com/${npmPacakgeName}`;
       const data = await this.requestJSON(pkgUrl);
       this.dirItems = {};
       this.dirItems['/'] = [];

--- a/config/binaries.ts
+++ b/config/binaries.ts
@@ -313,6 +313,8 @@ const binaries: {
     repo: 'imagemin/gifsicle-bin',
     distUrl: 'https://raw.githubusercontent.com',
     options: {
+      // should use https://www.npmjs.com/package/gifsicle
+      npmPacakgeName: 'gifsicle',
       // https://github.com/imagemin/gifsicle-bin/blob/v4.0.0/lib/index.js
       // https://github.com/imagemin/gifsicle-bin/blob/v5.0.0/lib/index.js
       nodePlatforms: [ 'macos', 'linux', 'freebsd', 'win' ],
@@ -496,6 +498,8 @@ const binaries: {
     repo: 'imagemin/guetzli-bin',
     distUrl: 'https://raw.githubusercontent.com',
     options: {
+      // should use https://www.npmjs.com/package/guetzli
+      npmPacakgeName: 'guetzli',
       // https://github.com/imagemin/guetzli-bin/blob/v4.0.0/lib/index.js
       nodePlatforms: [ 'macos', 'linux', 'win' ],
       nodeArchs: {

--- a/config/binaries.ts
+++ b/config/binaries.ts
@@ -30,6 +30,8 @@ export type BinaryTaskConfig = {
     },
     // default is 1
     maxPage?: number;
+    // custom npm package name, for ImageminBinary
+    npmPacakgeName?: string;
   },
   disable?: boolean;
 };
@@ -285,6 +287,8 @@ const binaries: {
     repo: 'imagemin/mozjpeg-bin',
     distUrl: 'https://raw.githubusercontent.com',
     options: {
+      // should use https://www.npmjs.com/package/mozjpeg
+      npmPacakgeName: 'mozjpeg',
       // https://github.com/imagemin/mozjpeg-bin/blob/v4.0.0/lib/index.js
       // https://github.com/imagemin/mozjpeg-bin/blob/v5.0.0/lib/index.js
       nodePlatforms: [ 'osx', 'macos', 'linux', 'win' ],

--- a/test/common/adapter/binary/ImageminBinary.test.ts
+++ b/test/common/adapter/binary/ImageminBinary.test.ts
@@ -192,4 +192,134 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
     assert(result.items[0].url === 'https://raw.githubusercontent.com/imagemin/mozjpeg-bin/v8.0.0/vendor/macos/cjpeg');
     assert(result.items[0].isDir === false);
   });
+
+  it('should fetch gifsicle-bin', async () => {
+    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['gifsicle-bin']);
+    const result = await binary.fetch('/');
+    assert(result);
+    // console.log(result.items);
+    assert(result.items.length > 0);
+    let matchDir1 = false;
+    let matchDir2 = false;
+    for (const item of result.items) {
+      if (item.name === 'v4.0.0/') {
+        assert(item.date);
+        assert(item.isDir === true);
+        assert(item.size === '-');
+        matchDir1 = true;
+      }
+      if (item.name === 'v6.0.1/') {
+        assert(item.date);
+        assert(item.isDir === true);
+        assert(item.size === '-');
+        matchDir2 = true;
+      }
+    }
+    assert(matchDir1);
+    assert(matchDir2);
+  });
+
+  it('should fetch optipng-bin', async () => {
+    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['optipng-bin']);
+    const result = await binary.fetch('/');
+    assert(result);
+    // console.log(result.items);
+    assert(result.items.length > 0);
+    let matchDir1 = false;
+    let matchDir2 = false;
+    for (const item of result.items) {
+      if (item.name === 'v4.0.0/') {
+        assert(item.date);
+        assert(item.isDir === true);
+        assert(item.size === '-');
+        matchDir1 = true;
+      }
+      if (item.name === 'v6.0.0/') {
+        assert(item.date);
+        assert(item.isDir === true);
+        assert(item.size === '-');
+        matchDir2 = true;
+      }
+    }
+    assert(matchDir1);
+    assert(matchDir2);
+  });
+
+  it('should fetch zopflipng-bin', async () => {
+    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['zopflipng-bin']);
+    const result = await binary.fetch('/');
+    assert(result);
+    // console.log(result.items);
+    assert(result.items.length > 0);
+    let matchDir1 = false;
+    let matchDir2 = false;
+    for (const item of result.items) {
+      if (item.name === 'v4.0.0/') {
+        assert(item.date);
+        assert(item.isDir === true);
+        assert(item.size === '-');
+        matchDir1 = true;
+      }
+      if (item.name === 'v6.0.1/') {
+        assert(item.date);
+        assert(item.isDir === true);
+        assert(item.size === '-');
+        matchDir2 = true;
+      }
+    }
+    assert(matchDir1);
+    assert(matchDir2);
+  });
+
+  it('should fetch jpegoptim-bin', async () => {
+    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['jpegoptim-bin']);
+    const result = await binary.fetch('/');
+    assert(result);
+    // console.log(result.items);
+    assert(result.items.length > 0);
+    let matchDir1 = false;
+    let matchDir2 = false;
+    for (const item of result.items) {
+      if (item.name === 'v4.0.0/') {
+        assert(item.date);
+        assert(item.isDir === true);
+        assert(item.size === '-');
+        matchDir1 = true;
+      }
+      if (item.name === 'v6.0.1/') {
+        assert(item.date);
+        assert(item.isDir === true);
+        assert(item.size === '-');
+        matchDir2 = true;
+      }
+    }
+    assert(matchDir1);
+    assert(matchDir2);
+  });
+
+  it('should fetch guetzli-bin', async () => {
+    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['guetzli-bin']);
+    const result = await binary.fetch('/');
+    assert(result);
+    // console.log(result.items);
+    assert(result.items.length > 0);
+    let matchDir1 = false;
+    let matchDir2 = false;
+    for (const item of result.items) {
+      if (item.name === 'v4.0.0/') {
+        assert(item.date);
+        assert(item.isDir === true);
+        assert(item.size === '-');
+        matchDir1 = true;
+      }
+      if (item.name === 'v4.0.2/') {
+        assert(item.date);
+        assert(item.isDir === true);
+        assert(item.size === '-');
+        matchDir2 = true;
+      }
+    }
+    assert(matchDir1);
+    assert(matchDir2);
+  });
 });

--- a/test/common/adapter/binary/ImageminBinary.test.ts
+++ b/test/common/adapter/binary/ImageminBinary.test.ts
@@ -131,4 +131,65 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
     assert(result.items[0].url === 'https://raw.githubusercontent.com/imagemin/advpng-bin/v4.0.0/vendor/osx/advpng');
     assert(result.items[0].isDir === false);
   });
+
+  it('should fetch mozjpeg-bin', async () => {
+    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['mozjpeg-bin']);
+    let result = await binary.fetch('/');
+    assert(result);
+    // console.log(result.items);
+    assert(result.items.length > 0);
+    let matchDir1 = false;
+    let matchDir2 = false;
+    for (const item of result.items) {
+      if (item.name === 'v4.0.0/') {
+        assert(item.date);
+        assert(item.isDir === true);
+        assert(item.size === '-');
+        matchDir1 = true;
+      }
+      if (item.name === 'v6.0.1/') {
+        assert(item.date);
+        assert(item.isDir === true);
+        assert(item.size === '-');
+        matchDir2 = true;
+      }
+    }
+    assert(matchDir1);
+    assert(matchDir2);
+
+    // https://github.com/imagemin/mozjpeg-bin/blob/v4.0.0/lib/index.js
+    result = await binary.fetch('/v4.0.0/');
+    assert(result);
+    assert(result.items.length === 1);
+    assert(result.items[0].name === 'vendor/');
+    assert(result.items[0].isDir === true);
+
+    result = await binary.fetch('/v4.0.0/vendor/');
+    assert(result);
+    assert(result.items.length === 4);
+    assert(result.items[0].name === 'osx/');
+    assert(result.items[0].isDir === true);
+    assert(result.items[1].name === 'macos/');
+    assert(result.items[1].isDir === true);
+    assert(result.items[2].name === 'linux/');
+    assert(result.items[2].isDir === true);
+    assert(result.items[3].name === 'win/');
+    assert(result.items[3].isDir === true);
+
+    result = await binary.fetch('/v4.0.0/vendor/osx/');
+    assert(result);
+    // console.log(result.items);
+    assert(result.items.length === 1);
+    assert(result.items[0].name === 'cjpeg');
+    assert(result.items[0].url === 'https://raw.githubusercontent.com/imagemin/mozjpeg-bin/v4.0.0/vendor/osx/cjpeg');
+    assert(result.items[0].isDir === false);
+
+    result = await binary.fetch('/v8.0.0/vendor/macos/');
+    assert(result);
+    // console.log(result.items);
+    assert(result.items.length === 1);
+    assert(result.items[0].name === 'cjpeg');
+    assert(result.items[0].url === 'https://raw.githubusercontent.com/imagemin/mozjpeg-bin/v8.0.0/vendor/macos/cjpeg');
+    assert(result.items[0].isDir === false);
+  });
 });


### PR DESCRIPTION
closes https://github.com/cnpm/mirrors/issues/283