### PR TITLE
fix: duplicate binary task

### DIFF
--- a/app/core/entity/Task.ts
+++ b/app/core/entity/Task.ts
@@ -216,6 +216,7 @@ export class Task<T extends TaskBaseData = TaskBaseData> extends Entity {
       targetName,
       authorId: `pid_${PID}`,
       authorIp: HOST_NAME,
+      bizId: `SyncBinary:${targetName}`,
       data: {
         // task execute worker
         taskWorker: '',

--- a/test/core/service/BinarySyncerService/createTask.test.ts
+++ b/test/core/service/BinarySyncerService/createTask.test.ts
@@ -1,0 +1,27 @@
+import assert = require('assert');
+import { app } from 'egg-mock/bootstrap';
+import { Context } from 'egg';
+import { BinarySyncerService } from 'app/core/service/BinarySyncerService';
+
+describe('test/core/service/BinarySyncerService/createTask.test.ts', () => {
+  let ctx: Context;
+  let binarySyncerService: BinarySyncerService;
+
+  beforeEach(async () => {
+    ctx = await app.mockModuleContext();
+    binarySyncerService = await ctx.getEggObject(BinarySyncerService);
+  });
+
+  afterEach(async () => {
+    await app.destroyModuleContext(ctx);
+  });
+
+  describe('createTask()', () => {
+    it('should ignore duplicate binary task', async () => {
+      const task = await binarySyncerService.createTask('banana', {});
+      const newTask = await binarySyncerService.createTask('banana', {});
+      assert(task?.taskId === newTask?.taskId);
+      assert(task?.bizId === 'SyncBinary:banana');
+    });
+  });
+});


### PR DESCRIPTION
> syncBinary 目前会通过定时任务单机每天创建，导致多实例冲突
> 其他任务类型均通过事件触发不受影响
* 创建 syncBinary 任务时，手动去重
* 添加 bizId 参数 进行兜底