### PR TITLE
feat: sso support oauth2

### DIFF
--- a/app/common/UserUtil.ts
+++ b/app/common/UserUtil.ts
@@ -3,6 +3,7 @@ import base from 'base-x';
 import { crc32 } from '@node-rs/crc32';
 import * as ssri from 'ssri';
 
+const words = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz~!@-#$';
 const base62 = base('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ');
 
 const crc32Buffer = Buffer.alloc(4);
@@ -38,4 +39,11 @@ export function checkIntegrity(plain: string, expectedIntegrity: string): boolea
 
 export function sha512(plain: string): string {
   return crypto.createHash('sha512').update(plain).digest('hex');
+}
+
+// https://stackoverflow.com/questions/9719570/generate-random-password-string-with-requirements-in-javascript
+export function randomPassword(length = 10): string {
+  return Array.from(crypto.randomFillSync(new Uint32Array(length)))
+    .map(x => words[x % words.length])
+    .join('');
 }

--- a/app/core/entity/User.ts
+++ b/app/core/entity/User.ts
@@ -1,7 +1,7 @@
 import { Entity, EntityData } from './Entity';
 import { EasyData, EntityUtil } from '../util/EntityUtil';
 
-interface UserData extends EntityData {
+export interface UserData extends EntityData {
   userId: string;
   name: string;
   email: string;

--- a/app/core/service/SsoService.ts
+++ b/app/core/service/SsoService.ts
@@ -1,0 +1,99 @@
+import {
+  AccessLevel,
+  ContextProto,
+  Inject,
+} from '@eggjs/tegg';
+
+import { AbstractService } from '../../common/AbstractService';
+import { EggContextHttpClient } from 'egg';
+import { ForbiddenError } from 'egg-errors';
+import { randomToken } from '../../../app/common/UserUtil';
+import { UserData } from '../entity/User';
+
+// sso user info must have fields name and email, edit next line if you custom response.
+type SSOUserInfo = Pick<UserData, 'name' | 'email'>;
+
+interface AccessToken {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  refresh_token: string;
+  scope: string;
+}
+
+@ContextProto({
+  accessLevel: AccessLevel.PUBLIC,
+})
+export class SsoService extends AbstractService {
+  @Inject()
+  private readonly httpclient: EggContextHttpClient;
+  private timeout = 10000;
+
+  getLoginUrlAndToken() {
+    const { clientId, scope, authorizationUri, redirectUri } = this.config.cnpmcore.oauth2;
+    const token = randomToken(this.config.cnpmcore.name);
+    const params = new URLSearchParams({
+      client_id: clientId,
+      scope,
+      response_type: 'code',
+      redirect_uri: redirectUri,
+      state: token,
+    });
+    const loginUrl = `${authorizationUri}?${params.toString()}`;
+    return [ loginUrl, token ];
+  }
+
+  async getAccessToken(code: string): Promise<AccessToken> {
+    const {
+      clientIdName,
+      clientSecretName,
+      accessTokenUri,
+      clientId,
+      clientSecret,
+      redirectUri,
+    } = this.config.cnpmcore.oauth2;
+
+    const params = {
+      code,
+      [clientIdName || 'client_id']: clientId,
+      [clientSecretName || 'client_secret']: clientSecret,
+      redirect_uri: redirectUri,
+      grant_type: 'authorization_code',
+    };
+
+    const { status, data } = await this.httpclient.request(accessTokenUri, {
+      method: 'POST',
+      data: params,
+      contentType: 'application/x-www-form-urlencoded',
+      dataType: 'json',
+      timing: true,
+      timeout: this.timeout,
+      followRedirect: true,
+    });
+
+    if (status !== 200) {
+      throw new ForbiddenError(`Get access_token error, status: "${status}", body: ${data}`);
+    }
+
+    return data;
+  }
+
+
+  async getUserInfo(accessToken: string): Promise<SSOUserInfo> {
+    const { userInfoUri } = this.config.cnpmcore.oauth2;
+    const url = new URL(userInfoUri);
+    url.searchParams.append('access_token', accessToken);
+
+    const { status, data } = await this.httpclient.curl(url.href, {
+      timeout: this.timeout,
+      dataType: 'json',
+    });
+
+    if (status !== 200) {
+      throw new ForbiddenError(`Get user info error, status: "${status}", data: ${data}`);
+    }
+
+    return data;
+  }
+
+}

--- a/app/core/service/SsoService.ts
+++ b/app/core/service/SsoService.ts
@@ -39,7 +39,7 @@ export class SsoService extends AbstractService {
       redirect_uri: redirectUri,
       state: token,
     });
-    const loginUrl = `${authorizationUri}?${params.toString()}`;
+    const loginUrl = `${authorizationUri}?${decodeURIComponent(params.toString())}`;
     return [ loginUrl, token ];
   }
 

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -69,6 +69,22 @@ export default (appInfo: EggAppConfig) => {
     cdnVaryHeader: 'Accept, Accept-Encoding',
     // store full package version manifests data to database table(package_version_manifests), default is false
     enableStoreFullPackageVersionManifestsToDatabase: false,
+    oauth2: {
+      enable: false,
+      npmOauthUser: 'npm_oauth_auth_dummy_user',
+      clientIdName: 'client_id',
+      clientSecretName: 'client_secret',
+      clientId: 'client_id',
+      clientSecret: 'client_secret',
+      scope: '',
+      // sso url
+      redirectUri: 'https://your_cnpm_host.com/-/sso/callback',
+      host: 'https://sso-example.com.com',
+      accessTokenUri: 'https://sso-example.com/oauth2/access_token',
+      authorizationUri: 'https://sso-example.com/oauth2/authorize',
+      userInfoUri: 'https://sso-example.com/oauth2/userinfo',
+      logoutUri: 'https://sso-example.com/oauth2/logout',
+    },
   };
 
   // override config from framework / plugin

