### PR TITLE
feat: init registry and scope

### DIFF
--- a/app/common/enum/Registry.ts
+++ b/app/common/enum/Registry.ts
@@ -1,0 +1,5 @@
+export enum RegistryType {
+  Npm = 'npm',
+  Cnpmcore = 'cnpmcore',
+  Cnpmjsorg = 'cnpmjsorg',
+}

--- a/app/core/entity/Registry.ts
+++ b/app/core/entity/Registry.ts
@@ -1,0 +1,38 @@
+import { Entity, EntityData } from './Entity';
+import { EasyData, EntityUtil } from '../util/EntityUtil';
+import type { RegistryType } from 'app/common/enum/Registry';
+
+interface RegistryData extends EntityData {
+  name: string;
+  registryId: string;
+  host: string;
+  changeStream: string;
+  userPrefix: string;
+  type: RegistryType;
+}
+
+export type CreateRegistryData = Omit<EasyData<RegistryData, 'registryId'>, 'id'>;
+
+export class Registry extends Entity {
+  name: string;
+  registryId: string;
+  host: string;
+  changeStream: string;
+  userPrefix: string;
+  type: RegistryType;
+
+  constructor(data: RegistryData) {
+    super(data);
+    this.name = data.name;
+    this.registryId = data.registryId;
+    this.host = data.host;
+    this.changeStream = data.changeStream;
+    this.userPrefix = data.userPrefix;
+    this.type = data.type;
+  }
+
+  public static create(data: CreateRegistryData): Registry {
+    const newData = EntityUtil.defaultData(data, 'registryId');
+    return new Registry(newData);
+  }
+}

--- a/app/core/entity/Scope.ts
+++ b/app/core/entity/Scope.ts
@@ -1,0 +1,28 @@
+import { Entity, EntityData } from './Entity';
+import { EasyData, EntityUtil } from '../util/EntityUtil';
+
+interface ScopeData extends EntityData {
+  name: string;
+  scopeId: string;
+  registryId: string;
+}
+
+export type CreateScopeData = Omit<EasyData<ScopeData, 'scopeId'>, 'id'>;
+
+export class Scope extends Entity {
+  name: string;
+  registryId: string;
+  scopeId: string;
+
+  constructor(data: ScopeData) {
+    super(data);
+    this.name = data.name;
+    this.registryId = data.registryId;
+    this.scopeId = data.scopeId;
+  }
+
+  static create(data: CreateScopeData): Scope {
+    const newData = EntityUtil.defaultData(data, 'scopeId');
+    return new Scope(newData);
+  }
+}

--- a/app/core/service/RegistryManagerService.ts
+++ b/app/core/service/RegistryManagerService.ts
@@ -1,0 +1,83 @@
+import {
+  AccessLevel,
+  ContextProto,
+  Inject,
+} from '@eggjs/tegg';
+import { NotFoundError } from 'egg-errors';
+import { RegistryRepository } from '../../repository/RegistryRepository';
+import { AbstractService } from '../../common/AbstractService';
+import { Registry } from '../entity/Registry';
+import { PageOptions, PageResult } from '../util/EntityUtil';
+import { ScopeManagerService } from './ScopeManagerService';
+
+export interface CreateRegistryCmd extends Pick<Registry, 'changeStream' | 'host' | 'userPrefix' | 'type' | 'name'> {
+  operatorId?: string;
+}
+export interface UpdateRegistryCmd extends Pick<Registry, 'changeStream' | 'host' | 'userPrefix' | 'type' | 'name' | 'registryId'> {
+  operatorId?: string;
+}
+export interface RemoveRegistryCmd extends Pick<Registry, 'registryId'> {
+  operatorId?: string;
+}
+
+
+@ContextProto({
+  accessLevel: AccessLevel.PUBLIC,
+})
+export class RegistryManagerService extends AbstractService {
+  @Inject()
+  private readonly registryRepository: RegistryRepository;
+  @Inject()
+  private readonly scopeManagerService: ScopeManagerService;
+
+  async createRegistry(createCmd: CreateRegistryCmd): Promise<Registry> {
+    const { name, changeStream, host, userPrefix, type, operatorId = '-' } = createCmd;
+    this.logger.info('[RegistryManagerService.createRegistry:prepare] operatorId: %s, createCmd: %j', operatorId, createCmd);
+    const registry = Registry.create({
+      name,
+      changeStream,
+      host,
+      userPrefix,
+      type,
+    });
+    await this.registryRepository.saveRegistry(registry);
+    return registry;
+  }
+
+  // 更新部分 registry 信息
+  // 不允许 userPrefix 字段变更
+  async updateRegistry(updateCmd: UpdateRegistryCmd) {
+    const { name, changeStream, host, type, registryId, operatorId = '-' } = updateCmd;
+    this.logger.info('[RegistryManagerService.updateRegistry:prepare] operatorId: %s, updateCmd: %j', operatorId, updateCmd);
+    const registry = await this.registryRepository.findRegistryByRegistryId(registryId);
+    if (!registry) {
+      throw new NotFoundError(`registry ${registryId} not found`);
+    }
+    Object.assign(registry, {
+      name,
+      changeStream,
+      host,
+      type,
+    });
+    await this.registryRepository.saveRegistry(registry);
+  }
+
+  // list all registries with scopes
+  async listRegistries(page: PageOptions): Promise<PageResult<Registry>> {
+    return await this.registryRepository.listRegistries(page);
+  }
+
+  async findByRegistryId(registryId: string): Promise<Registry | null> {
+    return await this.registryRepository.findRegistryByRegistryId(registryId);
+  }
+
+  // 删除 Registry 方法
+  // 可选传入 operatorId 作为参数，用于记录操作人员
+  // 同时删除对应的 scope 数据
+  async remove(removeCmd: RemoveRegistryCmd): Promise<void> {
+    const { registryId, operatorId = '-' } = removeCmd;
+    this.logger.info('[RegistryManagerService.remove:prepare] operatorId: %s, registryId: %s', operatorId, registryId);
+    await this.registryRepository.removeRegistry(registryId);
+    await this.scopeManagerService.removeByRegistryId({ registryId, operatorId });
+  }
+}

