### PR TITLE
feat: long description

### DIFF
--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -65,6 +65,7 @@ export interface PublishPackageCmd {
 
 const TOTAL = '@@TOTAL@@';
 const SCOPE_TOTAL_PREFIX = '@@SCOPE@@:';
+const DESCRIPTION_LIMIT = 1024 * 10;
 
 @ContextProto({
   accessLevel: AccessLevel.PUBLIC,
@@ -108,6 +109,11 @@ export class PackageManagerService extends AbstractService {
       if (!pkg.registryId && cmd.registryId) {
         pkg.registryId = cmd.registryId;
       }
+    }
+
+    // 防止 description 长度超过 db 限制
+    if (pkg.description?.length > DESCRIPTION_LIMIT) {
+      pkg.description = pkg.description.substring(0, DESCRIPTION_LIMIT);
     }
     await this.packageRepository.savePackage(pkg);
     // create maintainer

--- a/test/core/service/PackageManagerService/publish.test.ts
+++ b/test/core/service/PackageManagerService/publish.test.ts
@@ -75,6 +75,28 @@ describe('test/core/service/PackageManagerService/publish.test.ts', () => {
       app.expectLog(/\[\d+\.\d+\] \[NFSAdapter:uploadBytes|T\]/);
     });
 
+    it('should work slice long description', async () => {
+      app.mockLog();
+      const { packageId } = await packageManagerService.publish({
+        dist: {
+          content: Buffer.alloc(0),
+        },
+        tag: '',
+        scope: '',
+        name: 'foo',
+        description: '~'.repeat(1100 * 100),
+        packageJson: {},
+        readme: '',
+        version: '1.0.0',
+        isPrivate: true,
+      }, publisher);
+      const pkgVersion = await packageRepository.findPackageVersion(packageId, '1.0.0');
+      assert(pkgVersion);
+      assert.equal(pkgVersion.version, '1.0.0');
+      const pkg = await packageRepository.findPackage('', 'foo');
+      assert(pkg?.description === '~'.repeat(1024 * 10));
+    });
+
     it('should work with dist.localFile', async () => {
       const { packageId } = await packageManagerService.publish({
         dist: {


### PR DESCRIPTION
目前 db 限制 pkg.description 长度为 10k，cnpmjs.org 为 longtext，可能导致不兼容。

* 长 description 场景，截断字符保存，防止创建 pkg 失败