### PR TITLE
fix: registry host config

### DIFF
--- a/app/core/service/ChangesStreamService.ts
+++ b/app/core/service/ChangesStreamService.ts
@@ -100,14 +100,14 @@ export class ChangesStreamService extends AbstractService {
     }
 
     // 从配置文件默认生成
-    const { changesStreamRegistryMode, changesStreamRegistry: host } = this.config.cnpmcore;
-    const type = changesStreamRegistryMode === 'json' ? 'cnpmcore' : 'npm';
+    const { changesStreamRegistryMode, changesStreamRegistry: changesStreamHost, sourceRegistry: host } = this.config.cnpmcore;
+    const type = changesStreamRegistryMode === 'json' ? RegistryType.Cnpmcore : RegistryType.Npm;
     const registry = await this.registryManagerService.createRegistry({
       name: 'default',
-      type: type as RegistryType,
+      type,
       userPrefix: 'npm:',
       host,
-      changeStream: `${host}/_changes`,
+      changeStream: `${changesStreamHost}/_changes`,
     });
     task.data = {
       ...(task.data || {}),

--- a/sql/1.12.0.sql
+++ b/sql/1.12.0.sql
@@ -1,0 +1,8 @@
+-- fix https://github.com/cnpm/cnpmcore/issues/343
+UPDATE
+	`cnpmcore`.`registries`
+SET
+	`host` = 'https://registry.npmjs.org'
+WHERE
+	`name` = 'default'
+	AND `host` = 'https://replicate.npmjs.com';


### PR DESCRIPTION
fix #343 

之前默认用 changesStreamRegistry 作为默认的 registry 源，导致部分数据丢失。

~~* registryManageService 新增 ensureDefaultRegistry 方法~~
~~* 配置更新时，根据配置进行同步 defaultRegistry 配置~~
* 更新创建默认 registry 字段
* 添加 sql 订正脚本