--- a/app/core/service/ScopeManagerService.ts
+++ b/app/core/service/ScopeManagerService.ts
@@ -1,0 +1,64 @@
+import {
+  AccessLevel,
+  ContextProto,
+  Inject,
+} from '@eggjs/tegg';
+import { ScopeRepository } from '../../repository/ScopeRepository';
+import { AbstractService } from '../../common/AbstractService';
+import { Scope } from '../entity/Scope';
+import { PageOptions, PageResult } from '../util/EntityUtil';
+
+export interface CreateScopeCmd extends Pick<Scope, 'name' | 'registryId'> {
+  operatorId?: string;
+}
+export interface UpdateRegistryCmd extends Pick<Scope, 'name' | 'scopeId' | 'registryId'> {
+  operatorId?: string;
+}
+
+export interface RemoveScopeCmd {
+  scopeId: string;
+  operatorId?: string;
+}
+
+export interface RemoveScopeByRegistryIdCmd {
+  registryId: string;
+  operatorId?: string;
+}
+@ContextProto({
+  accessLevel: AccessLevel.PUBLIC,
+})
+export class ScopeManagerService extends AbstractService {
+  @Inject()
+  private readonly scopeRepository: ScopeRepository;
+
+  async createScope(createCmd: CreateScopeCmd): Promise<Scope> {
+    const { name, registryId, operatorId } = createCmd;
+    this.logger.info('[ScopeManagerService.CreateScope:prepare] operatorId: %s, createCmd: %s', operatorId, createCmd);
+    const scope = Scope.create({
+      name,
+      registryId,
+    });
+    await this.scopeRepository.saveScope(scope);
+    return scope;
+  }
+
+  async listScopes(page: PageOptions): Promise<PageResult<Scope>> {
+    return await this.scopeRepository.listScopes(page);
+  }
+
+  async listScopesByRegistryId(registryId: string, page: PageOptions): Promise<PageResult<Scope>> {
+    return await this.scopeRepository.listScopesByRegistryId(registryId, page);
+  }
+
+  async removeByRegistryId(removeCmd: RemoveScopeByRegistryIdCmd): Promise<void> {
+    const { registryId, operatorId } = removeCmd;
+    this.logger.info('[ScopeManagerService.remove:prepare] operatorId: %s, registryId: %s', operatorId, registryId);
+    return await this.scopeRepository.removeScopeByRegistryId(registryId);
+  }
+
+  async remove(removeCmd: RemoveScopeCmd): Promise<void> {
+    const { scopeId, operatorId } = removeCmd;
+    this.logger.info('[ScopeManagerService.remove:prepare] operatorId: %s, scopeId: %s', operatorId, scopeId);
+    return await this.scopeRepository.removeScope(scopeId);
+  }
+}

--- a/app/core/util/EntityUtil.ts
+++ b/app/core/util/EntityUtil.ts
@@ -1,10 +1,24 @@
 import { EntityData } from '../entity/Entity';
 import ObjectID from 'bson-objectid';
+import { E400 } from 'egg-errors';
 
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
 export type EasyData<T extends EntityData, Id extends keyof T> = PartialBy<T, 'createdAt' | 'updatedAt' | Id>;
 
