### PR TITLE
fix: task updatedAt save

### DIFF
--- a/app/core/service/TaskService.ts
+++ b/app/core/service/TaskService.ts
@@ -52,8 +52,6 @@ export class TaskService extends AbstractService {
       await this.appendLogToNFS(task, appendLog);
     }
     task.state = TaskState.Waiting;
-    // make sure updatedAt changed
-    task.updatedAt = new Date();
     await this.taskRepository.saveTask(task);
     await this.queueAdapter.push<string>(task.type, task.taskId);
     const queueLength = await this.getTaskQueueLength(task.type);
@@ -125,7 +123,6 @@ export class TaskService extends AbstractService {
 
   public async appendTaskLog(task: Task, appendLog: string) {
     await this.appendLogToNFS(task, appendLog);
-    task.updatedAt = new Date();
     await this.taskRepository.saveTask(task);
   }
 

--- a/app/repository/util/ModelConvertor.ts
+++ b/app/repository/util/ModelConvertor.ts
@@ -46,9 +46,10 @@ export class ModelConvertor {
       const attributeValue = _.get(entity, entityPropertyName);
       model[modelPropertyName] = attributeValue;
     }
-    if (!model.changed()) {
-      return false;
-    }
+
+    // 不允许设置 UPDATED_AT
+    // 通过 leoric 进行更新
+    model[UPDATED_AT] = undefined;
     await model.save(options);
     entity[UPDATED_AT] = model[UPDATED_AT];
     return true;

--- a/test/repository/TaskRepository.test.ts
+++ b/test/repository/TaskRepository.test.ts
@@ -1,6 +1,7 @@
 import assert = require('assert');
 import { app } from 'egg-mock/bootstrap';
 import { Context } from 'egg';
+import { setTimeout } from 'timers/promises';
 import { TaskRepository } from 'app/repository/TaskRepository';
 import { Task as TaskModel } from 'app/repository/model/Task';
 import { ChangesStreamTaskData, Task, TaskData } from '../../app/core/entity/Task';
@@ -53,6 +54,68 @@ describe('test/repository/TaskRepository.test.ts', () => {
       assert(task1.taskId);
       assert(task2.taskId);
       assert(task1.taskId === task2.taskId);
+    });
+
+    it('should update updatedAt', async () => {
+      const bizId = 'mock_dup_biz_id';
+      const data: EasyData<TaskData<ChangesStreamTaskData>, 'taskId'> = {
+        type: TaskType.ChangesStream,
+        state: TaskState.Waiting,
+        targetName: 'foo',
+        authorId: `pid_${process.pid}`,
+        authorIp: os.hostname(),
+        data: {
+          taskWorker: '',
+          since: '',
+        },
+        bizId,
+      };
+
+      // 首先创建一个 task1
+      const newData = EntityUtil.defaultData(data, 'taskId');
+      const task1 = new Task(newData);
+      // 持久化保存 task1
+      await taskRepository.saveTask(task1);
+      // 再取一个 asyncTask ，两者指向相同的数据行
+      const asyncTask = await taskRepository.findTask(task1.taskId) as Task;
+
+      // task1 对应的数据被更新了
+      await setTimeout(1);
+      task1.updatedAt = new Date();
+      await taskRepository.saveTask(task1);
+
+      await setTimeout(1);
+      asyncTask.updateSyncData({ lastSince: '9527', taskCount: 1 });
+      // 再执行 saveTask 的时候，会通过 id 重新查询一次 db 中的 model
+      // 由于已经被 task1 更新，所以会导致 asyncTask.updatedAd 会覆盖 model
+      await taskRepository.saveTask(asyncTask);
+
+      assert(asyncTask.updatedAt.getTime() !== asyncTask.createdAt.getTime());
+    });
+
+    it('cant modify updatedAt', async () => {
+      const bizId = 'mock_dup_biz_id';
+      const data: EasyData<TaskData<ChangesStreamTaskData>, 'taskId'> = {
+        type: TaskType.ChangesStream,
+        state: TaskState.Waiting,
+        targetName: 'foo',
+        authorId: `pid_${process.pid}`,
+        authorIp: os.hostname(),
+        data: {
+          taskWorker: '',
+          since: '',
+        },
+        bizId,
+      };
+
+      // 首先创建一个 task1
+      const newData = EntityUtil.defaultData(data, 'taskId');
+      const task1 = new Task(newData);
+      const lastSince = new Date();
+      task1.updatedAt = lastSince;
+      await taskRepository.saveTask(task1);
+
+      assert(task1.updatedAt.getTime() > lastSince.getTime());
     });
   });
 });


### PR DESCRIPTION
* 🧶 ModelConvertor 新增 autoUpdatedAt 参数，taskRepository.saveTask 默认开启。

目前 saveTask 前会先从 db 内查询 entity.id 对应的 model，如果 updatedAt 不一致则更新。
如果单个任务有多个 worker 在执行，会导致 updatedAt 和 entity 不一致，导致 updaptedAt 被错误覆盖。
后续会触发 timeout Retry，放大异常。