### PR TITLE
feat: changesStream adapter & needSync() method

### DIFF
--- a/app/common/adapter/changesStream/AbstractChangesStream.ts
+++ b/app/common/adapter/changesStream/AbstractChangesStream.ts
@@ -3,9 +3,9 @@ import {
   Inject,
   QualifierImplDecoratorUtil,
 } from '@eggjs/tegg';
-import { RegistryType } from 'app/common/enum/Registry';
 import { Readable } from 'node:stream';
-import { Registry } from 'app/core/entity/Registry';
+import { RegistryType } from '../../../common/enum/Registry';
+import { Registry } from '../../../core/entity/Registry';
 import {
   EggHttpClient,
   EggLogger,

--- a/app/common/adapter/changesStream/AbstractChangesStream.ts
+++ b/app/common/adapter/changesStream/AbstractChangesStream.ts
@@ -4,6 +4,7 @@ import {
   QualifierImplDecoratorUtil,
 } from '@eggjs/tegg';
 import { RegistryType } from 'app/common/enum/Registry';
+import { Readable } from 'node:stream';
 import { Registry } from 'app/core/entity/Registry';
 import {
   EggHttpClient,
@@ -11,14 +12,9 @@ import {
 } from 'egg';
 
 export const CHANGE_STREAM_ATTRIBUTE = 'CHANGE_STREAM_ATTRIBUTE';
-export type Change = {
+export type ChangesStreamChange = {
   seq: string;
   fullname: string;
-};
-export type FetchChangesResult = {
-  taskCount: number;
-  changes: Change[];
-  lastSince: string;
 };
 
 export abstract class AbstractChangeStream {
@@ -29,7 +25,7 @@ export abstract class AbstractChangeStream {
   protected httpclient: EggHttpClient;
 
   abstract getInitialSince(registry: Registry): Promise<string>;
-  abstract fetchChanges(registry: Registry, since: string): Promise<FetchChangesResult>;
+  abstract fetchChanges(registry: Registry, since: string): Promise<Readable>;
 }
 
 export const RegistryChangesStream: ImplDecorator<AbstractChangeStream, typeof RegistryType> =

--- a/app/common/adapter/changesStream/AbstractChangesStream.ts
+++ b/app/common/adapter/changesStream/AbstractChangesStream.ts
@@ -1,0 +1,36 @@
+import {
+  ImplDecorator,
+  Inject,
+  QualifierImplDecoratorUtil,
+} from '@eggjs/tegg';
+import { RegistryType } from 'app/common/enum/Registry';
+import { Registry } from 'app/core/entity/Registry';
+import {
+  EggHttpClient,
+  EggLogger,
+} from 'egg';
+
+export const CHANGE_STREAM_ATTRIBUTE = 'CHANGE_STREAM_ATTRIBUTE';
+export type Change = {
+  seq: string;
+  fullname: string;
+};
+export type FetchChangesResult = {
+  taskCount: number;
+  changes: Change[];
+  lastSince: string;
+};
+
+export abstract class AbstractChangeStream {
+  @Inject()
+  protected logger: EggLogger;
+
+  @Inject()
+  protected httpclient: EggHttpClient;
+
+  abstract getInitialSince(registry: Registry): Promise<string>;
+  abstract fetchChanges(registry: Registry, since: string): Promise<FetchChangesResult>;
+}
+
+export const RegistryChangesStream: ImplDecorator<AbstractChangeStream, typeof RegistryType> =
+  QualifierImplDecoratorUtil.generatorDecorator(AbstractChangeStream, CHANGE_STREAM_ATTRIBUTE);

--- a/app/common/adapter/changesStream/AbstractChangesStream.ts
+++ b/app/common/adapter/changesStream/AbstractChangesStream.ts
@@ -26,6 +26,15 @@ export abstract class AbstractChangeStream {
 
   abstract getInitialSince(registry: Registry): Promise<string>;
   abstract fetchChanges(registry: Registry, since: string): Promise<Readable>;
+
+  getChangesStreamUrl(registry: Registry, since: string, limit?: number): string {
+    const url = new URL(registry.changeStream);
+    url.searchParams.set('since', since);
+    if (limit) {
+      url.searchParams.set('limit', String(limit));
+    }
+    return url.toString();
+  }
 }
 
 export const RegistryChangesStream: ImplDecorator<AbstractChangeStream, typeof RegistryType> =

--- a/app/common/adapter/changesStream/CnpmcoreChangesStream.ts
+++ b/app/common/adapter/changesStream/CnpmcoreChangesStream.ts
@@ -1,7 +1,7 @@
 import { Readable } from 'node:stream';
 import { ContextProto } from '@eggjs/tegg';
-import { RegistryType } from 'app/common/enum/Registry';
-import { Registry } from 'app/core/entity/Registry';
+import { RegistryType } from '../../../common/enum/Registry';
+import { Registry } from '../../../core/entity/Registry';
 import { E500 } from 'egg-errors';
 import { AbstractChangeStream, ChangesStreamChange, RegistryChangesStream } from './AbstractChangesStream';
 

--- a/app/common/adapter/changesStream/CnpmcoreChangesStream.ts
+++ b/app/common/adapter/changesStream/CnpmcoreChangesStream.ts
@@ -1,0 +1,59 @@
+import { ContextProto } from '@eggjs/tegg';
+import { RegistryType } from 'app/common/enum/Registry';
+import { Registry } from 'app/core/entity/Registry';
+import { AbstractChangeStream, FetchChangesResult, RegistryChangesStream } from './AbstractChangesStream';
+
+@ContextProto()
+@RegistryChangesStream(RegistryType.Cnpmcore)
+export class CnpmcoreChangesStream extends AbstractChangeStream {
+
+  async getInitialSince(registry: Registry): Promise<string> {
+    const db = (new URL(registry.changeStream)).origin;
+    const { status, data } = await this.httpclient.request(db, {
+      followRedirect: true,
+      timeout: 10000,
+      dataType: 'json',
+    });
+    const since = String((data.update_seq || 7139548) - 10);
+    this.logger.warn('[ChangesStreamService.executeTask:firstSeq] GET %s status: %s, data: %j, since: %s',
+      registry.name, status, data, since);
+    return since;
+  }
+
+  async fetchChanges(registry: Registry, since: string): Promise<FetchChangesResult> {
+    let lastSince = since;
+    let taskCount = 0;
+    const changes: FetchChangesResult['changes'] = [];
+
+    const db = `${registry.changeStream}?since=${since}`;
+    // json mode
+    const { data } = await this.httpclient.request(db, {
+      followRedirect: true,
+      timeout: 30000,
+      dataType: 'json',
+      gzip: true,
+    });
+
+    if (data.results?.length > 0) {
+      for (const change of data.results) {
+        const seq = change.seq;
+        const fullname = change.id;
+        // cnpmcore 默认返回 >= 需要做特殊判断
+        if (seq && fullname && seq + '' !== since) {
+          taskCount++;
+          changes.push({
+            fullname,
+            seq,
+          });
+          lastSince = String(seq);
+        }
+      }
+    }
+
+    return {
+      lastSince,
+      taskCount,
+      changes,
+    };
+  }
+}

--- a/app/common/adapter/changesStream/CnpmcoreChangesStream.ts
+++ b/app/common/adapter/changesStream/CnpmcoreChangesStream.ts
@@ -28,7 +28,7 @@ export class CnpmcoreChangesStream extends AbstractChangeStream {
   async fetchChanges(registry: Registry, since: string): Promise<Readable> {
     const changes: ChangesStreamChange[] = [];
 
-    const db = `${registry.changeStream}?since=${since}`;
+    const db = this.getChangesStreamUrl(registry, since);
     // json mode
     const { data } = await this.httpclient.request(db, {
       followRedirect: true,

--- a/app/common/adapter/changesStream/CnpmjsorgChangesStream.ts
+++ b/app/common/adapter/changesStream/CnpmjsorgChangesStream.ts
@@ -1,7 +1,7 @@
 import { ContextProto } from '@eggjs/tegg';
 import { Readable } from 'node:stream';
-import { RegistryType } from 'app/common/enum/Registry';
-import { Registry } from 'app/core/entity/Registry';
+import { RegistryType } from '../../../common/enum/Registry';
+import { Registry } from '../../../core/entity/Registry';
 import { E500 } from 'egg-errors';
 import { AbstractChangeStream, ChangesStreamChange, RegistryChangesStream } from './AbstractChangesStream';
 

--- a/app/common/adapter/changesStream/CnpmjsorgChangesStream.ts
+++ b/app/common/adapter/changesStream/CnpmjsorgChangesStream.ts
@@ -14,8 +14,8 @@ export class CnpmjsorgChangesStream extends AbstractChangeStream {
   // cnpmjsorg 未实现 update_seq 字段
   // 默认返回当前时间戳字符串
   async getInitialSince(registry: Registry): Promise<string> {
-    const since = String((new Date()).getTime() - 1);
-    this.logger.warn(`[CnpmjsorgChangesStream.getInitialSince] since: 1, skip query ${registry.changeStream}`);
+    const since = String((new Date()).getTime());
+    this.logger.warn(`[CnpmjsorgChangesStream.getInitialSince] since: ${since}, skip query ${registry.changeStream}`);
     return since;
   }
 
@@ -23,7 +23,7 @@ export class CnpmjsorgChangesStream extends AbstractChangeStream {
     if (limit > MAX_LIMIT) {
       throw new E500(`limit too large, current since: ${since}, limit: ${limit}`);
     }
-    const db = `${registry.changeStream}?since=${since}&limit=${limit}`;
+    const db = this.getChangesStreamUrl(registry, since, limit);
     // json mode
     const res = await this.httpclient.request(db, {
       followRedirect: true,

--- a/app/common/adapter/changesStream/CnpmjsorgChangesStream.ts
+++ b/app/common/adapter/changesStream/CnpmjsorgChangesStream.ts
@@ -1,0 +1,77 @@
+import { ContextProto } from '@eggjs/tegg';
+import { RegistryType } from 'app/common/enum/Registry';
+import { Registry } from 'app/core/entity/Registry';
+import { E500 } from 'egg-errors';
+import { AbstractChangeStream, FetchChangesResult, RegistryChangesStream } from './AbstractChangesStream';
+
+const MAX_LIMIT = 10000;
+
+@ContextProto()
+@RegistryChangesStream(RegistryType.Cnpmjsorg)
+export class CnpmjsorgChangesStream extends AbstractChangeStream {
+
+  // cnpmjsorg 未实现 update_seq 字段
+  // 返回静态的 since
+  // 后续可以将 since 改为 registry.gmt_modified 来初始化增量同步
+  async getInitialSince(registry: Registry): Promise<string> {
+    const since = '1';
+    this.logger.warn(`[ChangesStreamService.executeTask:firstSeq] since: 1, skip query ${registry.changeStream}`);
+    return since;
+  }
+
+  private async tryFetch(registry: Registry, since: string, limit = 1000) {
+    if (limit > MAX_LIMIT) {
+      throw new E500(`limit too large, current since: ${since}, limit: ${limit}`);
+    }
+    const db = `${registry.changeStream}?since=${since}&limit=${limit}`;
+    // json mode
+    const res = await this.httpclient.request(db, {
+      followRedirect: true,
+      timeout: 30000,
+      dataType: 'json',
+      gzip: true,
+    });
+    const { results = [] } = res.data;
+    if (results?.length > 1) {
+      const [ first ] = results;
+      const last = results[results.length - 1];
+      if (first.gmt_modified === last.gmt_modified) {
+        return await this.tryFetch(registry, last.seq, limit + 1000);
+      }
+    }
+
+    return res;
+  }
+
+  async fetchChanges(registry: Registry, since: string): Promise<FetchChangesResult> {
+    let lastSince = since;
+    let taskCount = 0;
+    const changes: FetchChangesResult['changes'] = [];
+
+    // ref: https://github.com/cnpm/cnpmjs.org/pull/1734
+    // 由于 cnpmjsorg 无法计算准确的 seq
+    // since 是一个时间戳，需要确保一次返回的结果中首尾两个 gmtModified 不相等
+    const { data } = await this.tryFetch(registry, since);
+
+    if (data.results?.length > 0) {
+      for (const change of data.results) {
+        const seq = new Date(change.gmt_modified).getTime() + '';
+        const fullname = change.id;
+        if (seq && fullname && seq !== since) {
+          taskCount++;
+          changes.push({
+            fullname,
+            seq,
+          });
+          lastSince = seq;
+        }
+      }
+    }
+
+    return {
+      lastSince,
+      taskCount,
+      changes,
+    };
+  }
+}

--- a/app/common/adapter/changesStream/CnpmjsorgChangesStream.ts
+++ b/app/common/adapter/changesStream/CnpmjsorgChangesStream.ts
@@ -12,10 +12,9 @@ const MAX_LIMIT = 10000;
 export class CnpmjsorgChangesStream extends AbstractChangeStream {
 
   // cnpmjsorg 未实现 update_seq 字段
-  // 返回静态的 since
-  // 后续可以将 since 改为 registry.gmt_modified 来初始化增量同步
+  // 默认返回当前时间戳字符串
   async getInitialSince(registry: Registry): Promise<string> {
-    const since = '1';
+    const since = String((new Date()).getTime() - 1);
     this.logger.warn(`[CnpmjsorgChangesStream.getInitialSince] since: 1, skip query ${registry.changeStream}`);
     return since;
   }

--- a/app/common/adapter/changesStream/CnpmjsorgChangesStream.ts
+++ b/app/common/adapter/changesStream/CnpmjsorgChangesStream.ts
@@ -15,7 +15,7 @@ export class CnpmjsorgChangesStream extends AbstractChangeStream {
   // 后续可以将 since 改为 registry.gmt_modified 来初始化增量同步
   async getInitialSince(registry: Registry): Promise<string> {
     const since = '1';
-    this.logger.warn(`[ChangesStreamService.executeTask:firstSeq] since: 1, skip query ${registry.changeStream}`);
+    this.logger.warn(`[CnpmjsorgChangesStream.getInitialSince] since: 1, skip query ${registry.changeStream}`);
     return since;
   }
 

--- a/app/common/adapter/changesStream/NpmChangesStream.ts
+++ b/app/common/adapter/changesStream/NpmChangesStream.ts
@@ -1,6 +1,7 @@
 import { ContextProto } from '@eggjs/tegg';
 import { RegistryType } from 'app/common/enum/Registry';
 import { Registry } from 'app/core/entity/Registry';
+import { E500 } from 'egg-errors';
 import { AbstractChangeStream, FetchChangesResult, RegistryChangesStream } from './AbstractChangesStream';
 
 @ContextProto()
@@ -14,8 +15,11 @@ export class NpmChangesStream extends AbstractChangeStream {
       timeout: 10000,
       dataType: 'json',
     });
-    const since = String((data.update_seq || 7139548) - 10);
-    this.logger.warn('[ChangesStreamService.executeTask:firstSeq] GET %s status: %s, data: %j, since: %s',
+    const since = String(data.update_seq - 10);
+    if (!data.update_seq) {
+      throw new E500(`get getInitialSince failed: ${data.update_seq}`);
+    }
+    this.logger.warn('[NpmChangesStream.getInitialSince] GET %s status: %s, data: %j, since: %s',
       registry.name, registry.changeStream, status, data, since);
     return since;
   }

--- a/app/common/adapter/changesStream/NpmChangesStream.ts
+++ b/app/common/adapter/changesStream/NpmChangesStream.ts
@@ -52,7 +52,7 @@ export class NpmChangesStream extends AbstractChangeStream {
   async fetchChanges(registry: Registry, since: string): Promise<Readable> {
     const self = this;
     const { parseChangeChunk } = this;
-    const db = `${registry.changeStream}?since=${since}`;
+    const db = this.getChangesStreamUrl(registry, since);
     const { res } = await this.httpclient.request(db, {
       streaming: true,
       timeout: 10000,

--- a/app/common/adapter/changesStream/NpmChangesStream.ts
+++ b/app/common/adapter/changesStream/NpmChangesStream.ts
@@ -1,0 +1,61 @@
+import { ContextProto } from '@eggjs/tegg';
+import { RegistryType } from 'app/common/enum/Registry';
+import { Registry } from 'app/core/entity/Registry';
+import { AbstractChangeStream, FetchChangesResult, RegistryChangesStream } from './AbstractChangesStream';
+
+@ContextProto()
+@RegistryChangesStream(RegistryType.Npm)
+export class NpmChangesStream extends AbstractChangeStream {
+
+  async getInitialSince(registry: Registry): Promise<string> {
+    const db = (new URL(registry.changeStream)).origin;
+    const { status, data } = await this.httpclient.request(db, {
+      followRedirect: true,
+      timeout: 10000,
+      dataType: 'json',
+    });
+    const since = String((data.update_seq || 7139548) - 10);
+    this.logger.warn('[ChangesStreamService.executeTask:firstSeq] GET %s status: %s, data: %j, since: %s',
+      registry.name, registry.changeStream, status, data, since);
+    return since;
+  }
+
+  async fetchChanges(registry: Registry, since: string): Promise<FetchChangesResult> {
+    let lastSince = since;
+    let taskCount = 0;
+    const changes: FetchChangesResult['changes'] = [];
+
+    const db = `${registry.changeStream}?since=${since}`;
+    const { res } = await this.httpclient.request(db, {
+      streaming: true,
+      timeout: 10000,
+    });
+    for await (const chunk of res) {
+      const text: string = chunk.toString();
+      // {"seq":7138879,"id":"@danydodson/prettier-config","changes":[{"rev":"5-a56057032714af25400d93517773a82a"}]}
+      // console.log('😄%j😄', text);
+      // 😄"{\"seq\":7138738,\"id\":\"wargerm\",\"changes\":[{\"rev\":\"59-f0a0d326db4c62ed480987a04ba3bf8f\"}]}"😄
+      // 😄",\n{\"seq\":7138739,\"id\":\"@laffery/webpack-starter-kit\",\"changes\":[{\"rev\":\"4-84a8dc470a07872f4cdf85cf8ef892a1\"}]},\n{\"seq\":7138741,\"id\":\"venom-bot\",\"changes\":[{\"rev\":\"103-908654b1ad4b0e0fd40b468d75730674\"}]}"😄
+      // 😄",\n{\"seq\":7138743,\"id\":\"react-native-template-pytorch-live\",\"changes\":[{\"rev\":\"40-871c686b200312303ba7c4f7f93e0362\"}]}"😄
+      // 😄",\n{\"seq\":7138745,\"id\":\"ccxt\",\"changes\":[{\"rev\":\"10205-25367c525a0a3bd61be3a72223ce212c\"}]}"😄
+      const matchs = text.matchAll(/"seq":(\d+),"id":"([^"]+)"/gm);
+      for (const match of matchs) {
+        const seq = match[1];
+        const fullname = match[2];
+        if (seq && fullname) {
+          taskCount++;
+          changes.push({
+            fullname,
+            seq,
+          });
+          lastSince = seq;
+        }
+      }
+    }
+    return {
+      lastSince,
+      taskCount,
+      changes,
+    };
+  }
+}

--- a/app/common/adapter/changesStream/NpmChangesStream.ts
+++ b/app/common/adapter/changesStream/NpmChangesStream.ts
@@ -26,7 +26,7 @@ export class NpmChangesStream extends AbstractChangeStream {
   }
 
   async fetchChanges(registry: Registry, since: string): Promise<Readable> {
-
+    const { logger } = this;
     const db = `${registry.changeStream}?since=${since}`;
     const { res } = await this.httpclient.request(db, {
       streaming: true,
@@ -43,6 +43,8 @@ export class NpmChangesStream extends AbstractChangeStream {
           const fullname = match[2];
           if (seq && fullname) {
             this.push({ fullname, seq } as ChangesStreamChange);
+          } else {
+            logger.warn('[NpmChangesStream.fetchChanges] invalid change: %s', text);
           }
         }
         callback();

--- a/app/common/adapter/changesStream/NpmChangesStream.ts
+++ b/app/common/adapter/changesStream/NpmChangesStream.ts
@@ -2,7 +2,8 @@ import { ContextProto } from '@eggjs/tegg';
 import { RegistryType } from 'app/common/enum/Registry';
 import { Registry } from 'app/core/entity/Registry';
 import { E500 } from 'egg-errors';
-import { AbstractChangeStream, FetchChangesResult, RegistryChangesStream } from './AbstractChangesStream';
+import { AbstractChangeStream, ChangesStreamChange, RegistryChangesStream } from './AbstractChangesStream';
+import { Transform, Readable } from 'node:stream';
 
 @ContextProto()
 @RegistryChangesStream(RegistryType.Npm)
@@ -24,42 +25,31 @@ export class NpmChangesStream extends AbstractChangeStream {
     return since;
   }
 
-  async fetchChanges(registry: Registry, since: string): Promise<FetchChangesResult> {
-    let lastSince = since;
-    let taskCount = 0;
-    const changes: FetchChangesResult['changes'] = [];
+  async fetchChanges(registry: Registry, since: string): Promise<Readable> {
 
     const db = `${registry.changeStream}?since=${since}`;
     const { res } = await this.httpclient.request(db, {
       streaming: true,
       timeout: 10000,
     });
-    for await (const chunk of res) {
-      const text: string = chunk.toString();
-      // {"seq":7138879,"id":"@danydodson/prettier-config","changes":[{"rev":"5-a56057032714af25400d93517773a82a"}]}
-      // console.log('😄%j😄', text);
-      // 😄"{\"seq\":7138738,\"id\":\"wargerm\",\"changes\":[{\"rev\":\"59-f0a0d326db4c62ed480987a04ba3bf8f\"}]}"😄
-      // 😄",\n{\"seq\":7138739,\"id\":\"@laffery/webpack-starter-kit\",\"changes\":[{\"rev\":\"4-84a8dc470a07872f4cdf85cf8ef892a1\"}]},\n{\"seq\":7138741,\"id\":\"venom-bot\",\"changes\":[{\"rev\":\"103-908654b1ad4b0e0fd40b468d75730674\"}]}"😄
-      // 😄",\n{\"seq\":7138743,\"id\":\"react-native-template-pytorch-live\",\"changes\":[{\"rev\":\"40-871c686b200312303ba7c4f7f93e0362\"}]}"😄
-      // 😄",\n{\"seq\":7138745,\"id\":\"ccxt\",\"changes\":[{\"rev\":\"10205-25367c525a0a3bd61be3a72223ce212c\"}]}"😄
-      const matchs = text.matchAll(/"seq":(\d+),"id":"([^"]+)"/gm);
-      for (const match of matchs) {
-        const seq = match[1];
-        const fullname = match[2];
-        if (seq && fullname) {
-          taskCount++;
-          changes.push({
-            fullname,
-            seq,
-          });
-          lastSince = seq;
+
+    const transform = new Transform({
+      readableObjectMode: true,
+      transform(chunk, _, callback) {
+        const text = chunk.toString();
+        const matchs = text.matchAll(/"seq":(\d+),"id":"([^"]+)"/gm);
+        for (const match of matchs) {
+          const seq = match[1];
+          const fullname = match[2];
+          if (seq && fullname) {
+            this.push({ fullname, seq } as ChangesStreamChange);
+          }
         }
-      }
-    }
-    return {
-      lastSince,
-      taskCount,
-      changes,
-    };
+        callback();
+      },
+    });
+
+    return res.pipe(transform);
   }
+
 }

--- a/app/core/entity/Registry.ts
+++ b/app/core/entity/Registry.ts
@@ -1,6 +1,6 @@
 import { Entity, EntityData } from './Entity';
 import { EasyData, EntityUtil } from '../util/EntityUtil';
-import type { RegistryType } from 'app/common/enum/Registry';
+import type { RegistryType } from '../../common/enum/Registry';
 
 interface RegistryData extends EntityData {
   name: string;

--- a/app/core/entity/Task.ts
+++ b/app/core/entity/Task.ts
@@ -60,6 +60,7 @@ export interface ChangeStreamTaskData extends TaskBaseData {
   last_package?: string,
   last_package_created?: Date,
   task_count?: number,
+  registryId?: string,
 }
 
 export type CreateHookTask = Task<CreateHookTaskData>;

--- a/app/core/service/ChangesStreamService.ts
+++ b/app/core/service/ChangesStreamService.ts
@@ -13,11 +13,11 @@ import { HOST_NAME, ChangesStreamTask, Task } from '../entity/Task';
 import { PackageSyncerService } from './PackageSyncerService';
 import { TaskService } from './TaskService';
 import { RegistryManagerService } from './RegistryManagerService';
-import { RegistryType } from 'app/common/enum/Registry';
+import { RegistryType } from '../../common/enum/Registry';
 import { E500 } from 'egg-errors';
 import { Registry } from '../entity/Registry';
-import { AbstractChangeStream, ChangesStreamChange } from 'app/common/adapter/changesStream/AbstractChangesStream';
-import { getScopeAndName } from 'app/common/PackageUtil';
+import { AbstractChangeStream, ChangesStreamChange } from '../../common/adapter/changesStream/AbstractChangesStream';
+import { getScopeAndName } from '../../common/PackageUtil';
 import { ScopeManagerService } from './ScopeManagerService';
 
 @ContextProto({
@@ -159,17 +159,16 @@ export class ChangesStreamService extends AbstractService {
           skipDependencies: true,
           tips: `Sync cause by changes_stream(${registry.changeStream}) update seq: ${seq}`,
         });
+        // 实时更新 task 信息
+        task.updateSyncData({
+          lastSince,
+          lastPackage,
+          taskCount,
+        });
+        await this.taskRepository.saveTask(task);
       }
     }
 
-    // 更新任务记录信息
-    task.updateSyncData({
-      lastSince,
-      lastPackage,
-      taskCount,
-    });
-
-    await this.taskRepository.saveTask(task);
     return { lastSince, taskCount };
   }
 }

--- a/app/core/service/ChangesStreamService.ts
+++ b/app/core/service/ChangesStreamService.ts
@@ -122,12 +122,8 @@ export class ChangesStreamService extends AbstractService {
     }
 
     const registryScopeCount = await this.scopeManagerService.countByRegistryId(registry.registryId);
-    const inCurrentDefaultRegistry = !scope && !registryScopeCount;
-    if (inCurrentDefaultRegistry) {
-      return true;
-    }
-
-    return false;
+    // 当前包没有 scope 信息，且当前 registry 下没有 scope，是通用 registry，需要同步
+    return !scope && !registryScopeCount;
   }
   public async getInitialSince(task: ChangesStreamTask): Promise<string> {
     const registry = await this.prepareRegistry(task);

--- a/app/core/service/ChangesStreamService.ts
+++ b/app/core/service/ChangesStreamService.ts
@@ -3,17 +3,22 @@ import { setTimeout } from 'timers/promises';
 import {
   AccessLevel,
   ContextProto,
+  EggObjectFactory,
   Inject,
 } from '@eggjs/tegg';
-import {
-  EggContextHttpClient,
-} from 'egg';
 import { TaskType } from '../../common/enum/Task';
 import { AbstractService } from '../../common/AbstractService';
 import { TaskRepository } from '../../repository/TaskRepository';
 import { ChangeStreamTask, Task } from '../entity/Task';
 import { PackageSyncerService } from './PackageSyncerService';
 import { TaskService } from './TaskService';
+import { RegistryManagerService } from './RegistryManagerService';
+import { RegistryType } from 'app/common/enum/Registry';
+import { E500 } from 'egg-errors';
+import { Registry } from '../entity/Registry';
+import { AbstractChangeStream } from 'app/common/adapter/changesStream/AbstractChangesStream';
+import { getScopeAndName } from 'app/common/PackageUtil';
+import { ScopeManagerService } from './ScopeManagerService';
 
 @ContextProto({
   accessLevel: AccessLevel.PUBLIC,
@@ -22,11 +27,15 @@ export class ChangesStreamService extends AbstractService {
   @Inject()
   private readonly taskRepository: TaskRepository;
   @Inject()
-  private readonly httpclient: EggContextHttpClient;
-  @Inject()
   private readonly packageSyncerService: PackageSyncerService;
   @Inject()
   private readonly taskService: TaskService;
+  @Inject()
+  private readonly registryManagerService : RegistryManagerService;
+  @Inject()
+  private readonly scopeManagerService : ScopeManagerService;
+  @Inject()
+  private readonly eggObjectFactory: EggObjectFactory;
 
   public async findExecuteTask(): Promise<ChangeStreamTask | null> {
     const targetName = 'GLOBAL_WORKER';
@@ -42,29 +51,16 @@ export class ChangesStreamService extends AbstractService {
     task.authorId = `pid_${process.pid}`;
     await this.taskRepository.saveTask(task);
 
-    const changesStreamRegistry: string = this.config.cnpmcore.changesStreamRegistry;
-    // https://github.com/npm/registry-follower-tutorial
-    // default "update_seq": 7138885,
+    // 初始化 changeStream 任务
+    // since 默认从 1 开始
     try {
       let since: string = task.data.since;
-      // get update_seq from ${changesStreamRegistry} on the first time
       if (!since) {
-        const { status, data } = await this.httpclient.request(changesStreamRegistry, {
-          followRedirect: true,
-          timeout: 10000,
-          dataType: 'json',
-        });
-        if (data.update_seq) {
-          since = String(data.update_seq - 10);
-        } else {
-          since = '7139538';
-        }
-        this.logger.warn('[ChangesStreamService.executeTask:firstSeq] GET %s status: %s, data: %j, since: %s',
-          changesStreamRegistry, status, data, since);
+        since = await this.getInitialSince(task);
       }
       // allow disable changesStream dynamic
       while (since && this.config.cnpmcore.enableChangesStream) {
-        const { lastSince, taskCount } = await this.handleChanges(since, task);
+        const { lastSince, taskCount } = await this.fetchChanges(since, task);
         this.logger.warn('[ChangesStreamService.executeTask:changes] since: %s => %s, %d new tasks, taskId: %s, updatedAt: %j',
           since, lastSince, taskCount, task.taskId, task.updatedAt);
         since = lastSince;
@@ -81,101 +77,102 @@ export class ChangesStreamService extends AbstractService {
     }
   }
 
-  private async handleChanges(since: string, task: ChangeStreamTask) {
-    const changesStreamRegistry: string = this.config.cnpmcore.changesStreamRegistry;
-    const changesStreamRegistryMode: string = this.config.cnpmcore.changesStreamRegistryMode;
-    const db = `${changesStreamRegistry}/_changes?since=${since}`;
-    let lastSince = since;
-    let taskCount = 0;
-    if (changesStreamRegistryMode === 'streaming') {
-      const { res } = await this.httpclient.request(db, {
-        streaming: true,
-        timeout: 10000,
-      });
-      for await (const chunk of res) {
-        const text: string = chunk.toString();
-        // {"seq":7138879,"id":"@danydodson/prettier-config","changes":[{"rev":"5-a56057032714af25400d93517773a82a"}]}
-        // console.log('😄%j😄', text);
-        // 😄"{\"seq\":7138738,\"id\":\"wargerm\",\"changes\":[{\"rev\":\"59-f0a0d326db4c62ed480987a04ba3bf8f\"}]}"😄
-        // 😄",\n{\"seq\":7138739,\"id\":\"@laffery/webpack-starter-kit\",\"changes\":[{\"rev\":\"4-84a8dc470a07872f4cdf85cf8ef892a1\"}]},\n{\"seq\":7138741,\"id\":\"venom-bot\",\"changes\":[{\"rev\":\"103-908654b1ad4b0e0fd40b468d75730674\"}]}"😄
-        // 😄",\n{\"seq\":7138743,\"id\":\"react-native-template-pytorch-live\",\"changes\":[{\"rev\":\"40-871c686b200312303ba7c4f7f93e0362\"}]}"😄
-        // 😄",\n{\"seq\":7138745,\"id\":\"ccxt\",\"changes\":[{\"rev\":\"10205-25367c525a0a3bd61be3a72223ce212c\"}]}"😄
-        const matchs = text.matchAll(/"seq":(\d+),"id":"([^"]+)"/gm);
-        let count = 0;
-        let lastPackage = '';
-        for (const match of matchs) {
-          const seq = match[1];
-          const fullname = match[2];
-          if (seq && fullname) {
-            await this.packageSyncerService.createTask(fullname, {
-              authorIp: os.hostname(),
-              authorId: 'ChangesStreamService',
-              skipDependencies: true,
-              tips: `Sync cause by changes_stream(${changesStreamRegistry}) update seq: ${seq}`,
-            });
-            count++;
-            lastSince = seq;
-            lastPackage = fullname;
-          }
-        }
-        if (count > 0) {
-          taskCount += count;
-          task.data = {
-            ...task.data,
-            since: lastSince,
-            last_package: lastPackage,
-            last_package_created: new Date(),
-            task_count: (task.data.task_count || 0) + count,
-          };
-          await this.taskRepository.saveTask(task);
-        }
+  // 优先从 registryId 获取，如果没有的话再返回默认的 registry
+  public async prepareRegistry(task: ChangeStreamTask): Promise<Registry> {
+    const { registryId } = task.data || {};
+    // 如果已有 registryId, 查询 DB 直接获取
+    if (registryId) {
+      const registry = await this.registryManagerService.findByRegistryId(registryId);
+      if (!registry) {
+        this.logger.error('[ChangesStreamService.getRegistry:error] registryId %s not found', registryId);
+        throw new E500(`invalid change stream registry: ${registryId}`);
       }
-    } else {
-      // json mode
-      // {"results":[{"seq":1988653,"type":"PACKAGE_VERSION_ADDED","id":"dsr-package-mercy-magot-thorp-sward","changes":[{"version":"1.0.1"}]},
-      const { data } = await this.httpclient.request(db, {
-        followRedirect: true,
-        timeout: 30000,
-        dataType: 'json',
-        gzip: true,
-      });
-      if (data.results?.length > 0) {
-        let count = 0;
-        let lastPackage = '';
-        for (const change of data.results) {
-          const seq = change.seq;
-          const fullname = change.id;
-          if (seq && fullname && seq !== since) {
-            await this.packageSyncerService.createTask(fullname, {
-              authorIp: os.hostname(),
-              authorId: 'ChangesStreamService',
-              skipDependencies: true,
-              tips: `Sync cause by changes_stream(${changesStreamRegistry}) update seq: ${seq}, change: ${JSON.stringify(change)}`,
-            });
-            count++;
-            lastSince = seq;
-            lastPackage = fullname;
-          }
-        }
-        if (count > 0) {
-          taskCount += count;
-          task.data = {
-            ...task.data,
-            since: lastSince,
-            last_package: lastPackage,
-            last_package_created: new Date(),
-            task_count: (task.data.task_count || 0) + count,
-          };
-          await this.taskRepository.saveTask(task);
-        }
+      return registry;
+    }
+
+    // 从配置文件默认生成
+    const { changesStreamRegistryMode, changesStreamRegistry: host } = this.config.cnpmcore;
+    const type = changesStreamRegistryMode === 'json' ? 'cnpmcore' : 'npm';
+    const registry = await this.registryManagerService.createRegistry({
+      name: 'default',
+      type: type as RegistryType,
+      userPrefix: 'npm:',
+      host,
+      changeStream: `${host}/_changes`,
+    });
+    task.data = {
+      ...(task.data || {}),
+      registryId: registry.registryId,
+    };
+    await this.taskRepository.saveTask(task);
+
+    return registry;
+  }
+
+  // 根据 regsitry 判断是否需要添加同步任务
+  // 1. 该包的 scope 在当前 registry 下
+  // 2. 如果 registry 下没有配置 scope (认为是通用 registry 地址) ，且该包的 scope 不在其他 registry 下
+  public async needSync(registry: Registry, fullname: string): Promise<boolean> {
+    const [ scopeName ] = getScopeAndName(fullname);
+    const scope = await this.scopeManagerService.findByName(scopeName);
+
+    const inCurrentRegistry = scope && scope?.registryId === registry.registryId;
+    if (inCurrentRegistry) {
+      return true;
+    }
+
+    const registryScopeCount = await this.scopeManagerService.countByRegistryId(registry.registryId);
+    const inCurrentDefaultRegistry = !scope && !registryScopeCount;
+    if (inCurrentDefaultRegistry) {
+      return true;
+    }
+
+    return false;
+  }
+  public async getInitialSince(task: ChangeStreamTask): Promise<string> {
+    const registry = await this.prepareRegistry(task);
+    const changesStreamAdapter = await this.eggObjectFactory.getEggObject(AbstractChangeStream, registry.type) as AbstractChangeStream;
+    const since = await changesStreamAdapter.getInitialSince(registry);
+    return since;
+  }
+
+  // 从 changesStream 获取需要同步的数据
+  // 更新任务的 since 和 taskCount 相关字段
+  public async fetchChanges(since: string, task: ChangeStreamTask) {
+    const registry = await this.prepareRegistry(task);
+    const changesStreamAdapter = await this.eggObjectFactory.getEggObject(AbstractChangeStream, registry.type) as AbstractChangeStream;
+    let taskCount = 0;
+
+    // 获取需要同步的数据
+    // 只获取需要同步的 task 信息
+    const { changes, lastSince } = await changesStreamAdapter.fetchChanges(registry, since);
+    let lastPackage: string | undefined;
+
+    // 创建同步任务
+    for (const change of changes) {
+      const { fullname, seq } = change;
+      lastPackage = fullname;
+      const valid = await this.needSync(registry, fullname);
+      if (valid) {
+        taskCount++;
+        await this.packageSyncerService.createTask(fullname, {
+          authorIp: os.hostname(),
+          authorId: 'ChangesStreamService',
+          skipDependencies: true,
+          tips: `Sync cause by changes_stream(${registry.changeStream}) update seq: ${seq}`,
+        });
       }
     }
 
-    if (taskCount === 0) {
-      // keep update task, make sure updatedAt changed
-      task.updatedAt = new Date();
-      await this.taskRepository.saveTask(task);
+    // 更新任务记录信息
+    task.data.since = lastSince;
+    task.data.task_count = (task.data.task_count || 0) + taskCount;
+    if (taskCount > 0) {
+      task.data.last_package = lastPackage;
+      task.data.last_package_created = new Date();
     }
+
+    await this.taskRepository.saveTask(task);
     return { lastSince, taskCount };
   }
 }

--- a/app/core/service/ChangesStreamService.ts
+++ b/app/core/service/ChangesStreamService.ts
@@ -153,24 +153,16 @@ export class ChangesStreamService extends AbstractService {
     for await (const change of stream) {
       const { fullname, seq } = change as ChangesStreamChange;
       lastPackage = fullname;
-      try {
-        const valid = await this.needSync(registry, fullname);
-        if (valid) {
-          taskCount++;
-          lastSince = seq;
-          await this.packageSyncerService.createTask(fullname, {
-            authorIp: HOST_NAME,
-            bizId: `SyncPackage:${registry.registryId}:${fullname}:${seq}`,
-            authorId: 'ChangesStreamService',
-            skipDependencies: true,
-            tips: `Sync cause by changes_stream(${registry.changeStream}) update seq: ${seq}`,
-          });
-        }
-      } catch (e) {
-        // bizId 可能出现重复，(tag 和 version 一起创建)，导致任务创建失败
-        // 为了防止任务堵塞，在这里 catch
-        this.logger.error(`[ChangesStreamService.executeSync:error] registryId: ${registry.registryId}, fullname: ${fullname}, seq: ${seq}`);
-        this.logger.error(e);
+      const valid = await this.needSync(registry, fullname);
+      if (valid) {
+        taskCount++;
+        lastSince = seq;
+        await this.packageSyncerService.createTask(fullname, {
+          authorIp: HOST_NAME,
+          authorId: 'ChangesStreamService',
+          skipDependencies: true,
+          tips: `Sync cause by changes_stream(${registry.changeStream}) update seq: ${seq}`,
+        });
       }
     }
 

--- a/app/core/service/ScopeManagerService.ts
+++ b/app/core/service/ScopeManagerService.ts
@@ -31,6 +31,16 @@ export class ScopeManagerService extends AbstractService {
   @Inject()
   private readonly scopeRepository: ScopeRepository;
 
+  async findByName(name: string): Promise<Scope | null> {
+    const scope = await this.scopeRepository.findByName(name);
+    return scope;
+  }
+
+  async countByRegistryId(registryId: string): Promise<number> {
+    const count = await this.scopeRepository.countByRegistryId(registryId);
+    return count;
+  }
+
   async createScope(createCmd: CreateScopeCmd): Promise<Scope> {
     const { name, registryId, operatorId } = createCmd;
     this.logger.info('[ScopeManagerService.CreateScope:prepare] operatorId: %s, createCmd: %s', operatorId, createCmd);

--- a/app/core/util/ChangesStreamTransform.ts
+++ b/app/core/util/ChangesStreamTransform.ts
@@ -1,0 +1,49 @@
+import { ChangesStreamChange } from '../../common/adapter/changesStream/AbstractChangesStream';
+import { Transform, TransformCallback, TransformOptions } from 'node:stream';
+
+// 网络问题可能会导致获取到的数据不完整
+// 最后数据可能会发生截断，需要按行读取，例如:
+// "seq": 1, "id": "test1",
+// "seq"
+// :2,
+// "id": "test2",
+// 先保存在 legacy 中，参与下次解析
+export default class ChangesStreamTransform extends Transform {
+  constructor(opts: TransformOptions = {}) {
+    super({
+      ...opts,
+      readableObjectMode: true,
+    });
+  }
+  private legacy = '';
+  _transform(chunk: any, _: BufferEncoding, callback: TransformCallback): void {
+    const text = chunk.toString();
+    const lines = text.split('\n');
+
+    for (const line of lines) {
+      const content = this.legacy + line;
+      const match = /"seq":(\d+),"id":"([^"]+)"/g.exec(content);
+      const seq = match?.[1];
+      const fullname = match?.[2];
+      if (seq && fullname) {
+        this.legacy = '';
+        // https://nodejs.org/en/docs/guides/backpressuring-in-streams/
+        // 需要处理 backpressure 场景
+        // 如果下游无法消费数据，就先暂停发送数据
+        // 自定义的 push 事件需要特殊处理
+        const pushed = this.push({ fullname, seq } as ChangesStreamChange);
+        if (!pushed) {
+          this.pause();
+          // 需要使用 drain 会重复触发，使用 once
+          this.once('drain', () => {
+            this.resume();
+          });
+        }
+      } else {
+        this.legacy += line;
+      }
+    }
+
+    callback();
+  }
+}

--- a/app/port/controller/RegistryController.ts
+++ b/app/port/controller/RegistryController.ts
@@ -15,7 +15,7 @@ import { AbstractController } from './AbstractController';
 import { Static } from 'egg-typebox-validate/typebox';
 import { RegistryManagerService } from '../../core/service/RegistryManagerService';
 import { AdminAccess } from '../middleware/AdminAccess';
-import { ScopeManagerService } from 'app/core/service/ScopeManagerService';
+import { ScopeManagerService } from '../../core/service/ScopeManagerService';
 import { RegistryCreateOptions, QueryPageOptions } from '../typebox';
 
 @HTTPController()

--- a/app/port/controller/ScopeController.ts
+++ b/app/port/controller/ScopeController.ts
@@ -9,13 +9,13 @@ import {
   Inject,
   Middleware,
 } from '@eggjs/tegg';
+import { E400 } from 'egg-errors';
 import { AbstractController } from './AbstractController';
 import { Static } from 'egg-typebox-validate/typebox';
 import { AdminAccess } from '../middleware/AdminAccess';
 import { ScopeManagerService } from '../../core/service/ScopeManagerService';
-import { RegistryManagerService } from 'app/core/service/RegistryManagerService';
+import { RegistryManagerService } from '../../core/service/RegistryManagerService';
 import { ScopeCreateOptions } from '../typebox';
-import { E400 } from 'egg-errors';
 
 
 @HTTPController()

--- a/app/repository/ScopeRepository.ts
+++ b/app/repository/ScopeRepository.ts
@@ -12,6 +12,16 @@ export class ScopeRepository extends AbstractRepository {
   @Inject()
   private readonly Scope: typeof ScopeModel;
 
+  async countByRegistryId(registryId: string): Promise<number> {
+    return this.Scope.find({ registryId }).count();
+  }
+  async findByName(name: string): Promise<Scope | null> {
+    const model = await this.Scope.findOne({ name });
+    if (!model) {
+      return null;
+    }
+    return ModelConvertor.convertModelToEntity(model, Scope);
+  }
   async listScopesByRegistryId(registryId: string, page: PageOptions): Promise<PageResult<Scope>> {
     const { offset, limit } = EntityUtil.convertPageOptionsToLimitOption(page);
     const count = await this.Scope.find({ registryId }).count();

--- a/app/repository/ScopeRepository.ts
+++ b/app/repository/ScopeRepository.ts
@@ -13,7 +13,7 @@ export class ScopeRepository extends AbstractRepository {
   private readonly Scope: typeof ScopeModel;
 
   async countByRegistryId(registryId: string): Promise<number> {
-    return this.Scope.find({ registryId }).count();
+    return await this.Scope.find({ registryId }).count();
   }
   async findByName(name: string): Promise<Scope | null> {
     const model = await this.Scope.findOne({ name });

--- a/app/repository/model/Registry.ts
+++ b/app/repository/model/Registry.ts
@@ -1,5 +1,5 @@
 import { Attribute, Model } from '@eggjs/tegg-orm-decorator';
-import { RegistryType } from 'app/common/enum/Registry';
+import { RegistryType } from '../../common/enum/Registry';
 import { DataTypes, Bone } from 'leoric';
 
 @Model()

--- a/test/common/adapter/changesStream/CnpmcoreChangesStream.test.ts
+++ b/test/common/adapter/changesStream/CnpmcoreChangesStream.test.ts
@@ -43,6 +43,11 @@ describe('test/common/adapter/changesStream/CnpmcoreChangesStream.test.ts', () =
       });
       await assert.rejects(cnpmcoreChangesStream.getInitialSince(registry), /mock request/);
     });
+
+    it('should throw error invalid seq', async () => {
+      app.mockHttpclient(/https:\/\/r\.cnpmjs\.org/, { data: { update_seqs: 'invalid' } });
+      await assert.rejects(cnpmcoreChangesStream.getInitialSince(registry), /get getInitialSince failed/);
+    });
   });
 
   describe('fetchChanges()', () => {

--- a/test/common/adapter/changesStream/CnpmcoreChangesStream.test.ts
+++ b/test/common/adapter/changesStream/CnpmcoreChangesStream.test.ts
@@ -1,3 +1,4 @@
+import { ChangesStreamChange } from 'app/common/adapter/changesStream/AbstractChangesStream';
 import { CnpmcoreChangesStream } from 'app/common/adapter/changesStream/CnpmcoreChangesStream';
 import { RegistryType } from 'app/common/enum/Registry';
 import { Registry } from 'app/core/entity/Registry';
@@ -65,9 +66,14 @@ describe('test/common/adapter/changesStream/CnpmcoreChangesStream.test.ts', () =
           ],
         },
       });
-      const res = await cnpmcoreChangesStream.fetchChanges(registry, '1');
-      assert(res.changes.length === 1);
-      assert(res.lastSince === '2');
+      const stream = await cnpmcoreChangesStream.fetchChanges(registry, '1');
+      const res: ChangesStreamChange[] = [];
+
+      for await (const change of stream) {
+        res.push(change as ChangesStreamChange);
+      }
+
+      assert(res.length === 1);
     });
   });
 });

--- a/test/common/adapter/changesStream/CnpmjsorgChangesStream.test.ts
+++ b/test/common/adapter/changesStream/CnpmjsorgChangesStream.test.ts
@@ -28,7 +28,8 @@ describe('test/common/adapter/changesStream/CnpmjsorgChangesStream.test.ts', () 
   describe('getInitialSince()', () => {
     it('should work', async () => {
       const since = await cnpmjsorgChangesStream.getInitialSince(registry);
-      assert(since === '1');
+      const now = new Date().getTime();
+      assert(now - Number(since) < 10000);
     });
 
   });

--- a/test/common/adapter/changesStream/CnpmjsorgChangesStream.test.ts
+++ b/test/common/adapter/changesStream/CnpmjsorgChangesStream.test.ts
@@ -1,3 +1,4 @@
+import { ChangesStreamChange } from 'app/common/adapter/changesStream/AbstractChangesStream';
 import { CnpmjsorgChangesStream } from 'app/common/adapter/changesStream/CnpmjsorgChangesStream';
 import { RegistryType } from 'app/common/enum/Registry';
 import { Registry } from 'app/core/entity/Registry';
@@ -53,9 +54,12 @@ describe('test/common/adapter/changesStream/CnpmjsorgChangesStream.test.ts', () 
           ],
         },
       });
-      const res = await cnpmjsorgChangesStream.fetchChanges(registry, '1');
-      assert(res.changes.length === 2);
-      assert(res.lastSince === '1389814509000');
+      const stream = await cnpmjsorgChangesStream.fetchChanges(registry, '1');
+      const res: ChangesStreamChange[] = [];
+      for await (const change of stream) {
+        res.push(change as ChangesStreamChange);
+      }
+      assert(res.length === 2);
     });
 
     it('should reject when limit', async () => {

--- a/test/common/adapter/changesStream/CnpmjsorgChangesStream.test.ts
+++ b/test/common/adapter/changesStream/CnpmjsorgChangesStream.test.ts
@@ -1,0 +1,84 @@
+import { CnpmjsorgChangesStream } from 'app/common/adapter/changesStream/CnpmjsorgChangesStream';
+import { RegistryType } from 'app/common/enum/Registry';
+import { Registry } from 'app/core/entity/Registry';
+import { RegistryManagerService } from 'app/core/service/RegistryManagerService';
+import assert = require('assert');
+import { Context } from 'egg';
+import { app } from 'egg-mock/bootstrap';
+
+describe('test/common/adapter/changesStream/CnpmjsorgChangesStream.test.ts', () => {
+  let ctx: Context;
+  let cnpmjsorgChangesStream: CnpmjsorgChangesStream;
+  let registryManagerService: RegistryManagerService;
+  let registry: Registry;
+  beforeEach(async () => {
+    ctx = await app.mockModuleContext();
+    cnpmjsorgChangesStream = await ctx.getEggObject(CnpmjsorgChangesStream);
+    registryManagerService = await ctx.getEggObject(RegistryManagerService);
+    registry = await registryManagerService.createRegistry({
+      name: 'cnpmcore',
+      changeStream: 'https://r2.cnpmjs.org/_changes',
+      host: 'https://registry.npmmirror.com',
+      userPrefix: 'cnpm:',
+      type: RegistryType.Cnpmjsorg,
+    });
+  });
+
+  describe('getInitialSince()', () => {
+    it('should work', async () => {
+      const since = await cnpmjsorgChangesStream.getInitialSince(registry);
+      assert(since === '1');
+    });
+
+  });
+
+  describe('fetchChanges()', () => {
+    it('should work', async () => {
+      app.mockHttpclient(/https:\/\/r2\.cnpmjs\.org/, {
+        status: 200,
+        data: {
+          results: [
+            {
+              type: 'PACKAGE_VERSION_ADDED',
+              id: 'abc-cli',
+              changes: [{ version: '0.0.1' }],
+              gmt_modified: '2014-01-14T19:35:09.000Z',
+            },
+            {
+              type: 'PACKAGE_TAG_ADDED',
+              id: 'abc-cli',
+              changes: [{ tag: 'latest' }],
+              gmt_modified: '2014-01-15T19:35:09.000Z',
+            },
+          ],
+        },
+      });
+      const res = await cnpmjsorgChangesStream.fetchChanges(registry, '1');
+      assert(res.changes.length === 2);
+      assert(res.lastSince === '1389814509000');
+    });
+
+    it('should reject when limit', async () => {
+      app.mockHttpclient(/https:\/\/r2\.cnpmjs\.org/, {
+        status: 200,
+        data: {
+          results: [
+            {
+              type: 'PACKAGE_VERSION_ADDED',
+              id: 'abc-cli',
+              changes: [{ version: '0.0.1' }],
+              gmt_modified: '2014-01-14T19:35:09.000Z',
+            },
+            {
+              type: 'PACKAGE_TAG_ADDED',
+              id: 'abc-cli',
+              changes: [{ tag: 'latest' }],
+              gmt_modified: '2014-01-14T19:35:09.000Z',
+            },
+          ],
+        },
+      });
+      await assert.rejects(cnpmjsorgChangesStream.fetchChanges(registry, '1'), /limit too large/);
+    });
+  });
+});

--- a/test/common/adapter/changesStream/NpmChangesStream.test.ts
+++ b/test/common/adapter/changesStream/NpmChangesStream.test.ts
@@ -1,0 +1,75 @@
+import { NpmChangesStream } from 'app/common/adapter/changesStream/NpmChangesStream';
+import { RegistryType } from 'app/common/enum/Registry';
+import { Registry } from 'app/core/entity/Registry';
+import { RegistryManagerService } from 'app/core/service/RegistryManagerService';
+import assert = require('assert');
+import { Context } from 'egg';
+import { app, mock } from 'egg-mock/bootstrap';
+
+describe('test/common/adapter/changesStream/NpmChangesStream.test.ts', () => {
+  let ctx: Context;
+  let npmChangesStream: NpmChangesStream;
+  let registryManagerService: RegistryManagerService;
+  let registry: Registry;
+  beforeEach(async () => {
+    ctx = await app.mockModuleContext();
+    npmChangesStream = await ctx.getEggObject(NpmChangesStream);
+    registryManagerService = await ctx.getEggObject(RegistryManagerService);
+    registry = await registryManagerService.createRegistry({
+      name: 'npm',
+      changeStream: 'https://replicate.npmjs.com/_changes',
+      host: 'https://regsitry.npmjs.org',
+      userPrefix: 'npm:',
+      type: RegistryType.Npm,
+    });
+  });
+
+  describe('getInitialSince()', () => {
+    it('should work', async () => {
+      app.mockHttpclient(/https:\/\/replicate\.npmjs\.com/, {
+        status: 200,
+        data: {
+          update_seq: 9527,
+        },
+      });
+      const since = await npmChangesStream.getInitialSince(registry);
+      assert(since === '9517');
+    });
+
+    it('should throw error', async () => {
+      app.mockHttpclient(/https:\/\/replicate\.npmjs\.com/, () => {
+        throw new Error('mock request replicate _changes error');
+      });
+      await assert.rejects(npmChangesStream.getInitialSince(registry), /mock request/);
+    });
+  });
+
+  describe('fetchChanges()', () => {
+    it('should work', async () => {
+      mock(ctx.httpclient, 'request', async () => {
+        return {
+          res: [ Promise.resolve(
+            [
+              JSON.stringify({
+                seq: 2,
+                id: 'backbone.websql.deferred',
+                changes: [{ rev: '4-f5150b238ab62cd890211fb57fc9eca5' }],
+                deleted: true,
+              }),
+              JSON.stringify({
+                seq: 3,
+                id: 'binomal-hash-list',
+                changes: [{ rev: '2-dced04d62bef47954eac61c217ed6fc1' }],
+                deleted: true,
+              }),
+            ],
+          ) ],
+        };
+      });
+      const res = await npmChangesStream.fetchChanges(registry, '9517');
+      assert(res.changes.length === 2);
+      assert(res.lastSince === '3');
+    });
+  });
+
+});

--- a/test/common/adapter/changesStream/NpmChangesStream.test.ts
+++ b/test/common/adapter/changesStream/NpmChangesStream.test.ts
@@ -44,26 +44,21 @@ describe('test/common/adapter/changesStream/NpmChangesStream.test.ts', () => {
       });
       await assert.rejects(npmChangesStream.getInitialSince(registry), /mock request/);
     });
+
+    it('should throw error invalid seq', async () => {
+      app.mockHttpclient(/https:\/\/replicate\.npmjs\.com/, { data: { update_seqs: 'invalid' } });
+      await assert.rejects(npmChangesStream.getInitialSince(registry), /get getInitialSince failed/);
+    });
   });
 
   describe('fetchChanges()', () => {
     it('should work', async () => {
       mock(ctx.httpclient, 'request', async () => {
         return {
-          res: Readable.from(JSON.stringify([
-            {
-              seq: 2,
-              id: 'backbone.websql.deferred',
-              changes: [{ rev: '4-f5150b238ab62cd890211fb57fc9eca5' }],
-              deleted: true,
-            },
-            {
-              seq: 3,
-              id: 'binomal-hash-list',
-              changes: [{ rev: '2-dced04d62bef47954eac61c217ed6fc1' }],
-              deleted: true,
-            },
-          ])),
+          res: Readable.from(`
+          {"seq":2,"id":"backbone.websql.deferred","changes":[{"rev":"4-f5150b238ab62cd890211fb57fc9eca5"}],"deleted":true},
+          {"seq":3,"id":"backbone2.websql.deferred","changes":[{"rev":"4-f6150b238ab62cd890211fb57fc9eca5"}],"deleted":true},
+          `),
         };
       });
       const res: ChangesStreamChange[] = [];

--- a/test/core/service/ChangesStreamService.test.ts
+++ b/test/core/service/ChangesStreamService.test.ts
@@ -72,7 +72,7 @@ describe('test/core/service/ChangesStreamService.test.ts', () => {
 
     it('should throw error when invalid registryId', async () => {
       await changesStreamService.prepareRegistry(task);
-      let registries = await registryManagerService.listRegistries({});
+      const registries = await registryManagerService.listRegistries({});
       assert(registries.count === 3);
 
       // remove the registry

--- a/test/core/service/ChangesStreamService.test.ts
+++ b/test/core/service/ChangesStreamService.test.ts
@@ -4,7 +4,7 @@ import { app, mock } from 'egg-mock/bootstrap';
 import { Context } from 'egg';
 import { ChangesStreamService } from 'app/core/service/ChangesStreamService';
 import { TaskService } from 'app/core/service/TaskService';
-import { ChangeStreamTask, Task } from 'app/core/entity/Task';
+import { ChangesStreamTask, Task } from 'app/core/entity/Task';
 import { RegistryManagerService } from 'app/core/service/RegistryManagerService';
 import { RegistryType } from 'app/common/enum/Registry';
 import { ScopeManagerService } from 'app/core/service/ScopeManagerService';
@@ -16,7 +16,7 @@ describe('test/core/service/ChangesStreamService.test.ts', () => {
   let scopeManagerService: ScopeManagerService;
   let registryManagerService: RegistryManagerService;
   let taskService: TaskService;
-  let task: ChangeStreamTask;
+  let task: ChangesStreamTask;
   let npmRegistry: Registry;
   let cnpmRegistry: Registry;
   beforeEach(async () => {

--- a/test/core/service/ChangesStreamService.test.ts
+++ b/test/core/service/ChangesStreamService.test.ts
@@ -1,0 +1,152 @@
+import assert = require('assert');
+import { app, mock } from 'egg-mock/bootstrap';
+import { Context } from 'egg';
+import { ChangesStreamService } from 'app/core/service/ChangesStreamService';
+import { TaskService } from 'app/core/service/TaskService';
+import { ChangeStreamTask, Task } from 'app/core/entity/Task';
+import { RegistryManagerService } from 'app/core/service/RegistryManagerService';
+import { RegistryType } from 'app/common/enum/Registry';
+import { ScopeManagerService } from 'app/core/service/ScopeManagerService';
+import { Registry } from 'app/core/entity/Registry';
+
+describe('test/core/service/ChangesStreamService.test.ts', () => {
+  let ctx: Context;
+  let changesStreamService: ChangesStreamService;
+  let scopeManagerService: ScopeManagerService;
+  let registryManagerService: RegistryManagerService;
+  let taskService: TaskService;
+  let task: ChangeStreamTask;
+  let npmRegistry: Registry;
+  let cnpmRegistry: Registry;
+  beforeEach(async () => {
+    ctx = await app.mockModuleContext();
+    changesStreamService = await ctx.getEggObject(ChangesStreamService);
+    taskService = await ctx.getEggObject(TaskService);
+    registryManagerService = await ctx.getEggObject(RegistryManagerService);
+    scopeManagerService = await ctx.getEggObject(ScopeManagerService);
+    assert(changesStreamService);
+    task = Task.createChangesStream('GLOBAL_WORKER');
+    taskService.createTask(task, false);
+
+    // create default registry
+    await registryManagerService.createRegistry({
+      name: 'npm',
+      changeStream: 'https://replicate.npmjs.com/_changes',
+      host: 'https://regsitry.npmjs.org',
+      userPrefix: 'npm:',
+      type: RegistryType.Npm,
+    });
+
+    // create custom registry
+    await registryManagerService.createRegistry({
+      name: 'cnpm',
+      changeStream: 'https://r.cnpmjs.org',
+      host: 'https://r.npmjs.org',
+      userPrefix: 'cnpm:',
+      type: RegistryType.Cnpmcore,
+    });
+
+    const data = (await registryManagerService.listRegistries({})).data;
+    npmRegistry = data[0];
+    cnpmRegistry = data[1];
+
+    // create custom scope
+    await scopeManagerService.createScope({
+      name: '@cnpm',
+      registryId: cnpmRegistry.registryId,
+    });
+  });
+
+  describe('prepareRegistry()', () => {
+    it('should create default registry by config', async () => {
+      await changesStreamService.prepareRegistry(task);
+      let registries = await registryManagerService.listRegistries({});
+      assert(registries.count === 3);
+
+      // only create once
+      await changesStreamService.prepareRegistry(task);
+      registries = await registryManagerService.listRegistries({});
+      assert(registries.count === 3);
+    });
+  });
+
+  describe('needSync()', () => {
+    it('unscoped package should sync default registry', async () => {
+      const res = await changesStreamService.needSync(npmRegistry, 'banana');
+      assert(res);
+    });
+
+    it('scoped package should sync default registry', async () => {
+      const res = await changesStreamService.needSync(npmRegistry, '@gogogo/banana');
+      assert(res);
+    });
+
+    it('scoped package should sync custom registry', async () => {
+      let res = await changesStreamService.needSync(cnpmRegistry, '@cnpm/banana');
+      assert(res);
+      res = await changesStreamService.needSync(cnpmRegistry, '@dnpmjs/banana');
+      assert(!res);
+    });
+
+    it('unscoped package should not sync custom registry', async () => {
+      const res = await changesStreamService.needSync(cnpmRegistry, 'banana');
+      assert(!res);
+    });
+
+  });
+
+  describe('getInitialSince()', () => {
+    it('should work', async () => {
+      app.mockHttpclient(/https:\/\/replicate\.npmjs\.com/, {
+        status: 200,
+        data: {
+          update_seq: 9527,
+        },
+      });
+      const since = await changesStreamService.getInitialSince(task);
+      assert(since === '9517');
+    });
+  });
+
+  describe('getInitialSince()', () => {
+    it('should work', async () => {
+      app.mockHttpclient(/https:\/\/replicate\.npmjs\.com/, {
+        status: 200,
+        data: {
+          update_seq: 9527,
+        },
+      });
+      const since = await changesStreamService.getInitialSince(task);
+      assert(since === '9517');
+    });
+  });
+
+  describe('fetchChanges()', () => {
+    it('should work', async () => {
+      mock(ctx.httpclient, 'request', async () => {
+        return {
+          res: [ Promise.resolve(
+            [
+              JSON.stringify({
+                seq: 2,
+                id: 'backbone.websql.deferred',
+                changes: [{ rev: '4-f5150b238ab62cd890211fb57fc9eca5' }],
+                deleted: true,
+              }),
+              JSON.stringify({
+                seq: 3,
+                id: 'binomal-hash-list',
+                changes: [{ rev: '2-dced04d62bef47954eac61c217ed6fc1' }],
+                deleted: true,
+              }),
+            ],
+          ) ],
+        };
+      });
+      const changes = await changesStreamService.fetchChanges('1', task);
+      assert(changes.taskCount === 2);
+      assert(changes.lastSince === '3');
+    });
+  });
+
+});

--- a/test/core/service/ChangesStreamService.test.ts
+++ b/test/core/service/ChangesStreamService.test.ts
@@ -1,4 +1,5 @@
 import assert = require('assert');
+import { Readable } from 'node:stream';
 import { app, mock } from 'egg-mock/bootstrap';
 import { Context } from 'egg';
 import { ChangesStreamService } from 'app/core/service/ChangesStreamService';
@@ -125,7 +126,7 @@ describe('test/core/service/ChangesStreamService.test.ts', () => {
     it('should work', async () => {
       mock(ctx.httpclient, 'request', async () => {
         return {
-          res: [ Promise.resolve(
+          res: Readable.from(
             [
               JSON.stringify({
                 seq: 2,
@@ -140,10 +141,10 @@ describe('test/core/service/ChangesStreamService.test.ts', () => {
                 deleted: true,
               }),
             ],
-          ) ],
+          ),
         };
       });
-      const changes = await changesStreamService.fetchChanges('1', task);
+      const changes = await changesStreamService.executeSync('1', task);
       assert(changes.taskCount === 2);
       assert(changes.lastSince === '3');
     });

--- a/test/core/service/RegistryManagerService/index.test.ts
+++ b/test/core/service/RegistryManagerService/index.test.ts
@@ -54,7 +54,6 @@ describe('test/core/service/RegistryManagerService/index.test.ts', () => {
       it('pageOptions should work', async () => {
         // pageOptions should work
         let queryRes = await registryManagerService.listRegistries({ pageIndex: 0, pageSize: 1 });
-        console.log(queryRes.data);
         assert(queryRes.count === 2);
         assert(queryRes.data.length === 1);
         const [ firstRegistry ] = queryRes.data;

--- a/test/core/util/ChangesStreamTransform.test.ts
+++ b/test/core/util/ChangesStreamTransform.test.ts
@@ -1,0 +1,133 @@
+import ChangesStreamTransform from 'app/core/util/ChangesStreamTransform';
+import assert = require('assert');
+import { Readable, pipeline, Writable } from 'node:stream';
+import { ChangesStreamChange } from 'app/common/adapter/changesStream/AbstractChangesStream';
+
+describe('test/core/util/ChangesStreamTransform.test.ts', () => {
+  let stream: Readable;
+  let transform: ChangesStreamTransform;
+  beforeEach(async () => {
+    transform = new ChangesStreamTransform();
+  });
+  afterEach(async () => {
+    transform.end();
+    transform.destroy();
+  });
+
+
+  it('should work', async () => {
+    stream = Readable.from('');
+    const res = pipeline(stream, transform, error => {
+      assert(!error);
+    });
+
+    stream.push(`
+    {"results":[
+      {"seq":1,"id":"api.anyfetch.com","changes":[{"rev":"5-a87e847a323ce2503582b68c5f66a8a3"}],"deleted":true},
+      {"seq":2,"id":"backbone.websql.deferred","changes":[{"rev":"4-f5150b238ab62cd890211fb57fc9eca5"}],"deleted":true},
+      {"seq":3,"id":"binomal-hash-list","changes":[{"rev":"2-dced04d62bef47954eac61c217ed6fc1"}],"deleted":true},
+      {"seq":4,"id":"concat-file","changes":[{"rev":"5-e463032df555c6af3c47a7c9769904d4"}],"deleted":true},
+      {"seq":7,"id":"iron-core","changes":[{"rev":"4-b3b1f44a33c3a952ff0cbb2cee527f94"}],"deleted":true},
+    `);
+
+    const changes: ChangesStreamChange[] = [];
+    for await (const change of res) {
+      changes.push(change);
+    }
+
+    assert(changes.length === 5);
+    assert.deepEqual(changes.map(_ => _.fullname), [ 'api.anyfetch.com', 'backbone.websql.deferred', 'binomal-hash-list', 'concat-file', 'iron-core' ]);
+  });
+
+  it('should throw when pipe', async () => {
+    let triggered = false;
+    stream = Readable.from('');
+    const res = stream.pipe(transform);
+
+    await assert.rejects(async () => {
+      stream.push('"seq":1,');
+      stream.emit('error', new Error('mock errors'));
+      stream.push('"id":"test1"\n');
+      for await (const _ of res) {
+        triggered = true;
+        assert(_ !== null);
+      }
+    }, /mock errors/);
+
+    assert(triggered === false);
+  });
+
+  it('should work when concurrent', async () => {
+
+    stream = Readable.from('');
+    const res = pipeline(stream, transform, error => {
+      assert(!error);
+    });
+
+    stream.push(`
+      {"results":[
+        {"seq":1,"id":"api.anyfetch.com","changes":[{"rev":"5-a87e847a323ce2503582b68c5f66a8a3"}],"deleted":true},
+        {"seq":2,"id":"backbone.websql.deferred","changes":[{"rev":"4-f5150b238ab62cd890211fb57fc9eca5"}],"deleted":true},
+        {"seq":3,"id":"binomal-hash-list","changes":[{"rev":"2-dced04d62bef47954eac61c217ed6fc1"}],"deleted":true},
+        {"seq":4,"id":"concat-file","changes":[{"rev":"5-e463032df555c6af3c47a7c9769904d4"}],"deleted":true},
+        {"seq":7,"id":"iron-core","changes":[{"rev":"4-b3b1f44a33c3a952ff0cbb2cee527f94"}],"deleted":true},
+    `);
+
+    const changes: ChangesStreamChange[] = [];
+    async function parseMessage() {
+      for await (const change of res) {
+        changes.push(change);
+      }
+    }
+
+    const task = parseMessage();
+    stream.push('{"seq":8,"id":"icon-cone5","changes":[{"rev":"5-a87e847a323ce2503582b68c5f67a8a3"}],"deleted":true},');
+    await task;
+
+    assert(changes.length === 6);
+  });
+
+  it('should work handle backpressure', async () => {
+    let seq = 1;
+    stream = Readable.from('');
+    const transform = new ChangesStreamTransform();
+    let assertDrainTime = 0;
+    let assertWriteTime = 0;
+
+    // 模拟消费流，每 10ms 消费一个 changeObject
+    const assertWrite = new Writable({
+      objectMode: true,
+      highWaterMark: 1,
+      write(_, __, callback) {
+        assertWriteTime++;
+        setTimeout(() => {
+          callback();
+        }, 10);
+      },
+    });
+
+    assertWrite.on('drain', () => {
+      assertDrainTime++;
+    });
+
+    const res = new Promise<void>((resolve, reject) => {
+      pipeline(stream, transform, assertWrite, err => {
+        if (err) {
+          reject(err);
+        }
+        resolve();
+      });
+    });
+
+    (new Array(50)).fill(0).forEach(() => {
+      stream.push(`{"seq":${++seq},"id":"${seq}","changes":[{"rev":"5-a87e847a323ce2503582b68c5f66a8a3"}],"deleted":true},`);
+    });
+
+    await res;
+
+    assert(assertDrainTime === assertWriteTime - 1);
+    assert(assertWriteTime === 50);
+
+  });
+
+});

--- a/test/repository/TaskRepository.test.ts
+++ b/test/repository/TaskRepository.test.ts
@@ -3,7 +3,7 @@ import { app } from 'egg-mock/bootstrap';
 import { Context } from 'egg';
 import { TaskRepository } from 'app/repository/TaskRepository';
 import { Task as TaskModel } from 'app/repository/model/Task';
-import { ChangeStreamTaskData, Task, TaskData } from '../../app/core/entity/Task';
+import { ChangesStreamTaskData, Task, TaskData } from '../../app/core/entity/Task';
 import { TaskState, TaskType } from '../../app/common/enum/Task';
 import os from 'os';
 import { EasyData, EntityUtil } from '../../app/core/util/EntityUtil';
@@ -28,7 +28,7 @@ describe('test/repository/TaskRepository.test.ts', () => {
   describe('unique biz id', () => {
     it('should save succeed if biz id is equal', async () => {
       const bizId = 'mock_dup_biz_id';
-      const data: EasyData<TaskData<ChangeStreamTaskData>, 'taskId'> = {
+      const data: EasyData<TaskData<ChangesStreamTaskData>, 'taskId'> = {
         type: TaskType.ChangesStream,
         state: TaskState.Waiting,
         targetName: 'foo',


### PR DESCRIPTION
> [ref](https://github.com/cnpm/cnpmcore/pull/284) 子任务

1. 新增 changesStream Adapter 层
    * getInitalSince 负责返回不通 changesStream 对应初始参数
    * fetchChanges 负责获取同步源对应变更数据，统一返回 stream 进行消费
2. 修改 changesStreamService 实现
    * prepareRegsitry 负责兼容旧启动参数，初始化 registry 信息
    * 修改原有 taskData 更新流程