+const MAX_PAGE_SIZE = 100 as const;
+export interface PageOptions {
+  pageSize?: number;
+  pageIndex?: number;
+}
+export interface PageResult<T> {
+  count: number;
+  data: Array<T>
+}
+export interface PageLimitOptions {
+  offset: number;
+  limit: number;
+}
 
 export class EntityUtil {
   static defaultData<T extends EntityData, Id extends keyof T>(data: EasyData<T, Id>, id: Id): T {
@@ -16,5 +30,16 @@ export class EntityUtil {
 
   static createId(): string {
     return new ObjectID().toHexString();
+  }
+
+  static convertPageOptionsToLimitOption(page: PageOptions): PageLimitOptions {
+    const { pageIndex = 0, pageSize = 20 } = page;
+    if (pageSize > MAX_PAGE_SIZE) {
+      throw new E400(`max page size is 100, current request is ${pageSize}`);
+    }
+    return {
+      offset: pageIndex * pageSize,
+      limit: pageSize,
+    };
   }
 }

--- a/app/port/controller/RegistryController.ts
+++ b/app/port/controller/RegistryController.ts
@@ -1,0 +1,93 @@
+import {
+  Context,
+  EggContext,
+  HTTPBody,
+  HTTPController,
+  HTTPMethod,
+  HTTPMethodEnum,
+  HTTPParam,
+  HTTPQuery,
+  Inject,
+  Middleware,
+} from '@eggjs/tegg';
+import { NotFoundError } from 'egg-errors';
+import { AbstractController } from './AbstractController';
+import { Static } from 'egg-typebox-validate/typebox';
+import { RegistryManagerService } from '../../core/service/RegistryManagerService';
+import { AdminAccess } from '../middleware/AdminAccess';
+import { ScopeManagerService } from 'app/core/service/ScopeManagerService';
+import { RegistryCreateOptions, QueryPageOptions } from '../typebox';
+
+@HTTPController()
+export class RegistryController extends AbstractController {
+  @Inject()
+  private readonly registryManagerService: RegistryManagerService;
+  @Inject()
+  private readonly scopeManagerService: ScopeManagerService;
+
+  @HTTPMethod({
+    path: '/-/registry',
+    method: HTTPMethodEnum.GET,
+  })
+  async listRegistries(@HTTPQuery() pageSize: Static<typeof QueryPageOptions>['pageSize'], @HTTPQuery() pageIndex: Static<typeof QueryPageOptions>['pageIndex']) {
+    const registries = await this.registryManagerService.listRegistries({ pageSize, pageIndex });
+    return registries;
+  }
+
+  @HTTPMethod({
+    path: '/-/registry/:id',
+    method: HTTPMethodEnum.GET,
+  })
+  async showRegistry(@HTTPParam() id: string) {
+    const registry = await this.registryManagerService.findByRegistryId(id);
+    if (!registry) {
+      throw new NotFoundError('registry not found');
+    }
+    return registry;
+  }
+
+  @HTTPMethod({
+    path: '/-/registry/:id/scopes',
+    method: HTTPMethodEnum.GET,
+  })
+  async showRegistryScopes(@HTTPParam() id: string, @HTTPQuery() pageSize: Static<typeof QueryPageOptions>['pageSize'], @HTTPQuery() pageIndex: Static<typeof QueryPageOptions>['pageIndex']) {
+    const registry = await this.registryManagerService.findByRegistryId(id);
+    if (!registry) {
+      throw new NotFoundError('registry not found');
+    }
+    const scopes = await this.scopeManagerService.listScopesByRegistryId(id, { pageIndex, pageSize });
+    return scopes;
+  }
+
+  @HTTPMethod({
+    path: '/-/registry',
+    method: HTTPMethodEnum.POST,
+  })
+  @Middleware(AdminAccess)
+  async createRegistry(@Context() ctx: EggContext, @HTTPBody() registryOptions: Static<typeof RegistryCreateOptions>) {
+    ctx.tValidate(RegistryCreateOptions, registryOptions);
+    const authorizedUser = await this.userRoleManager.requiredAuthorizedUser(ctx, 'setting');
+    const { name, changeStream, host, userPrefix = '', type } = registryOptions;
+    await this.registryManagerService.createRegistry({
+      name,
+      changeStream,
+      host,
+      userPrefix,
+      operatorId: authorizedUser.userId,
+      type,
+    });
+    return { ok: true };
+  }
+
+  @HTTPMethod({
+    path: '/-/registry/:id',
+    method: HTTPMethodEnum.DELETE,
+  })
+  @Middleware(AdminAccess)
+  async removeRegistry(@Context() ctx: EggContext, @HTTPParam() id: string) {
+    const authorizedUser = await this.userRoleManager.requiredAuthorizedUser(ctx, 'setting');
+    await this.registryManagerService.remove({ registryId: id, operatorId: authorizedUser.userId });
+    return { ok: true };
+  }
+
+}

--- a/app/port/controller/ScopeController.ts
+++ b/app/port/controller/ScopeController.ts
@@ -1,0 +1,63 @@
+import {
+  Context,
+  EggContext,
+  HTTPBody,
+  HTTPController,
+  HTTPMethod,
+  HTTPMethodEnum,
+  HTTPParam,
+  Inject,
+  Middleware,
+} from '@eggjs/tegg';
+import { AbstractController } from './AbstractController';
+import { Static } from 'egg-typebox-validate/typebox';
+import { AdminAccess } from '../middleware/AdminAccess';
+import { ScopeManagerService } from '../../core/service/ScopeManagerService';
+import { RegistryManagerService } from 'app/core/service/RegistryManagerService';
+import { ScopeCreateOptions } from '../typebox';
+import { E400 } from 'egg-errors';
+
+
+@HTTPController()
+export class ScopeController extends AbstractController {
+  @Inject()
+  private readonly scopeManagerService: ScopeManagerService;
+
+  @Inject()
+  private readonly registryManagerService: RegistryManagerService;
+
+  @HTTPMethod({
+    path: '/-/scope',
+    method: HTTPMethodEnum.POST,
+  })
+  @Middleware(AdminAccess)
+  async createScope(@Context() ctx: EggContext, @HTTPBody() scopeOptions: Static<typeof ScopeCreateOptions>) {
+    const authorizedUser = await this.userRoleManager.requiredAuthorizedUser(ctx, 'setting');
+    ctx.tValidate(ScopeCreateOptions, scopeOptions);
+    const { name, registryId } = scopeOptions;
+
+    const registry = await this.registryManagerService.findByRegistryId(registryId);
+    if (!registry) {
+      throw new E400(`registry ${registryId} not found`);
+    }
+
+    await this.scopeManagerService.createScope({
+      name,
+      registryId,
+      operatorId: authorizedUser.userId,
+    });
+    return { ok: true };
+  }
+
+  @HTTPMethod({
+    path: '/-/scope/:id',
+    method: HTTPMethodEnum.DELETE,
+  })
+  @Middleware(AdminAccess)
+  async removeScope(@Context() ctx: EggContext, @HTTPParam() id: string) {
+    const authorizedUser = await this.userRoleManager.requiredAuthorizedUser(ctx, 'setting');
+    await this.scopeManagerService.remove({ scopeId: id, operatorId: authorizedUser.userId });
+    return { ok: true };
+  }
+
+}

--- a/app/port/middleware/AdminAccess.ts
+++ b/app/port/middleware/AdminAccess.ts
@@ -1,0 +1,12 @@
+import { EggContext, Next } from '@eggjs/tegg';
+import { ForbiddenError } from 'egg-errors';
+import { UserRoleManager } from '../UserRoleManager';
+
+export async function AdminAccess(ctx: EggContext, next: Next) {
+  const userRoleManager = await ctx.getEggObject(UserRoleManager);
+  const isAdmin = await userRoleManager.isAdmin(ctx);
+  if (!isAdmin) {
+    throw new ForbiddenError('Not allow to access');
+  }
+  await next();
+}

--- a/app/port/typebox.ts
+++ b/app/port/typebox.ts
@@ -1,4 +1,5 @@
 import { Type, Static } from '@sinclair/typebox';
+import { RegistryType } from '../common/enum/Registry';
 import semver from 'semver';
 import { HookType } from '../common/enum/Hook';
 
@@ -105,3 +106,99 @@ export function patchAjv(ajv: any) {
     },
   });
 }
+
+export const QueryPageOptions = Type.Object({
+  pageSize: Type.Optional(Type.Number({
+    transform: [ 'trim' ],
+    minimum: 1,
+    maximum: 100,
+  })),
+  pageIndex: Type.Optional(Type.Number({
+    transform: [ 'trim' ],
+    minimum: 0,
+  })),
+});
+
+export const RegistryCreateOptions = Type.Object({
+  name: Type.String({
+    transform: [ 'trim' ],
+    minLength: 1,
+    maxLength: 256,
+  }),
+  host: Type.String({
+    transform: [ 'trim' ],
+    minLength: 1,
+    maxLength: 4096,
+  }),
+  changeStream: Type.String({
+    transform: [ 'trim' ],
+    minLength: 1,
+    maxLength: 4096,
+  }),
+  userPrefix: Type.Optional(Type.String({
+    transform: [ 'trim' ],
+    minLength: 1,
+    maxLength: 256,
+  })),
+  type: Type.Enum(RegistryType),
+});
+
+export const RegistryUpdateOptions = Type.Object({
+  name: Type.String({
+    transform: [ 'trim' ],
+    minLength: 1,
+    maxLength: 256,
+  }),
+  host: Type.String({
+    transform: [ 'trim' ],
+    minLength: 1,
+    maxLength: 4096,
+  }),
+  changeStream: Type.String({
+    transform: [ 'trim' ],
+    minLength: 1,
+    maxLength: 4096,
+  }),
+  userPrefix: Type.Optional(Type.String({
+    transform: [ 'trim' ],
+    minLength: 1,
+    maxLength: 256,
+  })),
+  type: Type.Enum(RegistryType),
+  registryId: Type.String({
+    transform: [ 'trim' ],
+    minLength: 1,
+    maxLength: 256,
+  }),
+});
+
+export const ScopeCreateOptions = Type.Object({
+  name: Type.String({
+    transform: [ 'trim' ],
+    minLength: 1,
+    maxLength: 256,
+  }),
+  registryId: Type.String({
+    transform: [ 'trim' ],
+    minLength: 1,
+    maxLength: 256,
+  }),
+});
+
+export const ScopeUpdateOptions = Type.Object({
+  name: Type.String({
+    transform: [ 'trim' ],
+    minLength: 1,
+    maxLength: 256,
+  }),
+  registryId: Type.String({
+    transform: [ 'trim' ],
+    minLength: 1,
+    maxLength: 256,
+  }),
+  scopeId: Type.String({
+    transform: [ 'trim' ],
+    minLength: 1,
+    maxLength: 256,
+  }),
+});

