### PR TITLE
fix: lock mariadb version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - cnpm
 
   mysql:
-    image: mariadb
+    image: mariadb:10.7
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     restart: always
     environment:


### PR DESCRIPTION
mariadb:10.8 的 docker 镜像有问题，执行指令变成了 mariadbb，遂先锁定 mariadb 版本为 10.7

https://github.com/MariaDB/mariadb-docker/blob/c0d07be9ad5eb3bc212c6805cc8031308c56e9b6/10.8/Dockerfile#L5

```
command was: mariadbd --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --verbose --help --log-bin-index=/tmp/tmp.OCezpJGewP
```