--- a/test/common/UserUtil.test.ts
+++ b/test/common/UserUtil.test.ts
@@ -1,5 +1,5 @@
 import assert = require('assert');
-import { randomToken, checkToken } from '../../app/common/UserUtil';
+import { randomToken, checkToken, randomPassword } from '../../app/common/UserUtil';
 
 describe('test/common/UserUtil.test.ts', () => {
   describe('randomToken()', () => {
@@ -22,6 +22,12 @@ describe('test/common/UserUtil.test.ts', () => {
       assert(!checkToken('cnpm_1_2', 'npm'));
       assert(!checkToken('cnpm_1_2', 'cnpm'));
       assert(!checkToken('cnpm_1?!@#_2\\dd', 'cnpm'));
+    });
+  });
+
+  describe('randomPassword()', () => {
+    it('should work', () => {
+      assert.equal(randomPassword().length, 10);
     });
   });
 });

--- a/test/core/service/SsoService/auth.test.ts
+++ b/test/core/service/SsoService/auth.test.ts
@@ -1,0 +1,68 @@
+import assert = require('assert');
+import { app } from 'egg-mock/bootstrap';
+import { Context } from 'egg';
+
+import { SsoService } from 'app/core/service/SsoService';
+
+describe('test/core/service/SsoService/auth.test.ts', () => {
+  let ctx: Context;
+  let ssoService: SsoService;
+  const mockedAccessToken = 'mock_access_token';
+
+  beforeEach(async () => {
+    ctx = await app.mockModuleContext();
+    ssoService = await ctx.getEggObject(SsoService);
+  });
+
+  afterEach(async () => {
+    await app.destroyModuleContext(ctx);
+  });
+
+  describe('getLoginUrlAndToken()', () => {
+    it('should get url and token', () => {
+      const { oauth2 } = app.config.cnpmcore;
+      const { clientId, redirectUri, authorizationUri } = oauth2;
+      const [ url, token ] = ssoService.getLoginUrlAndToken();
+      const u = new URL(url);
+      const query = u.searchParams;
+      assert(query.get('client_id') === clientId);
+      assert(query.get('redirect_uri') === redirectUri);
+      assert(query.get('state') === token);
+      assert(`${u.origin}${u.pathname}` === authorizationUri);
+      assert.match(token, /^cnpm_\w+/);
+    });
+  });
+
+  describe('getAccessToken()', () => {
+    it('should get access token', async () => {
+      const { oauth2 } = app.config.cnpmcore;
+      const { accessTokenUri } = oauth2;
+      app.mockHttpclient(accessTokenUri, {
+        status: 200,
+        data: {
+          access_token: mockedAccessToken,
+        },
+      });
+      const accessToken = await ssoService.getAccessToken('mock_code');
+      assert(accessToken.access_token === mockedAccessToken);
+    });
+  });
+
+  describe('getUserInfo()', async () => {
+    it('should get user info', async () => {
+      const { oauth2 } = app.config.cnpmcore;
+      const { userInfoUri } = oauth2;
+      app.mockHttpclient(`${userInfoUri}?access_token=${mockedAccessToken}`, {
+        status: 200,
+        data: {
+          name: 'cnpm_user',
+          email: 'cnpm_user@npmmirror.com',
+        },
+      });
+      const userInfo = await ssoService.getUserInfo(mockedAccessToken);
+      assert(userInfo.name === 'cnpm_user');
+      assert(userInfo.email === 'cnpm_user@npmmirror.com');
+    });
+  });
+
+});


