### PR TITLE
feat: change node distUrl to release

### DIFF
--- a/config/binaries.ts
+++ b/config/binaries.ts
@@ -53,7 +53,7 @@ const binaries: {
     description: 'Node.js® is a JavaScript runtime built on Chrome\'s V8 JavaScript engine.',
     syncer: SyncerClass.NodeBinary,
     repo: 'nodejs/node',
-    distUrl: 'https://nodejs.org/dist',
+    distUrl: 'https://nodejs.org/download/release',
   },
   'node-rc': {
     category: 'node-rc',

--- a/test/common/adapter/binary/NodeBinary.test.ts
+++ b/test/common/adapter/binary/NodeBinary.test.ts
@@ -34,7 +34,7 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
           assert(item.date === '26-Aug-2011 16:21');
           assert(item.isDir === false);
           assert(item.size === '3813493');
-          assert(item.url === 'https://nodejs.org/dist/node-v0.1.100.tar.gz');
+          assert(item.url === 'https://nodejs.org/download/release/node-v0.1.100.tar.gz');
           matchFile = true;
         }
         if (!item.isDir) {
@@ -64,7 +64,7 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
           assert(item.date === '01-Dec-2021 16:13');
           assert(item.isDir === false);
           assert(item.size === '3153');
-          assert(item.url === 'https://nodejs.org/dist/v16.13.1/SHASUMS256.txt');
+          assert(item.url === 'https://nodejs.org/download/release/v16.13.1/SHASUMS256.txt');
           matchFile = true;
         }
         if (!item.isDir) {


### PR DESCRIPTION
是否考虑把 /dist 改成 download/release，目前遇到一个问题是， dist 有部分镜像版本的缺失，例如 v16.x 的 [latest](https://nodejs.org/download/release/latest-v16.x/) 版本更新到了 v16.14.1，但是 [dist](https://nodejs.org/dist/) 没有，导致镜像下载失败。

```
nvm install lts/gallium
nvm use lts/gallium
```

上面这行代码 `install` 过程会导致 404