### PR TITLE
fix: binary path

### DIFF
--- a/app/common/adapter/binary/NodePreGypBinary.ts
+++ b/app/common/adapter/binary/NodePreGypBinary.ts
@@ -144,6 +144,42 @@ export class NodePreGypBinary extends AbstractBinary {
             }
           }
         }
+      } else if (binaryFile.includes('{platform}-{arch}-{node_napi_label}')) {
+        // "_id": "skia-canvas@0.9.22",
+        // "binary": {
+        //   "module_name": "index",
+        //   "module_path": "./lib/v{napi_build_version}",
+        //   "remote_path": "./v{version}",
+        //   "package_name": "{platform}-{arch}-{node_napi_label}.tar.gz",
+        //   "host": "https://skia-canvas.s3.us-east-1.amazonaws.com",
+        //   "napi_versions": [
+        //     6
+        //   ]
+        // },
+        for (const platform of nodePlatforms) {
+          const archs = nodeArchs[platform];
+          for (const arch of archs) {
+            for (const napiVersion of napiVersions) {
+              const binaryFileName = binaryFile.replace('{platform}', platform)
+                .replace('{arch}', arch)
+                .replace('{node_napi_label}', napiVersion);
+              remotePath = remotePath.replace('{module_name}', moduleName)
+                .replace('{name}', binaryName)
+                .replace('{version}', version)
+                .replace('{configuration}', 'Release');
+              const binaryFilePath = join('/', remotePath, binaryFileName);
+              const remoteUrl = `${binaryConfig.distUrl}${binaryFilePath}`;
+              currentDir.push({
+                name: binaryFileName,
+                date,
+                size: '-',
+                isDir: false,
+                url: remoteUrl,
+                ignoreDownloadStatuses: [ 404 ],
+              });
+            }
+          }
+        }
       } else if (binaryFile.includes('{platform}') && binaryFile.includes('{arch}')) {
         // https://github.com/grpc/grpc-node/blob/master/packages/grpc-tools/package.json#L29
         // "binary": {

--- a/test/common/adapter/binary/NodePreGypBinary.test.ts
+++ b/test/common/adapter/binary/NodePreGypBinary.test.ts
@@ -157,6 +157,9 @@ describe('test/common/adapter/binary/NodePreGypBinary.test.ts', () => {
       }
       assert(matchDir);
 
+      result = await binary.fetch('/v0.9.24/', 'skia-canvas');
+      assert(result?.items.every(item => !/{.*}/.test(item.url)));
+
       result = await binary.fetch('/v0.9.30/', 'skia-canvas');
       assert(result);
       assert(result.items.length > 0);


### PR DESCRIPTION
> 目前逻辑会解析出 ` https://skia-canvas.s3.us-east-1.amazonaws.com/v0.9.24/linux-arm64-{node_napi_label}.tar.gz`  会导致任务多次失败重试

* 添加 if/else 判断兼容 `{platform}-{arch}-{node_napi_label}` 
* 临时兼容，后续通过变量替换实现