### PR DESCRIPTION
### 尝试提供一种 SSO 鉴权的能力 OAuth2。

原理：

1. 执行 `npm login --auth-type=sso` 后，npm cli 会根据 `/-/user/org.couchdb.user:npm_oauth_auth_dummy_user` 记录返回的 `token` 和 `sso` 登录跳转地址，并且打开浏览器登录。
2. 登录成功后，`sso` 返回用户名（name）+ 邮箱（email） 信息，server 端将该 `token` 和对应 `userID` set 到数据库，若无则创建 `user` 并 set 当前 `token`。
3. 客户端（npm cli）将 `callback` 返回的（sso 中的 state 参数）`token` 放在 request header 中 loop `/whoami` 接口，直至查询到对应 user 和 token 匹配后结束。

> 此过程应先创建 token，因此代码中有覆盖 token 的操作。
--- 
try
```bash
npm login --auth-type=sso --registry=http://localhost:7001 --verbose
```

see

```bash
$ npm login --registry=http://localhost:7001 --auth-typ=sso --verbose
npm verb cli /Users/lishimin/.nvm/versions/node/v16.0.0/bin/node /usr/local/bin/npm
npm info using npm@8.6.0
npm info using node@v16.0.0
npm timing npm:load:whichnode Completed in 0ms
npm timing config:load:defaults Completed in 1ms
npm timing config:load:file:/usr/local/lib/node_modules/npm/npmrc Completed in 2ms
npm timing config:load:builtin Completed in 2ms
npm verb config auth-type This method of SSO/SAML/OAuth is deprecated and will be removed in
npm verb config a future version of npm in favor of web-based login.
npm timing config:load:cli Completed in 3ms
npm timing config:load:env Completed in 0ms
npm timing config:load:project Completed in 1ms
npm timing config:load:file:/Users/lishimin/.npmrc Completed in 1ms
npm timing config:load:user Completed in 1ms
npm timing config:load:file:/usr/local/etc/npmrc Completed in 0ms
npm timing config:load:global Completed in 0ms
npm timing config:load:validate Completed in 0ms
npm timing config:load:credentials Completed in 1ms
npm timing config:load:setEnvs Completed in 0ms
npm timing config:load Completed in 9ms
npm timing npm:load:configload Completed in 10ms
npm timing npm:load:mkdirpcache Completed in 1ms
npm timing npm:load:mkdirplogs Completed in 1ms
npm verb title npm login
npm verb argv "login" "--registry" "http://localhost:7001" "--auth-typ" "sso" "--loglevel" "verbose"
npm timing npm:load:setTitle Completed in 14ms
npm timing config:load:flatten Completed in 2ms
npm timing npm:load:display Completed in 6ms
npm verb logfile logs-max:10 dir:/Users/lishimin/.npm/_logs
npm verb logfile /Users/lishimin/.npm/_logs/2022-05-05T16_59_21_654Z-debug-0.log
npm timing npm:load:logFile Completed in 3ms
npm timing npm:load:timers Completed in 0ms
npm timing npm:load:configScope Completed in 0ms
npm timing npm:load Completed in 36ms
npm notice Log in on http://localhost:7001/
npm WARN deprecated SSO --auth-type is deprecated
npm verb login before first PUT {
npm verb login   _id: 'org.couchdb.user:npm_oauth_auth_dummy_user',
npm verb login   name: 'npm_oauth_auth_dummy_user',
npm verb login   password: 'XXXXX',
npm verb login   type: 'user',
npm verb login   roles: [],
npm verb login   date: '2022-05-05T16:59:21.700Z'
npm verb login }
npm http fetch PUT 200 http://localhost:7001/-/user/org.couchdb.user:npm_oauth_auth_dummy_user 38ms
npm info adduser Polling for validated SSO session
npm http fetch GET 401 http://localhost:7001/-/whoami 27ms (cache skip)
npm info adduser Polling for validated SSO session
npm http fetch GET 401 http://localhost:7001/-/whoami 7ms (cache skip)
npm info adduser Polling for validated SSO session
npm http fetch GET 200 http://localhost:7001/-/whoami 57ms (cache updated)
npm info adduser Authorized user <sso_username>
Logged in as <sso_username> on http://localhost:7001/.
npm timing command:login Completed in 1283ms
npm verb exit 0
npm timing config:load:flatten Completed in 1ms
npm timing npm Completed in 1328ms
npm info ok
```