### PR TITLE
fix: findExecuteTask only return waiting task

### DIFF
--- a/app/core/entity/Task.ts
+++ b/app/core/entity/Task.ts
@@ -64,6 +64,11 @@ export interface ChangesStreamTaskData extends TaskBaseData {
   registryId?: string,
 }
 
+export interface TaskUpdateCondition {
+  taskId: string;
+  attempts: number;
+}
+
 export type CreateHookTask = Task<CreateHookTaskData>;
 export type TriggerHookTask = Task<TriggerHookTaskData>;
 export type CreateSyncPackageTask = Task<CreateSyncPackageTaskData>;
@@ -220,6 +225,17 @@ export class Task<T extends TaskBaseData = TaskBaseData> extends Entity {
     const task = this.create(data);
     task.logPath = `/binaries/${targetName}/syncs/${dayjs().format('YYYY/MM/DDHHmm')}-${task.taskId}.log`;
     return task;
+  }
+
+  start(): TaskUpdateCondition {
+    const condition = {
+      taskId: this.taskId,
+      attempts: this.attempts,
+    };
+    this.setExecuteWorker();
+    this.state = TaskState.Processing;
+    this.attempts += 1;
+    return condition;
   }
 }
 

--- a/app/repository/util/ModelConvertor.ts
+++ b/app/repository/util/ModelConvertor.ts
@@ -31,6 +31,24 @@ export class ModelConvertor {
     return model as T;
   }
 
+  static convertEntityToChanges<T extends Bone>(entity: object, ModelClazz: EggProtoImplClass<T>) {
+    const changes = {};
+    const metadata = ModelMetadataUtil.getModelMetadata(ModelClazz);
+    if (!metadata) {
+      throw new Error(`Model ${ModelClazz.name} has no metadata`);
+    }
+    for (const attributeMeta of metadata.attributes) {
+      const modelPropertyName = attributeMeta.propertyName;
+      const entityPropertyName = ModelConvertorUtil.getEntityPropertyName(ModelClazz, modelPropertyName);
+      if (entityPropertyName === CREATED_AT) continue;
+      const attributeValue = _.get(entity, entityPropertyName);
+      changes[modelPropertyName] = attributeValue;
+    }
+    changes[UPDATED_AT] = new Date();
+    entity[UPDATED_AT] = changes[UPDATED_AT];
+    return changes;
+  }
+
   // TODO: options is QueryOptions, should let leoric export it to use
   // Find out which attributes changed and set `updatedAt` to now
   static async saveEntityToModel<T extends Bone>(entity: object, model: T, options?): Promise<boolean> {


### PR DESCRIPTION
If multi instance access queue may return
same task id, update task attemp idempotent
for safe concurrent.