### PR TITLE
feat: support sync exist mode

### DIFF
--- a/app/core/service/ChangesStreamService.ts
+++ b/app/core/service/ChangesStreamService.ts
@@ -126,6 +126,11 @@ export class ChangesStreamService extends AbstractService {
     const [ scopeName, name ] = getScopeAndName(fullname);
     const packageEntity = await this.packageRepository.findPackage(scopeName, name);
 
+    // 如果包不存在，且处在 exist 模式下，则不同步
+    if (this.config.cnpmcore.syncMode === 'exist' && !packageEntity) {
+      return false;
+    }
+
     if (packageEntity?.registryId) {
       return registry.registryId === packageEntity.registryId;
     }

--- a/app/port/controller/AbstractController.ts
+++ b/app/port/controller/AbstractController.ts
@@ -42,8 +42,8 @@ export abstract class AbstractController extends MiddlewareController {
     return this.config.cnpmcore.sourceRegistry;
   }
 
-  protected get enableSyncAll() {
-    return this.config.cnpmcore.syncMode === 'all';
+  protected get enableSync() {
+    return this.config.cnpmcore.syncMode === 'all' || this.config.cnpmcore.syncMode === 'exist';
   }
 
   protected isPrivateScope(scope: string) {
@@ -57,7 +57,7 @@ export abstract class AbstractController extends MiddlewareController {
     // dont sync private scope
     if (!this.isPrivateScope(scope)) {
       // syncMode = none, redirect public package to source registry
-      if (!this.enableSyncAll) {
+      if (!this.enableSync) {
         err.redirectToSourceRegistry = this.sourceRegistry;
       }
     }

--- a/app/port/controller/PackageSyncController.ts
+++ b/app/port/controller/PackageSyncController.ts
@@ -54,7 +54,7 @@ export class PackageSyncController extends AbstractController {
     method: HTTPMethodEnum.PUT,
   })
   async createSyncTask(@Context() ctx: EggContext, @HTTPParam() fullname: string, @HTTPBody() data: SyncPackageTaskType) {
-    if (!this.enableSyncAll) {
+    if (!this.enableSync) {
       throw new ForbiddenError('Not allow to sync package');
     }
     const tips = data.tips || `Sync cause by "${ctx.href}", parent traceId: ${ctx.tracer.traceId}`;

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -21,6 +21,7 @@ export default (appInfo: EggAppConfig) => {
     // sync mode
     //  - none: don't sync npm package, just redirect it to sourceRegistry
     //  - all: sync all npm packages
+    //  - exist: only sync exist packages, effected when `enableCheckRecentlyUpdated` or `enableChangesStream` is enabled
     syncMode: 'none',
     hookEnable: false,
     syncPackageWorkerMaxConcurrentTasks: 10,

--- a/test/core/service/ChangesStreamService.test.ts
+++ b/test/core/service/ChangesStreamService.test.ts
@@ -121,6 +121,18 @@ describe('test/core/service/ChangesStreamService.test.ts', () => {
       assert(!res);
     });
 
+    it('the package does not exist should not sync with any registry', async () => {
+      mock(app.config.cnpmcore, 'syncMode', 'exist');
+      await TestUtil.createPackage({
+        name: '@cnpm/test',
+        isPrivate: false,
+        registryId: npmRegistry.registryId,
+      });
+      let res = await changesStreamService.needSync(npmRegistry, 'banana');
+      assert(!res);
+      res = await changesStreamService.needSync(npmRegistry, '@cnpm/test');
+      assert(res);
+    });
   });
 
   describe('getInitialSince()', () => {


### PR DESCRIPTION
添加`syncMode: exist`的支持，参考：https://github.com/cnpm/cnpmjs.org/blob/master/sync/sync_exist.js 的实现，定时自动同步所有存量的包，默认值为每周日凌晨1点整开始同步

注意事项：建议企业内部使用时，关闭 `enableChangesStream`，同时也关闭 `enableCheckRecentlyUpdated`。手工同步一些常见的包后，再启用 `syncMode: exist`，这样包的数量可控，也能保障包的状态是最新的