--- a/app/repository/RegistryRepository.ts
+++ b/app/repository/RegistryRepository.ts
@@ -1,0 +1,59 @@
+import { AccessLevel, ContextProto, Inject } from '@eggjs/tegg';
+import { ModelConvertor } from './util/ModelConvertor';
+import { Registry, Registry as RegistryEntity } from '../core/entity/Registry';
+import { AbstractRepository } from './AbstractRepository';
+import type { Registry as RegistryModel } from './model/Registry';
+import { EntityUtil, PageOptions, PageResult } from '../core/util/EntityUtil';
+
+@ContextProto({
+  accessLevel: AccessLevel.PUBLIC,
+})
+export class RegistryRepository extends AbstractRepository {
+  @Inject()
+  private readonly Registry: typeof RegistryModel;
+
+  async listRegistries(page: PageOptions): Promise<PageResult<Registry>> {
+    const { offset, limit } = EntityUtil.convertPageOptionsToLimitOption(page);
+    const count = await this.Registry.find().count();
+    const models = await this.Registry.find().offset(offset).limit(limit);
+    return {
+      count,
+      data: models.map(model => ModelConvertor.convertModelToEntity(model, RegistryEntity)),
+    };
+  }
+
+  async findRegistry(name: string): Promise<RegistryEntity | null> {
+    const model = await this.Registry.findOne({ name });
+    if (model) {
+      return ModelConvertor.convertModelToEntity(model, RegistryEntity);
+    }
+    return null;
+  }
+
+  async findRegistryByRegistryId(registryId: string): Promise<RegistryEntity | null> {
+    const model = await this.Registry.findOne({ registryId });
+    if (model) {
+      return ModelConvertor.convertModelToEntity(model, RegistryEntity);
+    }
+    return null;
+  }
+
+  async saveRegistry(registry: Registry) {
+    if (registry.id) {
+      const model = await this.Registry.findOne({ id: registry.id });
+      if (!model) return;
+      await ModelConvertor.saveEntityToModel(registry, model);
+      return model;
+    }
+    const model = await ModelConvertor.convertEntityToModel(registry, this.Registry);
+    this.logger.info('[RegistryRepository:saveRegistry:new] id: %s, registryId: %s',
+      model.id, model.registryId);
+    return model;
+
+  }
+
+  async removeRegistry(registryId: string): Promise<void> {
+    await this.Registry.remove({ registryId });
+  }
+
+}

--- a/app/repository/ScopeRepository.ts
+++ b/app/repository/ScopeRepository.ts
@@ -1,0 +1,57 @@
+import { AccessLevel, ContextProto, Inject } from '@eggjs/tegg';
+import { ModelConvertor } from './util/ModelConvertor';
+import { AbstractRepository } from './AbstractRepository';
+import { Scope as ScopeModel } from './model/Scope';
+import { Scope } from '../core/entity/Scope';
+import { EntityUtil, PageOptions, PageResult } from '../core/util/EntityUtil';
+
+@ContextProto({
+  accessLevel: AccessLevel.PUBLIC,
+})
+export class ScopeRepository extends AbstractRepository {
+  @Inject()
+  private readonly Scope: typeof ScopeModel;
+
+  async listScopesByRegistryId(registryId: string, page: PageOptions): Promise<PageResult<Scope>> {
+    const { offset, limit } = EntityUtil.convertPageOptionsToLimitOption(page);
+    const count = await this.Scope.find({ registryId }).count();
+    const models = await this.Scope.find({ registryId }).offset(offset).limit(limit);
+    return {
+      count,
+      data: models.map(model => ModelConvertor.convertModelToEntity(model, Scope)),
+    };
+  }
+
+  async listScopes(page: PageOptions): Promise<PageResult<Scope>> {
+    const { offset, limit } = EntityUtil.convertPageOptionsToLimitOption(page);
+    const count = await this.Scope.find().count();
+    const models = await this.Scope.find().offset(offset).limit(limit);
+    return {
+      count,
+      data: models.map(model => ModelConvertor.convertModelToEntity(model, Scope)),
+    };
+  }
+
+  async saveScope(scope: Scope) {
+    if (scope.id) {
+      const model = await this.Scope.findOne({ id: scope.id });
+      if (!model) return;
+      await ModelConvertor.saveEntityToModel(scope, model);
+      return model;
+    }
+    const model = await ModelConvertor.convertEntityToModel(scope, this.Scope);
+    this.logger.info('[ScopeRepository:saveScope:new] id: %s, scopeId: %s',
+      model.id, model.scopeId);
+    await model.save();
+    return model;
+  }
+
+  async removeScope(scopeId: string): Promise<void> {
+    await this.Scope.remove({ scopeId });
+  }
+
+  async removeScopeByRegistryId(registryId: string): Promise<void> {
+    await this.Scope.remove({ registryId });
+  }
+
+}

