### PR TITLE
WIP: feat: merge changes

### DIFF
--- a/app/port/schedule/SyncPackageWorker.ts
+++ b/app/port/schedule/SyncPackageWorker.ts
@@ -2,7 +2,7 @@ import { EggAppConfig, EggLogger } from 'egg';
 import { IntervalParams, Schedule, ScheduleType } from '@eggjs/tegg/schedule';
 import { Inject } from '@eggjs/tegg';
 import { PackageSyncerService } from '../../core/service/PackageSyncerService';
-
+import { CacheAdapter } from '../../../app/common/adapter/CacheAdapter';
 
 let executingCount = 0;
 
@@ -22,6 +22,9 @@ export class SyncPackageWorker {
   @Inject()
   private readonly logger: EggLogger;
 
+  @Inject()
+  private readonly cacheAdapter: CacheAdapter;
+
   async subscribe() {
     if (this.config.cnpmcore.syncMode !== 'all') return;
     if (executingCount >= this.config.cnpmcore.syncPackageWorkerMaxConcurrentTasks) return;
@@ -30,11 +33,20 @@ export class SyncPackageWorker {
     try {
       let task = await this.packageSyncerService.findExecuteTask();
       while (task) {
+        const taskId = task.taskId;
         const startTime = Date.now();
         this.logger.info('[SyncPackageWorker:subscribe:executeTask:start][%s] taskId: %s, targetName: %s, attempts: %s, params: %j, updatedAt: %s, delay %sms',
           executingCount, task.taskId, task.targetName, task.attempts, task.data, task.updatedAt,
           startTime - task.updatedAt.getTime());
-        await this.packageSyncerService.executeTask(task);
+        // 默认独占 1 分钟
+        // 防止同名任务导致互相冲突
+        // 只需保证间隔顺序即可
+        await this.cacheAdapter.waitForUnLock(`${task.type}_${task.targetName}`, 60, async () => {
+          const refreshedTask = await this.packageSyncerService.findTask(taskId);
+          if (refreshedTask) {
+            await this.packageSyncerService.executeTask(refreshedTask);
+          }
+        });
         const use = Date.now() - startTime;
         this.logger.info('[SyncPackageWorker:subscribe:executeTask:success][%s] taskId: %s, targetName: %s, use %sms',
           executingCount, task.taskId, task.targetName, use);

--- a/test/common/adapter/CacheAdapter.test.ts
+++ b/test/common/adapter/CacheAdapter.test.ts
@@ -67,5 +67,25 @@ describe('test/common/adapter/CacheAdapter.test.ts', () => {
       const lockId3 = await cache.lock('CNPMCORE_L_unittest', 10);
       assert(lockId3);
     });
+
+    describe('waitForUnLock()', () => {
+      it('should work', async () => {
+        let trigger = 0;
+        await cache.lock('unittest-waitForUnLock', 1);
+        await cache.waitForUnLock('unittest-waitForUnLock', 1, async () => {
+          trigger++;
+        });
+        assert(trigger === 1);
+      });
+
+      it('should abort after retry', async () => {
+        let trigger = 0;
+        await cache.lock('unittest-waitForUnLock', 10);
+        await cache.waitForUnLock('unittest-waitForUnLock', 1, async () => {
+          trigger++;
+        });
+        assert(trigger === 0);
+      });
+    });
   });
 });


### PR DESCRIPTION
> 目前 syncPackage 任务执行时，会分别执行:
> 1) versions 表更新
> 2) versions 写入 pkg.manifest 
> 3) tag 写入 pkg.manifest
> 在并发场景下，versions 表可能被其他 task 更新完
> 但可能 versions 还未 写入pkg.manifest，tag 在这种情况下也会写入 pkg.manifest 中
> 导致期间依赖查询失败（manifest 有 tag 没 version）致使下游的 regsitry 产生脏数据

此外，同名 task 可能还会导致 version change 和 tag change 互相冲突覆盖的问题 [ref](https://github.com/cnpm/cnpmcore/pull/355)

 为了尽可能减少任务并发带来的影响：
 
1.  在任务分发时，合并相同 id 的 change，version 和 tag change 进行合并，忽略前者
2. 在任务消费时，syncPackgeWoker 添加锁，减少请求并发带来的影响

部分极端场景，可能会致使 tag 更新延迟 60s 更新，牺牲时效性确保数据一致性 😈
