### PR TITLE
🐛 FIX: skia-canvas should use NodePreGypBinary

### DIFF
--- a/app/common/adapter/binary/NodePreGypBinary.ts
+++ b/app/common/adapter/binary/NodePreGypBinary.ts
@@ -33,6 +33,7 @@ export class NodePreGypBinary extends AbstractBinary {
         let currentDir = this.dirItems['/'];
         let versionPrefix = '';
         const remotePath = pkgVersion.binary.remote_path;
+        const napiVersions = pkgVersion.binary.napi_versions ?? [];
         if (remotePath?.includes('{version}')) {
           const dirName = remotePath.includes('v{version}') ? `v${version}` : version;
           versionPrefix = `/${dirName}`;
@@ -99,6 +100,41 @@ export class NodePreGypBinary extends AbstractBinary {
                   url: `${this.binaryConfig.distUrl}/${this.binaryConfig.category}${versionPrefix}/${name}`,
                   ignoreDownloadStatuses: [ 404 ],
                 });
+              }
+            }
+          }
+        } else if (binaryFile.includes('{platform}-{arch}-{node_napi_label}-{libc}') && napiVersions.length > 0) {
+          // https://skia-canvas.s3.us-east-1.amazonaws.com/v0.9.30/darwin-arm64-napi-v6-unknown.tar.gz
+          // https://github.com/samizdatco/skia-canvas/blob/2a75801d7cce3b4e4e6ad015a173daefaa8465e6/package.json#L48
+          // "binary": {
+          //   "module_name": "index",
+          //   "module_path": "./lib/v{napi_build_version}",
+          //   "remote_path": "./v{version}",
+          //   "package_name": "{platform}-{arch}-{node_napi_label}-{libc}.tar.gz",
+          //   "host": "https://skia-canvas.s3.us-east-1.amazonaws.com",
+          //   "napi_versions": [
+          //     6
+          //   ]
+          // },
+          for (const platform of nodePlatforms) {
+            const archs = nodeArchs[platform];
+            const libcs = nodeLibcs[platform];
+            for (const arch of archs) {
+              for (const libc of libcs) {
+                for (const napiVersion of napiVersions) {
+                  const name = binaryFile.replace('{platform}', platform)
+                    .replace('{arch}', arch)
+                    .replace('{node_napi_label}', `napi-v${napiVersion}`)
+                    .replace('{libc}', libc);
+                  currentDir.push({
+                    name,
+                    date,
+                    size: '-',
+                    isDir: false,
+                    url: `${this.binaryConfig.distUrl}${versionPrefix}/${name}`,
+                    ignoreDownloadStatuses: [ 404 ],
+                  });
+                }
               }
             }
           }

--- a/config/binaries.ts
+++ b/config/binaries.ts
@@ -133,6 +133,13 @@ const binaries: {
     repo: 'grpc/grpc-node',
     distUrl: 'https://node-precompiled-binaries.grpc.io',
   },
+  'skia-canvas': {
+    category: 'skia-canvas',
+    description: 'A canvas environment for Node',
+    syncer: SyncerClass.NodePreGypBinary,
+    repo: 'samizdatco/skia-canvas',
+    distUrl: 'https://skia-canvas.s3.us-east-1.amazonaws.com',
+  },
   nodegit: {
     category: 'nodegit',
     description: 'Native Node bindings to Git.',
@@ -828,13 +835,6 @@ const binaries: {
     syncer: SyncerClass.PlaywrightBinary,
     repo: 'microsoft/playwright',
     distUrl: 'https://github.com/microsoft/playwright/releases',
-  },
-  'skia-canvas': {
-    category: 'skia-canvas',
-    description: 'A canvas environment for Node',
-    syncer: SyncerClass.BucketBinary,
-    repo: 'samizdatco/skia-canvas',
-    distUrl: 'https://skia-canvas.s3.us-east-1.amazonaws.com/',
   },
 };
 

--- a/test/common/adapter/binary/NodePreGypBinary.test.ts
+++ b/test/common/adapter/binary/NodePreGypBinary.test.ts
@@ -128,5 +128,53 @@ describe('test/common/adapter/binary/NodePreGypBinary.test.ts', () => {
       assert(matchFile2);
       assert(matchFile3);
     });
+
+    it('should fetch skia-canvas', async () => {
+      const binary = new NodePreGypBinary(ctx.httpclient, ctx.logger, binaries['skia-canvas']);
+      let result = await binary.fetch('/');
+      assert(result);
+      assert(result.items.length > 0);
+      // console.log(JSON.stringify(result.items, null, 2));
+      let matchDir = false;
+      for (const item of result.items) {
+        assert(item.isDir === true);
+        if (item.name === 'v0.9.30/') {
+          matchDir = true;
+        }
+      }
+      assert(matchDir);
+
+      result = await binary.fetch('/v0.9.30/');
+      assert(result);
+      assert(result.items.length > 0);
+      // console.log(JSON.stringify(result.items, null, 2));
+      let matchFile1 = false;
+      let matchFile2 = false;
+      let matchFile3 = false;
+      for (const item of result.items) {
+        assert(item.isDir === false);
+        if (item.name === 'darwin-arm64-napi-v6-unknown.tar.gz') {
+          assert(item.date === '2022-06-08T01:53:43.908Z');
+          assert(item.size === '-');
+          assert(item.url === 'https://skia-canvas.s3.us-east-1.amazonaws.com/v0.9.30/darwin-arm64-napi-v6-unknown.tar.gz');
+          matchFile1 = true;
+        }
+        if (item.name === 'linux-arm-napi-v6-glibc.tar.gz') {
+          assert(item.date === '2022-06-08T01:53:43.908Z');
+          assert(item.size === '-');
+          assert(item.url === 'https://skia-canvas.s3.us-east-1.amazonaws.com/v0.9.30/linux-arm-napi-v6-glibc.tar.gz');
+          matchFile2 = true;
+        }
+        if (item.name === 'win32-x64-napi-v6-unknown.tar.gz') {
+          assert(item.date === '2022-06-08T01:53:43.908Z');
+          assert(item.size === '-');
+          assert(item.url === 'https://skia-canvas.s3.us-east-1.amazonaws.com/v0.9.30/win32-x64-napi-v6-unknown.tar.gz');
+          matchFile3 = true;
+        }
+      }
+      assert(matchFile1);
+      assert(matchFile2);
+      assert(matchFile3);
+    });
   });
 });


### PR DESCRIPTION
closes https://github.com/cnpm/cnpmcore/pull/258