### PR TITLE
Lazy set registryId when executeTask

### DIFF
--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -104,6 +104,10 @@ export class PackageManagerService extends AbstractService {
       if (pkg.description !== cmd.description) {
         pkg.description = cmd.description;
       }
+
+      if (!pkg.registryId && cmd.registryId) {
+        pkg.registryId = cmd.registryId;
+      }
     }
     await this.packageRepository.savePackage(pkg);
     // create maintainer


### PR DESCRIPTION

> packageSyncer#executeTask 时，根据 scope 和 data.registryId 更新 pkg.registryId 配置

解决问题:
1. 例如 @cnpm 配置特定 registry，当 @cnpm/a 依赖了 @cnpm/b 时，@cnpm/b 同步任务执行异常
2. 存量 registryId 为 null 的 package 无时机更新 registryId
3. 存量 registryId 为 null ，手动触发 sync 任务时，不支持传入 registryName: default