--- a/app/repository/model/Registry.ts
+++ b/app/repository/model/Registry.ts
@@ -1,0 +1,39 @@
+import { Attribute, Model } from '@eggjs/tegg-orm-decorator';
+import { RegistryType } from 'app/common/enum/Registry';
+import { DataTypes, Bone } from 'leoric';
+
+@Model()
+export class Registry extends Bone {
+  @Attribute(DataTypes.BIGINT, {
+    primary: true,
+    autoIncrement: true,
+  })
+  id: bigint;
+
+  @Attribute(DataTypes.DATE, { name: 'gmt_create' })
+  createdAt: Date;
+
+  @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
+  updatedAt: Date;
+
+  @Attribute(DataTypes.STRING(24), {
+    unique: true,
+  })
+  registryId: string;
+
+  @Attribute(DataTypes.STRING(256))
+  name: string;
+
+  @Attribute(DataTypes.STRING(4096))
+  host: string;
+
+  @Attribute(DataTypes.STRING(4096), { name: 'change_stream' })
+  changeStream: string;
+
+  @Attribute(DataTypes.STRING(4096), { name: 'user_prefix' })
+  userPrefix: string;
+
+  @Attribute(DataTypes.STRING(256))
+  type: RegistryType;
+
+}

--- a/app/repository/model/Scope.ts
+++ b/app/repository/model/Scope.ts
@@ -1,0 +1,26 @@
+import { Attribute, Model } from '@eggjs/tegg-orm-decorator';
+import { DataTypes, Bone } from 'leoric';
+
+@Model()
+export class Scope extends Bone {
+  @Attribute(DataTypes.BIGINT, {
+    primary: true,
+    autoIncrement: true,
+  })
+  id: bigint;
+
+  @Attribute(DataTypes.DATE, { name: 'gmt_create' })
+  createdAt: Date;
+
+  @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
+  updatedAt: Date;
+
+  @Attribute(DataTypes.STRING(214))
+  name: string;
+
+  @Attribute(DataTypes.STRING(256))
+  registryId: string;
+
+  @Attribute(DataTypes.STRING(256))
+  scopeId: string;
+}

