### PR TITLE
refactor: binary sync task use binaryName by default

### DIFF
--- a/app/common/adapter/binary/AbstractBinary.ts
+++ b/app/common/adapter/binary/AbstractBinary.ts
@@ -19,11 +19,13 @@ export abstract class AbstractBinary {
   protected httpclient: EggContextHttpClient;
   protected logger: EggLogger;
   protected binaryConfig: BinaryTaskConfig;
+  protected binaryName: string;
 
-  constructor(httpclient: EggContextHttpClient, logger: EggLogger, binaryConfig: BinaryTaskConfig) {
+  constructor(httpclient: EggContextHttpClient, logger: EggLogger, binaryConfig: BinaryTaskConfig, binaryName: string) {
     this.httpclient = httpclient;
     this.logger = logger;
     this.binaryConfig = binaryConfig;
+    this.binaryName = binaryName;
   }
 
   abstract fetch(dir: string, params?: any): Promise<FetchResult | undefined>;

--- a/app/common/adapter/binary/ApiBinary.ts
+++ b/app/common/adapter/binary/ApiBinary.ts
@@ -4,13 +4,13 @@ import { BinaryTaskConfig } from '../../../../config/binaries';
 
 export class ApiBinary extends AbstractBinary {
   private apiUrl: string;
-  constructor(httpclient: EggContextHttpClient, logger: EggLogger, binaryConfig: BinaryTaskConfig, apiUrl: string) {
-    super(httpclient, logger, binaryConfig);
+  constructor(httpclient: EggContextHttpClient, logger: EggLogger, binaryConfig: BinaryTaskConfig, apiUrl: string, binaryName: string) {
+    super(httpclient, logger, binaryConfig, binaryName);
     this.apiUrl = apiUrl;
   }
 
   async fetch(dir: string): Promise<FetchResult | undefined> {
-    const url = `${this.apiUrl}/${this.binaryConfig.category}${dir}`;
+    const url = `${this.apiUrl}/${this.binaryName}${dir}`;
     const data = await this.requestJSON(url);
     if (!Array.isArray(data)) {
       this.logger.warn('[ApiBinary.fetch:response-data-not-array] data: %j', data);

--- a/app/common/adapter/binary/ImageminBinary.ts
+++ b/app/common/adapter/binary/ImageminBinary.ts
@@ -8,7 +8,7 @@ export class ImageminBinary extends AbstractBinary {
   async fetch(dir: string): Promise<FetchResult | undefined> {
     if (!this.dirItems) {
       this.dirItems = {};
-      const npmPackageName = this.binaryConfig.options?.npmPackageName ?? this.binaryConfig.category;
+      const npmPackageName = this.binaryConfig.options?.npmPackageName ?? this.binaryName;
       const pkgUrl = `https://registry.npmjs.com/${npmPackageName}`;
       const data = await this.requestJSON(pkgUrl);
       this.dirItems = {};

--- a/app/common/adapter/binary/NodePreGypBinary.ts
+++ b/app/common/adapter/binary/NodePreGypBinary.ts
@@ -10,7 +10,7 @@ export class NodePreGypBinary extends AbstractBinary {
   async fetch(dir: string): Promise<FetchResult | undefined> {
     if (!this.dirItems) {
       this.dirItems = {};
-      const pkgUrl = `https://registry.npmjs.com/${this.binaryConfig.category}`;
+      const pkgUrl = `https://registry.npmjs.com/${this.binaryName}`;
       const data = await this.requestJSON(pkgUrl);
       this.dirItems = {};
       this.dirItems['/'] = [];
@@ -77,7 +77,7 @@ export class NodePreGypBinary extends AbstractBinary {
                     date,
                     size: '-',
                     isDir: false,
-                    url: `${this.binaryConfig.distUrl}/${this.binaryConfig.category}${versionPrefix}/${name}`,
+                    url: `${this.binaryConfig.distUrl}/${this.binaryName}${versionPrefix}/${name}`,
                     ignoreDownloadStatuses: [ 404 ],
                   });
                 }
@@ -99,7 +99,7 @@ export class NodePreGypBinary extends AbstractBinary {
                   date,
                   size: '-',
                   isDir: false,
-                  url: `${this.binaryConfig.distUrl}/${this.binaryConfig.category}${versionPrefix}/${name}`,
+                  url: `${this.binaryConfig.distUrl}/${this.binaryName}${versionPrefix}/${name}`,
                   ignoreDownloadStatuses: [ 404 ],
                 });
               }
@@ -163,7 +163,7 @@ export class NodePreGypBinary extends AbstractBinary {
               const binaryFileName = binaryFile.replace('{platform}', platform)
                 .replace('{arch}', arch);
               remotePath = remotePath.replace('{module_name}', moduleName)
-                .replace('{name}', this.binaryConfig.category)
+                .replace('{name}', this.binaryName)
                 .replace('{version}', version)
                 .replace('{configuration}', 'Release');
               const binaryFilePath = join('/', remotePath, binaryFileName);

--- a/app/core/service/BinarySyncerService.ts
+++ b/app/core/service/BinarySyncerService.ts
@@ -289,13 +289,13 @@ export class BinarySyncerService extends AbstractService {
 
   private createBinaryInstance(binaryName: string): AbstractBinary | undefined {
     const config = this.config.cnpmcore;
+    const binaryConfig = binaries[binaryName];
+
     if (config.sourceRegistryIsCNpm) {
-      const binaryConfig = binaries[binaryName];
       const syncBinaryFromAPISource = config.syncBinaryFromAPISource || `${config.sourceRegistry}/-/binary`;
       return new ApiBinary(this.httpclient, this.logger, binaryConfig, syncBinaryFromAPISource, binaryName);
     }
-    for (const [ binaryName, binaryConfig ] of Object.entries(binaries)) {
-      return new BinaryClasses[binaryConfig.syncer](this.httpclient, this.logger, binaryConfig, binaryName);
-    }
+
+    return new BinaryClasses[binaryConfig.syncer](this.httpclient, this.logger, binaryConfig, binaryName);
   }
 }

--- a/app/core/service/BinarySyncerService.ts
+++ b/app/core/service/BinarySyncerService.ts
@@ -294,7 +294,7 @@ export class BinarySyncerService extends AbstractService {
       const syncBinaryFromAPISource = config.syncBinaryFromAPISource || `${config.sourceRegistry}/-/binary`;
       return new ApiBinary(this.httpclient, this.logger, binaryConfig, syncBinaryFromAPISource, binaryName);
     }
-    for (const [binaryName, binaryConfig] of Object.entries(binaries)) {
+    for (const [ binaryName, binaryConfig ] of Object.entries(binaries)) {
       return new BinaryClasses[binaryConfig.syncer](this.httpclient, this.logger, binaryConfig, binaryName);
     }
   }

--- a/app/core/service/BinarySyncerService.ts
+++ b/app/core/service/BinarySyncerService.ts
@@ -92,7 +92,7 @@ export class BinarySyncerService extends AbstractService {
       categoryBinary,
     ] = await Promise.all(reqs);
 
-    const versions = rootBinary.map(b => b.name)
+    const versions = rootBinary.map(b => b.name);
     categoryBinary?.forEach(b => {
       const version = b.name;
       // 只将没有的版本添加进去

--- a/app/core/service/BinarySyncerService.ts
+++ b/app/core/service/BinarySyncerService.ts
@@ -78,13 +78,12 @@ export class BinarySyncerService extends AbstractService {
     // 所以查询 canvas 的时候，需要将 binaryName 和 category 的数据都查出来
     const {
       category,
-      mergeCategory,
     } = binaries[binaryName];
     const reqs = [
       this.binaryRepository.listBinaries(binaryName, '/'),
     ];
-    if (mergeCategory && mergeCategory !== category) {
-      reqs.push(this.binaryRepository.listBinaries(mergeCategory, '/'));
+    if (category && category !== binaryName) {
+      reqs.push(this.binaryRepository.listBinaries(category, '/'));
     }
 
     const [
@@ -293,12 +292,10 @@ export class BinarySyncerService extends AbstractService {
     if (config.sourceRegistryIsCNpm) {
       const binaryConfig = binaries[binaryName];
       const syncBinaryFromAPISource = config.syncBinaryFromAPISource || `${config.sourceRegistry}/-/binary`;
-      return new ApiBinary(this.httpclient, this.logger, binaryConfig, syncBinaryFromAPISource);
+      return new ApiBinary(this.httpclient, this.logger, binaryConfig, syncBinaryFromAPISource, binaryName);
     }
-    for (const binaryConfig of Object.values(binaries)) {
-      if (binaryConfig.category === binaryName) {
-        return new BinaryClasses[binaryConfig.syncer](this.httpclient, this.logger, binaryConfig);
-      }
+    for (const [binaryName, binaryConfig] of Object.entries(binaries)) {
+      return new BinaryClasses[binaryConfig.syncer](this.httpclient, this.logger, binaryConfig, binaryName);
     }
   }
 }

--- a/app/port/controller/BinarySyncController.ts
+++ b/app/port/controller/BinarySyncController.ts
@@ -33,7 +33,7 @@ export class BinarySyncController extends AbstractController {
     method: HTTPMethodEnum.GET,
   })
   async listBinaries() {
-    return Object.entries(binaries).map(([binaryName, binaryConfig]) => {
+    return Object.entries(binaries).map(([ binaryName, binaryConfig ]) => {
       return {
         name: `${binaryName}}/`,
         category: `${binaryConfig.category}/`,

--- a/app/port/controller/BinarySyncController.ts
+++ b/app/port/controller/BinarySyncController.ts
@@ -33,10 +33,10 @@ export class BinarySyncController extends AbstractController {
     method: HTTPMethodEnum.GET,
   })
   async listBinaries() {
-    return Object.values(binaries).map(binaryConfig => {
+    return Object.entries(binaries).map(([binaryName, binaryConfig]) => {
       return {
-        name: `${binaryConfig.category}/`,
-        mergeCategory: `${binaryConfig.mergeCategory}/`,
+        name: `${binaryName}}/`,
+        category: `${binaryConfig.category}/`,
         description: binaryConfig.description,
         distUrl: binaryConfig.distUrl,
         repoUrl: /^https?:\/\//.test(binaryConfig.repo) ? binaryConfig.repo : `https://github.com/${binaryConfig.repo}`,
@@ -64,11 +64,11 @@ export class BinarySyncController extends AbstractController {
     let binary = await this.binarySyncerService.findBinary(binaryName, parent, name);
     if (!binary) {
       // 查询不到再去查询 mergeCategory 的情况
-      const mergeCategory = binaries?.[binaryName]?.mergeCategory;
-      if (mergeCategory) {
+      const category = binaries?.[binaryName]?.category;
+      if (category) {
         // canvas/v2.6.1/canvas-v2.6.1-node-v57-linux-glibc-x64.tar.gz
         // -> node-canvas-prebuilt/v2.6.1/node-canvas-prebuilt-v2.6.1-node-v57-linux-glibc-x64.tar.gz
-        binary = await this.binarySyncerService.findBinary(mergeCategory, parent, name.replace(new RegExp(`^${binaryName}-`), `${mergeCategory}-`));
+        binary = await this.binarySyncerService.findBinary(category, parent, name.replace(new RegExp(`^${binaryName}-`), `${category}-`));
       }
     }
 

--- a/app/port/schedule/CreateSyncBinaryTask.ts
+++ b/app/port/schedule/CreateSyncBinaryTask.ts
@@ -21,10 +21,14 @@ export class CreateSyncBinaryTask {
   async subscribe() {
     if (!this.config.cnpmcore.enableSyncBinary) return;
 
-    for (const binary of Object.values(binaries)) {
-      if (this.config.env === 'unittest' && binary.category !== 'node') continue;
+    for (const [binaryName, binary] of Object.entries(binaries)) {
+      if (this.config.env === 'unittest' && binaryName !== 'node') continue;
       if (binary.disable) continue;
-      await this.binarySyncerService.createTask(binary.category);
+
+      // 默认只同步 binaryName 的二进制，即使有不一致的 category，会在同名的 binaryName 任务中同步
+      // 例如 canvas 只同步 binaryName 为 canvas 的二进制，不同步 category 为 node-canvas-prebuilt 的二进制
+      // node-canvas-prebuilt 的二进制会在 node-canvas-prebuilt 的任务中同步
+      await this.binarySyncerService.createTask(binaryName);
     }
   }
 }

--- a/app/port/schedule/CreateSyncBinaryTask.ts
+++ b/app/port/schedule/CreateSyncBinaryTask.ts
@@ -21,7 +21,7 @@ export class CreateSyncBinaryTask {
   async subscribe() {
     if (!this.config.cnpmcore.enableSyncBinary) return;
 
-    for (const [binaryName, binary] of Object.entries(binaries)) {
+    for (const [ binaryName, binary ] of Object.entries(binaries)) {
       if (this.config.env === 'unittest' && binaryName !== 'node') continue;
       if (binary.disable) continue;
 

--- a/config/binaries.ts
+++ b/config/binaries.ts
@@ -13,12 +13,11 @@ export enum SyncerClass {
 }
 
 export type BinaryTaskConfig = {
-  category: string;
+  category: string; // 默认 category 为 binaryName，但是有些 binary 会有不同的 category，比如 canvas，包含 canvas 和 node-canvas-prebuilt 两个
   description: string;
   syncer: SyncerClass;
   repo: string;
   distUrl: string;
-  mergeCategory?: string;
   ignoreDirs?: string[];
   ignoreFiles?: string[];
   options?: {
@@ -857,9 +856,8 @@ const binaries: {
     distUrl: 'https://github.com/dragonflyoss/image-service/releases',
   },
   canvas: {
-    category: 'canvas',
     // canvas@<=2.6.1 二进制需要从 node-canvas-prebuilt 下载
-    mergeCategory: 'node-canvas-prebuilt',
+    category: 'node-canvas-prebuilt',
     description: 'Node canvas is a Cairo backed Canvas implementation for NodeJS.',
     syncer: SyncerClass.GithubBinary,
     repo: 'Automattic/node-canvas',

--- a/config/binaries.ts
+++ b/config/binaries.ts
@@ -18,6 +18,7 @@ export type BinaryTaskConfig = {
   syncer: SyncerClass;
   repo: string;
   distUrl: string;
+  mergeCategory?: string;
   ignoreDirs?: string[];
   ignoreFiles?: string[];
   options?: {
@@ -637,13 +638,6 @@ const binaries: {
     repo: 'eugeneware/ffmpeg-static',
     distUrl: 'https://github.com/eugeneware/ffmpeg-static/releases',
   },
-  canvas: {
-    category: 'canvas',
-    description: 'Node canvas is a Cairo backed Canvas implementation for NodeJS.',
-    syncer: SyncerClass.GithubBinary,
-    repo: 'Automattic/node-canvas',
-    distUrl: 'https://github.com/Automattic/node-canvas/releases',
-  },
   nodejieba: {
     category: 'nodejieba',
     description: '"结巴"中文分词的Node.js版本',
@@ -861,6 +855,43 @@ const binaries: {
     syncer: SyncerClass.GithubBinary,
     repo: 'dragonflyoss/image-service',
     distUrl: 'https://github.com/dragonflyoss/image-service/releases',
+  },
+  canvas: {
+    category: 'canavs',
+    // canvas@<=2.6.1 二进制需要从 node-canvas-prebuilt 下载
+    mergeCategory: 'node-canvas-prebuilt',
+    description: 'Node canvas is a Cairo backed Canvas implementation for NodeJS.',
+    syncer: SyncerClass.GithubBinary,
+    repo: 'Automattic/node-canvas',
+    distUrl: 'https://github.com/Automattic/node-canvas/releases',
+  },
+ 'canvas-prebuilt': {
+    category: 'canvas-prebuilt',
+    distUrl: 'https://github.com/node-gfx/node-canvas-prebuilt/releases',
+    repo: 'chearon/node-canvas-prebuilt',
+    description: 'Prebuilt versions of node-canvas as a drop-in replacement',
+    syncer: SyncerClass.GithubBinary,
+    options: {
+      nodeArchs: {
+        linux: [ 'x64' ],
+        darwin: [ 'x64' ],
+        win32: [ 'x64' ],
+      },
+    },
+  },
+  'node-canvas-prebuilt': {
+    category: 'node-canvas-prebuilt',
+    distUrl: 'https://github.com/node-gfx/node-canvas-prebuilt/releases',
+    repo: 'node-gfx/node-canvas-prebuilt',
+    description: 'Repo used to build binaries for node-canvas on CI',
+    syncer: SyncerClass.GithubBinary,
+    options: {
+      nodeArchs: {
+        linux: [ 'x64' ],
+        darwin: [ 'x64' ],
+        win32: [ 'x64' ],
+      },
+    },
   },
 };
 

--- a/config/binaries.ts
+++ b/config/binaries.ts
@@ -865,7 +865,7 @@ const binaries: {
     repo: 'Automattic/node-canvas',
     distUrl: 'https://github.com/Automattic/node-canvas/releases',
   },
- 'canvas-prebuilt': {
+  'canvas-prebuilt': {
     category: 'canvas-prebuilt',
     distUrl: 'https://github.com/node-gfx/node-canvas-prebuilt/releases',
     repo: 'chearon/node-canvas-prebuilt',

--- a/test/TestUtil.ts
+++ b/test/TestUtil.ts
@@ -324,12 +324,16 @@ export class TestUtil {
     return Buffer.concat(chunks).toString();
   }
 
-  static delDynamicKey(obj, keys) {
-    const d = JSON.parse(JSON.stringify(obj));
-    for (const key of keys) {
-      delete d[key];
-    }
+  static pickKeys(obj, keys) {
+    const d: Record<string, any> = [];
+    obj.forEach(item => {
+      const newItem = {};
+      for (const key of keys) {
+        newItem[key] = item[key];
+      }
 
+      d.push(newItem);
+    });
     return d;
   }
 }

--- a/test/TestUtil.ts
+++ b/test/TestUtil.ts
@@ -323,4 +323,13 @@ export class TestUtil {
     }
     return Buffer.concat(chunks).toString();
   }
+
+  static delDynamicKey(obj, keys) {
+    const d = JSON.parse(JSON.stringify(obj));
+    for (const key of keys) {
+      delete d[key];
+    }
+
+    return d;
+  }
 }

--- a/test/common/adapter/binary/ApiBinary.test.ts
+++ b/test/common/adapter/binary/ApiBinary.test.ts
@@ -22,7 +22,7 @@ describe('test/common/adapter/binary/ApiBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('cnpmjs.org/mirrors/apis/node.json'),
         persist: false,
       });
-      const binary = new ApiBinary(ctx.httpclient, ctx.logger, binaries.node, 'https://cnpmjs.org/mirrors/apis');
+      const binary = new ApiBinary(ctx.httpclient, ctx.logger, binaries.node, 'https://cnpmjs.org/mirrors/apis', 'node');
       const result = await binary.fetch('/');
       assert(result);
       assert(result.items.length > 0);
@@ -56,7 +56,7 @@ describe('test/common/adapter/binary/ApiBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('r.cnpmjs.org/-/binary/node/v16.13.1.json'),
         persist: false,
       });
-      const binary = new ApiBinary(ctx.httpclient, ctx.logger, binaries.node, 'https://r.cnpmjs.org/-/binary');
+      const binary = new ApiBinary(ctx.httpclient, ctx.logger, binaries.node, 'https://r.cnpmjs.org/-/binary', 'node');
       const result = await binary.fetch('/v16.13.1/');
       assert(result);
       assert(result.items.length > 0);

--- a/test/common/adapter/binary/BucketBinary.test.ts
+++ b/test/common/adapter/binary/BucketBinary.test.ts
@@ -22,7 +22,7 @@ describe('test/common/adapter/binary/BucketBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('chromedriver.storage.googleapis.com/index.xml'),
         persist: false,
       });
-      const binary = new BucketBinary(ctx.httpclient, ctx.logger, binaries.chromedriver);
+      const binary = new BucketBinary(ctx.httpclient, ctx.logger, binaries.chromedriver, 'chromedriver');
       const result = await binary.fetch('/');
       assert(result);
       assert(result.items.length > 0);
@@ -51,7 +51,7 @@ describe('test/common/adapter/binary/BucketBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('chromedriver.storage.googleapis.com/97.0.4692.71.xml'),
         persist: false,
       });
-      const binary = new BucketBinary(ctx.httpclient, ctx.logger, binaries.chromedriver);
+      const binary = new BucketBinary(ctx.httpclient, ctx.logger, binaries.chromedriver, 'chromedriver');
       const result = await binary.fetch('/97.0.4692.71/');
       assert(result);
       assert(result.items.length > 0);
@@ -77,7 +77,7 @@ describe('test/common/adapter/binary/BucketBinary.test.ts', () => {
         persist: false,
       });
       // https://selenium-release.storage.googleapis.com/?delimiter=/&prefix=2.43/
-      const binary = new BucketBinary(ctx.httpclient, ctx.logger, binaries.selenium);
+      const binary = new BucketBinary(ctx.httpclient, ctx.logger, binaries.selenium, 'selenium');
       const result = await binary.fetch('/2.43/');
       assert(result);
       assert(result.items.length > 0);
@@ -91,7 +91,7 @@ describe('test/common/adapter/binary/BucketBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('node-inspector.s3.amazonaws.com/index.xml'),
         persist: false,
       });
-      const binary = new BucketBinary(ctx.httpclient, ctx.logger, binaries['node-inspector']);
+      const binary = new BucketBinary(ctx.httpclient, ctx.logger, binaries['node-inspector'], 'node-inspector');
       const result = await binary.fetch('/');
       assert(result);
       assert(result.items.length > 0);
@@ -105,7 +105,7 @@ describe('test/common/adapter/binary/BucketBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('prisma-builds.s3-eu-west-1.amazonaws.com/index.xml'),
         persist: false,
       });
-      const binary = new BucketBinary(ctx.httpclient, ctx.logger, binaries.prisma);
+      const binary = new BucketBinary(ctx.httpclient, ctx.logger, binaries.prisma, 'prisma');
       const result = await binary.fetch('/');
       assert(result);
       assert(result.items.length > 0);

--- a/test/common/adapter/binary/CypressBinary.test.ts
+++ b/test/common/adapter/binary/CypressBinary.test.ts
@@ -22,7 +22,7 @@ describe('test/common/adapter/binary/CypressBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('registry.npmjs.com/cypress.json'),
         persist: false,
       });
-      const binary = new CypressBinary(ctx.httpclient, ctx.logger, binaries.cypress);
+      const binary = new CypressBinary(ctx.httpclient, ctx.logger, binaries.cypress, 'cypress');
       const result = await binary.fetch('/');
       assert(result);
       assert(result.items.length > 0);
@@ -51,7 +51,7 @@ describe('test/common/adapter/binary/CypressBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('registry.npmjs.com/cypress.json'),
         persist: false,
       });
-      const binary = new CypressBinary(ctx.httpclient, ctx.logger, binaries.cypress);
+      const binary = new CypressBinary(ctx.httpclient, ctx.logger, binaries.cypress, 'cypress');
       let result = await binary.fetch('/4.0.0/');
       assert(result);
       assert(result.items.length === 4);

--- a/test/common/adapter/binary/ElectronBinary.test.ts
+++ b/test/common/adapter/binary/ElectronBinary.test.ts
@@ -23,7 +23,7 @@ describe('test/common/adapter/binary/ElectronBinary.test.ts', () => {
         data: response,
         status: 200,
       });
-      const binary = new ElectronBinary(ctx.httpclient, ctx.logger, binaries.electron);
+      const binary = new ElectronBinary(ctx.httpclient, ctx.logger, binaries.electron, 'electron');
       let result = await binary.fetch('/');
       assert(result);
       assert(result.items.length > 0);

--- a/test/common/adapter/binary/GithubBinary.test.ts
+++ b/test/common/adapter/binary/GithubBinary.test.ts
@@ -23,7 +23,7 @@ describe('test/common/adapter/binary/GithubBinary.test.ts', () => {
         data: response,
         status: 200,
       });
-      const binary = new GithubBinary(ctx.httpclient, ctx.logger, binaries.electron);
+      const binary = new GithubBinary(ctx.httpclient, ctx.logger, binaries.electron, 'electron');
       let result = await binary.fetch('/');
       assert(result);
       assert(result.items.length > 0);

--- a/test/common/adapter/binary/ImageminBinary.test.ts
+++ b/test/common/adapter/binary/ImageminBinary.test.ts
@@ -20,7 +20,7 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
     app.mockHttpclient('https://registry.npmjs.com/jpegtran-bin', 'GET', {
       data: await TestUtil.readFixturesFile('registry.npmjs.com/jpegtran-bin.json'),
     });
-    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['jpegtran-bin']);
+    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['jpegtran-bin'], 'jpegtran-bin');
     let result = await binary.fetch('/');
     assert(result);
     assert(result.items.length > 0);
@@ -88,7 +88,7 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
     app.mockHttpclient('https://registry.npmjs.com/advpng-bin', 'GET', {
       data: await TestUtil.readFixturesFile('registry.npmjs.com/advpng-bin.json'),
     });
-    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['advpng-bin']);
+    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['advpng-bin'], 'advpng-bin');
     let result = await binary.fetch('/');
     assert(result);
     assert(result.items.length > 0);
@@ -141,7 +141,7 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
     app.mockHttpclient('https://registry.npmjs.com/mozjpeg', 'GET', {
       data: await TestUtil.readFixturesFile('registry.npmjs.com/mozjpeg.json'),
     });
-    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['mozjpeg-bin']);
+    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['mozjpeg-bin'], 'mozjpeg-bin');
     let result = await binary.fetch('/');
     assert(result);
     // console.log(result.items);
@@ -205,7 +205,7 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
     app.mockHttpclient('https://registry.npmjs.com/gifsicle', 'GET', {
       data: await TestUtil.readFixturesFile('registry.npmjs.com/gifsicle.json'),
     });
-    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['gifsicle-bin']);
+    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['gifsicle-bin'], 'gifsicle-bin');
     const result = await binary.fetch('/');
     assert(result);
     // console.log(result.items);
@@ -234,7 +234,7 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
     app.mockHttpclient('https://registry.npmjs.com/optipng-bin', 'GET', {
       data: await TestUtil.readFixturesFile('registry.npmjs.com/optipng-bin.json'),
     });
-    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['optipng-bin']);
+    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['optipng-bin'], 'optipng-bin');
     const result = await binary.fetch('/');
     assert(result);
     // console.log(result.items);
@@ -263,7 +263,7 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
     app.mockHttpclient('https://registry.npmjs.com/zopflipng-bin', 'GET', {
       data: await TestUtil.readFixturesFile('registry.npmjs.com/zopflipng-bin.json'),
     });
-    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['zopflipng-bin']);
+    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['zopflipng-bin'], 'zopflipng-bin');
     const result = await binary.fetch('/');
     assert(result);
     // console.log(result.items);
@@ -292,7 +292,7 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
     app.mockHttpclient('https://registry.npmjs.com/jpegoptim-bin', 'GET', {
       data: await TestUtil.readFixturesFile('registry.npmjs.com/jpegoptim-bin.json'),
     });
-    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['jpegoptim-bin']);
+    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['jpegoptim-bin'], 'jpegoptim-bin');
     const result = await binary.fetch('/');
     assert(result);
     // console.log(result.items);
@@ -321,7 +321,7 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
     app.mockHttpclient('https://registry.npmjs.com/guetzli', 'GET', {
       data: await TestUtil.readFixturesFile('registry.npmjs.com/guetzli.json'),
     });
-    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['guetzli-bin']);
+    const binary = new ImageminBinary(ctx.httpclient, ctx.logger, binaries['guetzli-bin'], 'guetzli-bin');
     const result = await binary.fetch('/');
     assert(result);
     // console.log(result.items);

--- a/test/common/adapter/binary/NodeBinary.test.ts
+++ b/test/common/adapter/binary/NodeBinary.test.ts
@@ -21,7 +21,7 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
       app.mockHttpclient('https://nodejs.org/dist/', 'GET', {
         data: await TestUtil.readFixturesFile('nodejs.org/site/index.html'),
       });
-      const binary = new NodeBinary(ctx.httpclient, ctx.logger, binaries.node);
+      const binary = new NodeBinary(ctx.httpclient, ctx.logger, binaries.node, 'node');
       const result = await binary.fetch('/');
       assert(result);
       assert(result.items.length > 0);
@@ -54,7 +54,7 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
       app.mockHttpclient('https://nodejs.org/dist/v16.13.1/', 'GET', {
         data: await TestUtil.readFixturesFile('nodejs.org/site/v16.13.1/index.html'),
       });
-      const binary = new NodeBinary(ctx.httpclient, ctx.logger, binaries.node);
+      const binary = new NodeBinary(ctx.httpclient, ctx.logger, binaries.node, 'node');
       const result = await binary.fetch('/v16.13.1/');
       assert(result);
       assert(result.items.length > 0);
@@ -87,7 +87,7 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
       app.mockHttpclient('https://nodejs.org/download/nightly/v14.0.0-nightly20200119b318926634/', 'GET', {
         data: await TestUtil.readFixturesFile('nodejs.org/download/nightly/v14.0.0-nightly20200119b318926634/index.html'),
       });
-      const binary = new NodeBinary(ctx.httpclient, ctx.logger, binaries['node-nightly']);
+      const binary = new NodeBinary(ctx.httpclient, ctx.logger, binaries['node-nightly'], 'node-nightly');
       const result = await binary.fetch('/v14.0.0-nightly20200119b318926634/');
       assert(result);
       assert(result.items.length > 0);
@@ -129,7 +129,7 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
       app.mockHttpclient('https://nodejs.org/download/nightly/v14.0.0-nightly20200204ee9e689df2/', 'GET', {
         data: await TestUtil.readFixturesFile('nodejs.org/download/nightly/v14.0.0-nightly20200204ee9e689df2/index.html'),
       });
-      const binary = new NodeBinary(ctx.httpclient, ctx.logger, binaries['node-nightly']);
+      const binary = new NodeBinary(ctx.httpclient, ctx.logger, binaries['node-nightly'], 'node-nightly');
       const result = await binary.fetch('/v14.0.0-nightly20200204ee9e689df2/');
       assert(result);
       assert(result.items.length > 0);
@@ -184,7 +184,7 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
         persist: false,
       });
 
-      const binary = new NodeBinary(ctx.httpclient, ctx.logger, binaries.python);
+      const binary = new NodeBinary(ctx.httpclient, ctx.logger, binaries.python, 'python');
       let result = await binary.fetch('/');
       assert(result);
       assert(result.items.length > 0);

--- a/test/common/adapter/binary/NodePreGypBinary.test.ts
+++ b/test/common/adapter/binary/NodePreGypBinary.test.ts
@@ -24,7 +24,7 @@ describe('test/common/adapter/binary/NodePreGypBinary.test.ts', () => {
       app.mockHttpclient('https://nodejs.org/dist/index.json', 'GET', {
         data: await TestUtil.readFixturesFile('nodejs.org/site/index.json'),
       });
-      const binary = new NodePreGypBinary(ctx.httpclient, ctx.logger, binaries.grpc);
+      const binary = new NodePreGypBinary(ctx.httpclient, ctx.logger, binaries.grpc, 'grpc');
       let result = await binary.fetch('/');
       assert(result);
       assert(result.items.length > 0);
@@ -67,7 +67,7 @@ describe('test/common/adapter/binary/NodePreGypBinary.test.ts', () => {
       app.mockHttpclient('https://nodejs.org/dist/index.json', 'GET', {
         data: await TestUtil.readFixturesFile('nodejs.org/site/index.json'),
       });
-      const binary = new NodePreGypBinary(ctx.httpclient, ctx.logger, binaries['grpc-tools']);
+      const binary = new NodePreGypBinary(ctx.httpclient, ctx.logger, binaries['grpc-tools'], 'grpc-tools');
       let result = await binary.fetch('/');
       assert(result);
       assert(result.items.length > 0);
@@ -111,7 +111,7 @@ describe('test/common/adapter/binary/NodePreGypBinary.test.ts', () => {
       app.mockHttpclient('https://nodejs.org/dist/index.json', 'GET', {
         data: await TestUtil.readFixturesFile('nodejs.org/site/index.json'),
       });
-      const binary = new NodePreGypBinary(ctx.httpclient, ctx.logger, binaries.nodegit);
+      const binary = new NodePreGypBinary(ctx.httpclient, ctx.logger, binaries.nodegit, 'nodegit');
       const result = await binary.fetch('/');
       assert(result);
       assert(result.items.length > 0);
@@ -155,7 +155,7 @@ describe('test/common/adapter/binary/NodePreGypBinary.test.ts', () => {
       app.mockHttpclient('https://nodejs.org/dist/index.json', 'GET', {
         data: await TestUtil.readFixturesFile('nodejs.org/site/index.json'),
       });
-      const binary = new NodePreGypBinary(ctx.httpclient, ctx.logger, binaries['skia-canvas']);
+      const binary = new NodePreGypBinary(ctx.httpclient, ctx.logger, binaries['skia-canvas'], 'skia-canvas');
       let result = await binary.fetch('/');
       assert(result);
       assert(result.items.length > 0);
@@ -210,7 +210,7 @@ describe('test/common/adapter/binary/NodePreGypBinary.test.ts', () => {
       app.mockHttpclient('https://nodejs.org/dist/index.json', 'GET', {
         data: await TestUtil.readFixturesFile('nodejs.org/site/index.json'),
       });
-      const binary = new NodePreGypBinary(ctx.httpclient, ctx.logger, binaries.wrtc);
+      const binary = new NodePreGypBinary(ctx.httpclient, ctx.logger, binaries.wrtc, 'wrtc');
       let result = await binary.fetch('/');
       assert(result);
       assert(result.items.length > 0);

--- a/test/common/adapter/binary/NwjsBinary.test.ts
+++ b/test/common/adapter/binary/NwjsBinary.test.ts
@@ -22,7 +22,7 @@ describe('test/common/adapter/binary/NwjsBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('dl.nwjs.io/index.html'),
         persist: false,
       });
-      const binary = new NwjsBinary(ctx.httpclient, ctx.logger, binaries.nwjs);
+      const binary = new NwjsBinary(ctx.httpclient, ctx.logger, binaries.nwjs, 'nwjs');
       const result = await binary.fetch('/');
       assert(result);
       assert(result.items.length > 0);
@@ -44,7 +44,7 @@ describe('test/common/adapter/binary/NwjsBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('nwjs2.s3.amazonaws.com/v0.59.0.xml'),
         persist: false,
       });
-      const binary = new NwjsBinary(ctx.httpclient, ctx.logger, binaries.nwjs);
+      const binary = new NwjsBinary(ctx.httpclient, ctx.logger, binaries.nwjs, 'nwjs');
       let result = await binary.fetch('/v0.59.0/');
       assert(result);
       assert(result.items.length > 0);

--- a/test/common/adapter/binary/PlaywrightBinary.test.ts
+++ b/test/common/adapter/binary/PlaywrightBinary.test.ts
@@ -29,7 +29,7 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
         })
         .reply(200, await TestUtil.readFixturesFile('unpkg.com/playwright-core-browsers.json'))
         .persist();
-      const binary = new PlaywrightBinary(ctx.httpclient, ctx.logger, binaries.playwright);
+      const binary = new PlaywrightBinary(ctx.httpclient, ctx.logger, binaries.playwright, 'playwright');
       const result = await binary.fetch('/');
       assert(result);
       assert(result.items.length > 0);
@@ -57,7 +57,7 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
         })
         .reply(200, await TestUtil.readFixturesFile('unpkg.com/playwright-core-browsers.json'))
         .persist();
-      const binary = new PlaywrightBinary(ctx.httpclient, ctx.logger, binaries.playwright);
+      const binary = new PlaywrightBinary(ctx.httpclient, ctx.logger, binaries.playwright, 'playwright');
       let result = await binary.fetch('/builds/');
       assert(result);
       // console.log(result.items);

--- a/test/common/adapter/binary/PuppeteerBinary.test.ts
+++ b/test/common/adapter/binary/PuppeteerBinary.test.ts
@@ -30,7 +30,7 @@ describe('test/common/adapter/binary/PuppeteerBinary.test.ts', () => {
         data: '1055816',
         persist: false,
       });
-      const binary = new PuppeteerBinary(ctx.httpclient, ctx.logger, binaries['chromium-browser-snapshots']);
+      const binary = new PuppeteerBinary(ctx.httpclient, ctx.logger, binaries['chromium-browser-snapshots'], 'chromium-browser-snapshots');
       let result = await binary.fetch('/');
       assert(result);
       assert(result.items.length === 5);

--- a/test/common/adapter/binary/SqlcipherBinary.test.ts
+++ b/test/common/adapter/binary/SqlcipherBinary.test.ts
@@ -22,7 +22,7 @@ describe('test/common/adapter/binary/SqlcipherBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('registry.npmjs.com/@journeyapps/sqlcipher.json'),
         persist: false,
       });
-      const binary = new SqlcipherBinary(ctx.httpclient, ctx.logger, binaries['@journeyapps/sqlcipher']);
+      const binary = new SqlcipherBinary(ctx.httpclient, ctx.logger, binaries['@journeyapps/sqlcipher'], '@journeyapps/sqlcipher');
       const result = await binary.fetch('/');
       assert(result);
       assert(result.items.length > 0);
@@ -52,7 +52,7 @@ describe('test/common/adapter/binary/SqlcipherBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('registry.npmjs.com/@journeyapps/sqlcipher.json'),
         persist: false,
       });
-      const binary = new SqlcipherBinary(ctx.httpclient, ctx.logger, binaries['@journeyapps/sqlcipher']);
+      const binary = new SqlcipherBinary(ctx.httpclient, ctx.logger, binaries['@journeyapps/sqlcipher'], '@journeyapps/sqlcipher');
       const result = await binary.fetch('/v5.3.1/');
       assert(result);
       assert(result.items.length > 0);

--- a/test/port/controller/BinarySyncController/showBinary.test.ts
+++ b/test/port/controller/BinarySyncController/showBinary.test.ts
@@ -304,7 +304,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
 
       assert.strictEqual(res.status, 200);
       assert(res.body);
-      let stableData = TestUtil.delDynamicKey(res.body, [ 'id', 'modified' ]);
+      let stableData = TestUtil.pickKeys(res.body, [ 'category', 'name', 'date', 'type', 'url' ]);
       assert.deepStrictEqual(stableData, [
         {
           category: 'canvas',
@@ -327,7 +327,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
 
       assert.strictEqual(res.status, 200);
       assert(res.body);
-      stableData = TestUtil.delDynamicKey(res.body, [ 'id', 'modified' ]);
+      stableData = TestUtil.pickKeys(res.body, [ 'category', 'name', 'date', 'type', 'url' ]);
       assert.deepStrictEqual(stableData, [
         {
           category: 'node-canvas-prebuilt',
@@ -350,7 +350,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
 
       assert.strictEqual(res.status, 200);
       assert(res.body);
-      stableData = TestUtil.delDynamicKey(res.body, [ 'id', 'modified' ]);
+      stableData = TestUtil.pickKeys(res.body, [ 'category', 'name', 'date', 'type', 'url' ]);
 
       assert.deepStrictEqual(stableData, [
         {
@@ -367,7 +367,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
 
       assert.strictEqual(res.status, 200);
       assert(res.body);
-      stableData = TestUtil.delDynamicKey(res.body, [ 'id', 'modified' ]);
+      stableData = TestUtil.pickKeys(res.body, [ 'category', 'name', 'date', 'type', 'url' ]);
 
       assert.deepStrictEqual(stableData, [
         {
@@ -384,7 +384,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
 
       assert.strictEqual(res.status, 200);
       assert(res.body);
-      stableData = TestUtil.delDynamicKey(res.body, [ 'id', 'modified' ]);
+      stableData = TestUtil.pickKeys(res.body, [ 'category', 'name', 'date', 'type', 'url' ]);
 
       assert.deepStrictEqual(stableData, [
         {
@@ -450,9 +450,9 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
         date: '2021-12-14T13:12:31.587Z',
       }));
 
-        mock(nfsClientAdapter, 'url', (storeKey: string) => {
-          return `https://cdn.mock.com${storeKey}`;
-        });
+      mock(nfsClientAdapter, 'url', (storeKey: string) => {
+        return `https://cdn.mock.com${storeKey}`;
+      });
       const res = await app.httpRequest()
         .get('/-/binary/canvas/v2.6.1/canvas-v2.6.1-node-v57-linux-glibc-x64.tar.gz');
 

--- a/test/port/controller/BinarySyncController/showBinary.test.ts
+++ b/test/port/controller/BinarySyncController/showBinary.test.ts
@@ -3,7 +3,7 @@ import { Context } from 'egg';
 import { app, mock } from 'egg-mock/bootstrap';
 import { BinarySyncerService } from 'app/core/service/BinarySyncerService';
 import { NodeBinary } from 'app/common/adapter/binary/NodeBinary';
-import { SqlcipherBinary }  from 'app/common/adapter/binary/SqlcipherBinary';
+import { SqlcipherBinary } from 'app/common/adapter/binary/SqlcipherBinary';
 import { BinaryRepository } from 'app/repository/BinaryRepository';
 import { Binary } from 'app/core/entity/Binary';
 import { TestUtil } from 'test/TestUtil';
@@ -307,7 +307,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
         category: d.category,
         date: d.date,
         url: d.url,
-      }))
+      }));
       assert.deepStrictEqual(stableData, [
         {
           category: 'canvas',
@@ -322,7 +322,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
           date: '2021-12-14T13:12:31.587Z',
           type: 'dir',
           url: 'http://localhost:7001/-/binary/node-canvas-prebuilt/v2.6.1/',
-        }
+        },
       ]);
 
       res = await app.httpRequest()
@@ -351,7 +351,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
           date: '2021-12-14T13:12:31.587Z',
           type: 'dir',
           url: 'http://localhost:7001/-/binary/node-canvas-prebuilt/v2.7.0/',
-        }
+        },
       ]);
 
       res = await app.httpRequest()
@@ -373,8 +373,8 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
           type: 'file',
           category: 'canvas',
           date: '2021-12-14T13:12:31.587Z',
-          url: 'http://localhost:7001/-/binary/canvas/v2.7.0/canvas-v2.7.0-node-v57-linux-glibc-x64.tar.gz'
-        }
+          url: 'http://localhost:7001/-/binary/canvas/v2.7.0/canvas-v2.7.0-node-v57-linux-glibc-x64.tar.gz',
+        },
       ]);
 
       res = await app.httpRequest()
@@ -396,8 +396,8 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
           type: 'file',
           category: 'node-canvas-prebuilt',
           date: '2021-12-14T13:12:31.587Z',
-          url: 'http://localhost:7001/-/binary/node-canvas-prebuilt/v2.6.1/node-canvas-prebuilt-v2.6.1-node-v57-linux-glibc-x64.tar.gz'
-        }
+          url: 'http://localhost:7001/-/binary/node-canvas-prebuilt/v2.6.1/node-canvas-prebuilt-v2.6.1-node-v57-linux-glibc-x64.tar.gz',
+        },
       ]);
 
       res = await app.httpRequest()
@@ -419,8 +419,8 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
           type: 'file',
           category: 'node-canvas-prebuilt',
           date: '2021-12-14T13:12:31.587Z',
-          url: 'http://localhost:7001/-/binary/node-canvas-prebuilt/v2.6.1/node-canvas-prebuilt-v2.6.1-node-v57-linux-glibc-x64.tar.gz'
-        }
+          url: 'http://localhost:7001/-/binary/node-canvas-prebuilt/v2.6.1/node-canvas-prebuilt-v2.6.1-node-v57-linux-glibc-x64.tar.gz',
+        },
       ]);
 
       res = await app.httpRequest()


### PR DESCRIPTION
1. 默认使用 config/binaries 的 binaryName 创建同步任务；
2. config/binaries 中的 category 为组合不同 binary 数据的配置。默认跟 binaryName 保持一致；
3. 当 category 跟 binaryName 不一致时，合并 binaryName 和 category 两个二进制数据信息。

以 canvas 和 node-canvas-prebuilt 为例：
1. 创建同步任务时，分别同步各自的数据；
2. 查询二进制数据时，由于 canvas 中的 category 配置为 node-canvas-prebuilt，这时候会合并 canvas 和 node-canvas-prebuilt 两个 binary（binaryName）的数据并返回。

这个重构删除 mergeCategory 字段，使得配置数据更加精简。