### PR TITLE
feat: serial same task

### DIFF
--- a/app/repository/TaskRepository.ts
+++ b/app/repository/TaskRepository.ts
@@ -93,6 +93,12 @@ export class TaskRepository extends AbstractRepository {
     return tasks.map(task => ModelConvertor.convertModelToEntity(task, TaskEntity));
   }
 
+  async findTasksByTargetNameAndType(targetName: string, type: TaskType) {
+    const where: any = { targetName, type };
+    const tasks = await this.Task.find(where);
+    return tasks.map(task => ModelConvertor.convertModelToEntity(task, TaskEntity));
+  }
+
   async findTaskByTargetName(targetName: string, type: TaskType, state?: TaskState) {
     const where: any = { targetName, type };
     if (state) {


### PR DESCRIPTION
> [version, tag] 类型的 change 触发时，无法保证 version 和 tag 执行顺序，可能出现 version 和 tag 请求时错误覆盖
> version task processing
> tag task triggered
> tag task finished
> version task finished <- 错误覆盖

* 同一类型任务，应当限制串行执行
* 修改 taskService.findExecuteTask 逻辑，确保当前有其他任务在执行时，就先跳过
* finishTask 时进行回调，如果还有正在等待的同名任务就执行 retryTask，兼容超时重试的场景