### PR TITLE
fix: changes stream updatedAt

### DIFF
--- a/app/core/entity/Task.ts
+++ b/app/core/entity/Task.ts
@@ -156,7 +156,6 @@ export class Task<T extends TaskBaseData = TaskBaseData> extends Entity {
   public updateSyncData({ lastSince, taskCount, lastPackage }: SyncInfo) {
     const syncData = this.data as unknown as ChangesStreamTaskData;
     // 更新任务记录信息
-    this.updatedAt = new Date();
     syncData.since = lastSince;
     syncData.task_count = (syncData.task_count || 0) + taskCount;
 

--- a/app/core/entity/Task.ts
+++ b/app/core/entity/Task.ts
@@ -156,6 +156,7 @@ export class Task<T extends TaskBaseData = TaskBaseData> extends Entity {
   public updateSyncData({ lastSince, taskCount, lastPackage }: SyncInfo) {
     const syncData = this.data as unknown as ChangesStreamTaskData;
     // 更新任务记录信息
+    this.updatedAt = new Date();
     syncData.since = lastSince;
     syncData.task_count = (syncData.task_count || 0) + taskCount;
 

--- a/test/common/adapter/changesStream/CnpmcoreChangesStream.test.ts
+++ b/test/common/adapter/changesStream/CnpmcoreChangesStream.test.ts
@@ -71,7 +71,7 @@ describe('test/common/adapter/changesStream/CnpmcoreChangesStream.test.ts', () =
           ],
         },
       });
-      const stream = await cnpmcoreChangesStream.fetchChanges(registry, '1');
+      const stream = cnpmcoreChangesStream.fetchChanges(registry, '1');
       const res: ChangesStreamChange[] = [];
 
       for await (const change of stream) {

--- a/test/repository/TaskRepository.test.ts
+++ b/test/repository/TaskRepository.test.ts
@@ -77,16 +77,16 @@ describe('test/repository/TaskRepository.test.ts', () => {
 
       const originTask = await taskRepository.findTask(task1.taskId) as Task;
       originTask.updateSyncData({ lastSince: '9527', taskCount: 0 });
-      await setTimeout(1000);
+      await setTimeout(1);
       await taskRepository.saveTask(originTask);
       const firstUpdated = originTask.updatedAt;
 
       originTask.updateSyncData({ lastSince: '9527', taskCount: 0 });
-      await setTimeout(1000);
+      await setTimeout(1);
       await taskRepository.saveTask(originTask);
       const secondUpdated = originTask.updatedAt;
 
-      assert(secondUpdated.getTime() - firstUpdated.getTime() >= 1000);
+      assert(secondUpdated.getTime() - firstUpdated.getTime() >= 1);
 
     });
   });


### PR DESCRIPTION
* 修复 changesStream data 内容不变时， updateAt 字段未更新的问题。
* 修复 executeSync 累积耗时超过 10min 时，会导致 changesStream 状态判断异常。

retryExecuteTimeoutTasks 对于 10min 未更新 updatedAt 的任务，会重新 push 进队列。
changesStream Worker 会重新初始化任务执行，
导致多个 changesStream 并行抢占 updatedAt。