--- a/sql/1.11.0.sql
+++ b/sql/1.11.0.sql
@@ -17,3 +17,28 @@ CREATE TABLE IF NOT EXISTS `hooks` (
   UNIQUE KEY `uk_type_name_owner_id` (`type`, `name`, `owner_id`),
   KEY `idx_type_name_id` (`type`, `name`, `id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci COMMENT='task info';
+
+CREATE TABLE IF NOT EXISTS `registries` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
+  `gmt_create` datetime(3) NOT NULL COMMENT 'create time',
+  `gmt_modified` datetime(3) NOT NULL COMMENT 'modified time',
+  `registry_id` varchar(24) NOT NULL COMMENT 'registry id',
+  `name` varchar(256) DEFAULT NULL COMMENT 'registry name',
+  `host` varchar(4096) DEFAULT NULL COMMENT 'registry host',
+  `change_stream` varchar(4096) DEFAULT NULL COMMENT 'change stream url',
+  `type` varchar(256) DEFAULT NULL COMMENT 'registry type cnpmjsorg/cnpmcore/npm ',
+  `user_prefix` varchar(256) DEFAULT NULL COMMENT 'user prefix',
+  UNIQUE KEY `uk_name` (`name`),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci COMMENT='registry info';
+
+CREATE TABLE IF NOT EXISTS `scopes` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'primary key',
+  `gmt_create` datetime(3) NOT NULL COMMENT 'create time',
+  `gmt_modified` datetime(3) NOT NULL COMMENT 'modified time',
+  `scope_id` varchar(24) NOT NULL COMMENT 'scope id',
+  `name` varchar(214) DEFAULT NULL COMMENT 'scope name',
+  `registry_id` varchar(24) NOT NULL COMMENT 'registry id',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci COMMENT='scope info';

--- a/test/core/service/RegistryManagerService/index.test.ts
+++ b/test/core/service/RegistryManagerService/index.test.ts
@@ -1,0 +1,108 @@
+import assert = require('assert');
+import { app } from 'egg-mock/bootstrap';
+import { Context } from 'egg';
+import { RegistryManagerService } from 'app/core/service/RegistryManagerService';
+import { RegistryType } from 'app/common/enum/Registry';
+
+describe('test/core/service/RegistryManagerService/index.test.ts', () => {
+  let ctx: Context;
+  let registryManagerService: RegistryManagerService;
+
+  before(async () => {
+    ctx = await app.mockModuleContext();
+    registryManagerService = await ctx.getEggObject(RegistryManagerService);
+  });
+
+  beforeEach(async () => {
+    // create Registry
+    await registryManagerService.createRegistry({
+      name: 'custom',
+      changeStream: 'https://r.cnpmjs.org/_changes',
+      host: 'https://cnpmjs.org',
+      userPrefix: 'cnpm:',
+      type: RegistryType.Cnpmcore,
+    });
+  });
+
+  afterEach(async () => {
+    await app.destroyModuleContext(ctx);
+  });
+
+  describe('RegistryManagerService', () => {
+
+    describe('query should work', async () => {
+      beforeEach(async () => {
+        // create another
+        await registryManagerService.createRegistry({
+          name: 'custom2',
+          changeStream: 'https://r.cnpmjs.org/_changes',
+          host: 'https://cnpmjs.org',
+          userPrefix: 'ccnpm:',
+          type: RegistryType.Cnpmcore,
+        });
+      });
+
+      it('query success', async () => {
+        // query success
+        const queryRes = await registryManagerService.listRegistries({});
+        assert(queryRes.count === 2);
+        const [ _, registry ] = queryRes.data;
+        assert(_);
+        assert(registry.name === 'custom2');
+      });
+
+      it('pageOptions should work', async () => {
+        // pageOptions should work
+        let queryRes = await registryManagerService.listRegistries({ pageIndex: 0, pageSize: 1 });
+        console.log(queryRes.data);
+        assert(queryRes.count === 2);
+        assert(queryRes.data.length === 1);
+        const [ firstRegistry ] = queryRes.data;
+        assert(firstRegistry.name === 'custom');
+
+        queryRes = await registryManagerService.listRegistries({ pageIndex: 1, pageSize: 1 });
+        assert(queryRes.count === 2);
+        assert(queryRes.data.length === 1);
+        const [ secondRegistry ] = queryRes.data;
+        assert(secondRegistry.name === 'custom2');
+      });
+
+    });
+
+    it('update work', async () => {
+      let queryRes = await registryManagerService.listRegistries({});
+      const [ registry ] = queryRes.data;
+
+      await registryManagerService.updateRegistry({
+        ...registry,
+        name: 'custom3',
+      });
+
+      queryRes = await registryManagerService.listRegistries({});
+      assert(queryRes.data[0].name === 'custom3');
+
+    });
+
+    it('update should check registry', async () => {
+      const queryRes = await registryManagerService.listRegistries({});
+      assert(queryRes.count === 1);
+      const [ registry ] = queryRes.data;
+      await assert.rejects(
+        registryManagerService.updateRegistry({
+          ...registry,
+          registryId: 'not_exist',
+          name: 'boo',
+        }),
+        /not found/,
+      );
+    });
+
+    it('remove should work', async () => {
+      let queryRes = await registryManagerService.listRegistries({});
+      assert(queryRes.count === 1);
+      await registryManagerService.remove({ registryId: queryRes.data[0].registryId });
+      queryRes = await registryManagerService.listRegistries({});
+      assert(queryRes.count === 0);
+    });
+  });
+});

--- a/test/core/service/ScopeManagerService/index.test.ts
+++ b/test/core/service/ScopeManagerService/index.test.ts
@@ -1,0 +1,47 @@
+import assert = require('assert');
+import { app } from 'egg-mock/bootstrap';
+import { Context } from 'egg';
+import { ScopeManagerService } from 'app/core/service/ScopeManagerService';
+
+describe('test/core/service/ScopeManagerService/index.test.ts', () => {
+  let ctx: Context;
+  let scopeManagerService: ScopeManagerService;
+
+  before(async () => {
+    ctx = await app.mockModuleContext();
+    scopeManagerService = await ctx.getEggObject(ScopeManagerService);
+  });
+
+  beforeEach(async () => {
+    // create
+    await scopeManagerService.createScope({
+      name: 'custom',
+      registryId: 'banana',
+    });
+  });
+
+  afterEach(async () => {
+    await app.destroyModuleContext(ctx);
+  });
+
+  describe('ScopeManagerService', () => {
+    it('query should work', async () => {
+      const queryRes = await scopeManagerService.listScopes({});
+      assert(queryRes.data[0].name === 'custom');
+    });
+
+    it('query after create work', async () => {
+      // create another
+      await scopeManagerService.createScope({
+        name: 'custom2',
+        registryId: 'banana',
+      });
+
+      const queryRes = await scopeManagerService.listScopes({});
+      const [ _, otherScope ] = queryRes.data;
+      assert(_);
+      assert(otherScope.name === 'custom2');
+
+    });
+  });
+});

--- a/test/core/util/EntityUtil.test.ts
+++ b/test/core/util/EntityUtil.test.ts
@@ -1,0 +1,25 @@
+import { EntityUtil } from 'app/core/util/EntityUtil';
+import assert = require('assert');
+
+describe('test/core/util/EntityUtil.test.ts', () => {
+  describe('convertPageOptionsToLimitOption', () => {
+    it('should work', async () => {
+      const res = EntityUtil.convertPageOptionsToLimitOption({ pageIndex: 1, pageSize: 10 });
+      assert(res.limit === 10);
+      assert(res.offset === 10);
+    });
+
+    it('should work for default value', async () => {
+      const res = EntityUtil.convertPageOptionsToLimitOption({});
+      assert(res.limit === 20);
+      assert(res.offset === 0);
+    });
+
+    it('should validate params', async () => {
+      assert.throws(() => {
+        EntityUtil.convertPageOptionsToLimitOption({ pageIndex: 1, pageSize: 101 });
+      }, /max page size is 100, current request is 101/);
+
+    });
+  });
+});

--- a/test/port/controller/RegistryController/index.test.ts
+++ b/test/port/controller/RegistryController/index.test.ts
@@ -1,0 +1,199 @@
+import { Registry } from 'app/core/entity/Registry';
+import assert = require('assert');
+import { Context } from 'egg';
+import { app } from 'egg-mock/bootstrap';
+import { TestUtil } from '../../../TestUtil';
+
+describe('test/port/controller/RegistryController/index.test.ts', () => {
+  let ctx: Context;
+  let adminUser: any;
+  let registry: Registry;
+  before(async () => {
+    ctx = await app.mockModuleContext();
+  });
+  beforeEach(async () => {
+    adminUser = await TestUtil.createAdmin();
+    // create success
+    await app.httpRequest()
+      .post('/-/registry')
+      .set('authorization', adminUser.authorization)
+      .send(
+        {
+          name: 'custom3',
+          host: 'https://r.cnpmjs.org/',
+          changeStream: 'https://r.cnpmjs.org/_changes',
+          type: 'cnpmcore',
+        })
+      .expect(200);
+
+    // query success
+    const res = await app.httpRequest()
+      .get('/-/registry')
+      .expect(200);
+
+    registry = res.body.data[0];
+  });
+
+  afterEach(async () => {
+    await app.destroyModuleContext(ctx);
+  });
+
+  describe('[POST /-/registry] createRegistry()', () => {
+    it('should 200', async () => {
+      // create success
+      const res = await app.httpRequest()
+        .post('/-/registry')
+        .set('authorization', adminUser.authorization)
+        .send(
+          {
+            name: 'custom6',
+            host: 'https://r.cnpmjs.org/',
+            changeStream: 'https://r.cnpmjs.org/_changes',
+            type: 'cnpmcore',
+          });
+
+      assert(res.body.ok);
+    });
+
+    it('should verify params', async () => {
+      // create success
+      const res = await app.httpRequest()
+        .post('/-/registry')
+        .set('authorization', adminUser.authorization)
+        .send(
+          {
+            name: 'custom',
+            type: 'cnpmcore',
+          })
+        .expect(422);
+
+      assert(res.body.error === '[INVALID_PARAM] must have required property \'host\'');
+    });
+
+    it('should 403', async () => {
+      // create forbidden
+      const res = await app.httpRequest()
+        .post('/-/registry')
+        .send(
+          {
+            name: 'custom',
+            host: 'https://r.cnpmjs.org/',
+            changeStream: 'https://r.cnpmjs.org/_changes',
+            type: 'cnpmcore',
+          })
+        .expect(403);
+
+      assert(res.body.error === '[FORBIDDEN] Not allow to access');
+    });
+
+  });
+
+  describe('[GET /-/registry] listRegistries()', () => {
+    it('should 200', async () => {
+      // create success
+      await app.httpRequest()
+        .post('/-/registry')
+        .set('authorization', adminUser.authorization)
+        .send(
+          {
+            name: 'custom5',
+            host: 'https://r.cnpmjs.org/',
+            changeStream: 'https://r.cnpmjs.org/_changes',
+            type: 'cnpmcore',
+          })
+        .expect(200);
+
+      // query success
+      const res = await app.httpRequest()
+        .get('/-/registry')
+        .expect(200);
+
+      assert(res.body.count === 2);
+      assert(res.body.data[1].name === 'custom5');
+    });
+  });
+
+  describe('[GET /-/registry/:id/scopes] showRegistryScopes()', () => {
+    it('should 200', async () => {
+      // create scope
+      await app.httpRequest()
+        .post('/-/scope')
+        .set('authorization', adminUser.authorization)
+        .send({
+          registryId: registry.registryId,
+          name: '@banana',
+        });
+
+      await app.httpRequest()
+        .post('/-/scope')
+        .set('authorization', adminUser.authorization)
+        .send({
+          registryId: registry.registryId,
+          name: '@apple',
+        });
+
+      await app.httpRequest()
+        .post('/-/scope')
+        .set('authorization', adminUser.authorization)
+        .send({
+          registryId: registry.registryId,
+          name: '@orange',
+        });
+
+      let scopRes = await app.httpRequest()
+        .get(`/-/registry/${registry.registryId}/scopes`)
+        .expect(200);
+      assert(scopRes.body.count === 3);
+      assert(scopRes.body.data.length === 3);
+
+      scopRes = await app.httpRequest()
+        .get(`/-/registry/${registry.registryId}/scopes?pageSize=1`)
+        .expect(200);
+      assert(scopRes.body.count === 3);
+      assert(scopRes.body.data.length === 1);
+
+      scopRes = await app.httpRequest()
+        .get(`/-/registry/${registry.registryId}/scopes?pageSize=2&pageIndex=1`)
+        .expect(200);
+      assert(scopRes.body.count === 3);
+      assert(scopRes.body.data.length === 1);
+
+    });
+    it('should error', async () => {
+      await app.httpRequest()
+        .get('/-/registry/not_exist_id/scopes')
+        .expect(404);
+    });
+  });
+
+  describe('[GET /-/registry/:id] showRegistry()', () => {
+    it('should 200', async () => {
+      const queryRes = await app.httpRequest()
+        .get(`/-/registry/${registry.registryId}`);
+      assert.deepEqual(queryRes.body, registry);
+    });
+
+    it('should error', async () => {
+      await app.httpRequest()
+        .get('/-/registry/not_exist_id')
+        .expect(404);
+    });
+  });
+
+  describe('[DELETE /-/registry] deleteRegistry()', () => {
+    it('should 200', async () => {
+      await app.httpRequest()
+        .delete(`/-/registry/${registry.registryId}`)
+        .set('authorization', adminUser.authorization)
+        .expect(200);
+
+      // query success
+      const queryRes = await app.httpRequest()
+        .get('/-/registry')
+        .set('authorization', adminUser.authorization)
+        .expect(200);
+
+      assert(queryRes.body.count === 0);
+    });
+  });
+});

--- a/test/port/controller/ScopeController/index.test.ts
+++ b/test/port/controller/ScopeController/index.test.ts
@@ -1,0 +1,106 @@
+import assert = require('assert');
+import { RegistryType } from 'app/common/enum/Registry';
+import { RegistryManagerService } from 'app/core/service/RegistryManagerService';
+import { Context } from 'egg';
+import { app } from 'egg-mock/bootstrap';
+import { TestUtil } from '../../../TestUtil';
+import { Scope } from 'app/core/entity/Scope';
+
+describe('test/port/controller/ScopeController/index.test.ts', () => {
+  let ctx: Context;
+  let adminUser: any;
+  let registryManagerService: RegistryManagerService;
+  beforeEach(async () => {
+    ctx = await app.mockModuleContext();
+    adminUser = await TestUtil.createAdmin();
+    registryManagerService = await ctx.getEggObject(RegistryManagerService);
+    // create registry
+    await registryManagerService.createRegistry({
+      name: 'custom',
+      host: 'https://r.cnpmjs.org/',
+      changeStream: 'https://r.cnpmjs.org/_changes',
+      userPrefix: 'cnpm:',
+      type: RegistryType.Cnpmcore,
+    });
+  });
+
+  afterEach(async () => {
+    await app.destroyModuleContext(ctx);
+  });
+
+  describe('[POST /-/scope] createScope()', () => {
+    it('should 200', async () => {
+
+      const queryRes = await registryManagerService.listRegistries({});
+      const [ registry ] = queryRes.data;
+
+      // create success
+      const res = await app.httpRequest()
+        .post('/-/scope')
+        .set('authorization', adminUser.authorization)
+        .send(
+          {
+            name: '@cnpm',
+            registryId: registry.registryId,
+          })
+        .expect(200);
+
+      assert(res.body.ok);
+    });
+
+    it('should 400', async () => {
+      const res = await app.httpRequest()
+        .post('/-/scope')
+        .set('authorization', adminUser.authorization)
+        .send(
+          {
+            name: '@cnpmbanana',
+            registryId: 'banana',
+          })
+        .expect(400);
+
+      assert(res.body.error === '[BAD_REQUEST] registry banana not found');
+    });
+
+    it('should 403', async () => {
+      // create success
+      const res = await app.httpRequest()
+        .post('/-/scope')
+        .send(
+          {
+            name: '@cnpm',
+          })
+        .expect(403);
+
+      assert(res.body.error === '[FORBIDDEN] Not allow to access');
+    });
+
+  });
+
+  describe('[DELETE /-/scope/:id] deleteScope()', () => {
+    let scope: Scope;
+    beforeEach(async () => {
+      const queryRes = await registryManagerService.listRegistries({});
+      const registry = queryRes.data[0];
+      let res = await app.httpRequest()
+        .post('/-/scope')
+        .set('authorization', adminUser.authorization)
+        .send(
+          {
+            name: '@cnpmjsa',
+            registryId: registry.registryId,
+          });
+      res = await app.httpRequest()
+        .get(`/-/registry/${registry.registryId}/scopes`);
+
+      scope = res.body.data[0];
+    });
+    it('should 200', async () => {
+      const res = await app.httpRequest()
+        .delete(`/-/scope/${scope.scopeId}`)
+        .set('authorization', adminUser.authorization)
+        .expect(200);
+      assert(res.body.ok);
+    });
+  });
+});

--- a/test/repository/RegistryRepository.test.ts
+++ b/test/repository/RegistryRepository.test.ts
@@ -1,0 +1,78 @@
+import assert = require('assert');
+import { app } from 'egg-mock/bootstrap';
+import { Context } from 'egg';
+import { RegistryRepository } from 'app/repository/RegistryRepository';
+import { Registry } from 'app/core/entity/Registry';
+import { RegistryType } from 'app/common/enum/Registry';
+
+describe('test/repository/RegistryRepository.test.ts', () => {
+  let ctx: Context;
+
+  let registryRepository: RegistryRepository;
+  let registryModel: Registry;
+
+  beforeEach(async () => {
+    ctx = await app.mockModuleContext();
+    registryRepository = await ctx.getEggObject(RegistryRepository);
+    registryModel = await registryRepository.saveRegistry(Registry.create({
+      name: 'cnpmcore',
+      userPrefix: 'cnpm:',
+      changeStream: 'https://r.npmjs.com/_changes',
+      host: 'https://registry.npmjs.org',
+      type: 'cnpmcore' as RegistryType,
+    })) as Registry;
+
+  });
+
+  afterEach(async () => {
+    await app.destroyModuleContext(ctx);
+  });
+
+
+  describe('RegistryRepository', () => {
+    it('create work', async () => {
+      const newRegistry = await registryRepository.saveRegistry(Registry.create({
+        name: 'npm',
+        userPrefix: 'npm:',
+        changeStream: 'https://ra.npmjs.com/_changes',
+        host: 'https://registry.npmjs.org',
+        type: 'cnpmcore' as RegistryType,
+      })) as Registry;
+      assert(newRegistry);
+      assert(newRegistry.type === 'cnpmcore');
+    });
+    it('update work', async () => {
+      const updatedRegistry = await registryRepository.saveRegistry({
+        ...registryModel,
+        registryId: registryModel.registryId,
+        id: registryModel.id,
+        name: 'banana',
+        userPrefix: 'cnpm:',
+        host: 'https://registry.npmjs.org',
+        type: 'cnpmcore' as RegistryType,
+        changeStream: 'https://replicate.npmjs.com/_changes',
+      });
+      assert(updatedRegistry);
+      assert(updatedRegistry.name === 'banana');
+    });
+    it('list work', async () => {
+      const registries = await registryRepository.listRegistries({});
+      assert(registries.count === 1);
+    });
+
+    it('query null', async () => {
+      const queryRes = await registryRepository.findRegistry('orange');
+      assert(queryRes === null);
+    });
+
+    it('query work', async () => {
+      const queryRes = await registryRepository.findRegistry('cnpmcore');
+      assert(queryRes?.name === 'cnpmcore');
+    });
+    it('remove work', async () => {
+      await registryRepository.removeRegistry(registryModel.registryId);
+      const emptyRes = await registryRepository.listRegistries({});
+      assert.deepEqual(emptyRes.data, []);
+    });
+  });
+});

--- a/test/repository/ScopeRepository.test.ts
+++ b/test/repository/ScopeRepository.test.ts
@@ -1,0 +1,73 @@
+import assert = require('assert');
+import { app } from 'egg-mock/bootstrap';
+import { Context } from 'egg';
+import { ScopeRepository } from 'app/repository/ScopeRepository';
+import { Scope } from 'app/core/entity/Scope';
+
+describe('test/repository/ScopeRepository.test.ts', () => {
+  let ctx: Context;
+
+  let scopeRepository: ScopeRepository;
+  let cnpmjsScope: Scope;
+
+  beforeEach(async () => {
+    ctx = await app.mockModuleContext();
+    scopeRepository = await ctx.getEggObject(ScopeRepository);
+    cnpmjsScope = await scopeRepository.saveScope(Scope.create({
+      name: '@cnpmjs',
+      registryId: '1',
+    })) as Scope;
+  });
+
+  afterEach(async () => {
+    await app.destroyModuleContext(ctx);
+  });
+
+  describe('RegistryRepository', () => {
+    it('create work', async () => {
+      const cnpmScope = await scopeRepository.saveScope(Scope.create({
+        name: '@cnpm',
+        registryId: '1',
+      }));
+      assert(cnpmScope);
+      assert(cnpmjsScope);
+    });
+
+    it('list work', async () => {
+      // list
+      const cnpmScope = await scopeRepository.saveScope(Scope.create({
+        name: '@cnpm',
+        registryId: '1',
+      })) as Scope;
+      const scopeRes = await scopeRepository.listScopes({});
+      assert.deepEqual([ cnpmjsScope.name, cnpmScope.name ], scopeRes.data.map(scope => scope.name));
+    });
+
+    it('update work', async () => {
+      await scopeRepository.saveScope({
+        ...cnpmjsScope,
+        id: cnpmjsScope.id,
+        scopeId: cnpmjsScope.scopeId,
+        name: '@anpm',
+        registryId: '1',
+      });
+      const scopeRes = await scopeRepository.listScopes({});
+      assert(scopeRes.count === 1);
+      assert(scopeRes.data[0].name === '@anpm');
+    });
+
+    it('remove work', async () => {
+      // remove
+      const cnpmScope = await scopeRepository.saveScope(Scope.create({
+        name: '@cnpm',
+        registryId: '1',
+      })) as Scope;
+      await scopeRepository.removeScope(cnpmjsScope.scopeId);
+      const scopesAfterRemove = await scopeRepository.listScopes({});
+      assert.deepEqual(scopesAfterRemove.data.map(scope => scope.name), [ cnpmScope.name ]);
+      await scopeRepository.removeScopeByRegistryId(cnpmjsScope.registryId);
+      const emptyRes = await scopeRepository.listScopes({});
+      assert.deepEqual(emptyRes.data, []);
+    });
+  });
+});


### PR DESCRIPTION
1. 初始化 Registry 和 Scope 模型及接口
2. Registry 和 Scope 为一等公民，单独用接口来处理增啥改查和关联关系信息
3. 仅管理员可作修改，所有人可以进行查询
~~4. Registry 查询 VO 模型内，返回 scopes 信息~~
5. 新增 @Middleware AdminAccess 中间件处理管理员鉴权