### PR TITLE
fix: config path

### DIFF
--- a/app/common/adapter/binary/ElectronBinary.ts
+++ b/app/common/adapter/binary/ElectronBinary.ts
@@ -1,6 +1,6 @@
 import { SingletonProto } from '@eggjs/tegg';
 import { BinaryType } from '../../enum/Binary';
-import binaries from 'config/binaries';
+import binaries from '../../../../config/binaries';
 import { BinaryAdapter, BinaryItem, FetchResult } from './AbstractBinary';
 import { GithubBinary } from './GithubBinary';
 

--- a/app/common/adapter/binary/GithubBinary.ts
+++ b/app/common/adapter/binary/GithubBinary.ts
@@ -1,6 +1,6 @@
 import { SingletonProto } from '@eggjs/tegg';
 import { BinaryType } from '../../enum/Binary';
-import binaries, { BinaryTaskConfig } from 'config/binaries';
+import binaries, { BinaryTaskConfig } from '../../../../config/binaries';
 import { AbstractBinary, FetchResult, BinaryItem, BinaryAdapter } from './AbstractBinary';
 
 @SingletonProto()

--- a/app/common/adapter/binary/ImageminBinary.ts
+++ b/app/common/adapter/binary/ImageminBinary.ts
@@ -1,6 +1,6 @@
 import { SingletonProto } from '@eggjs/tegg';
 import { BinaryType } from '../../enum/Binary';
-import binaries from 'config/binaries';
+import binaries from '../../../../config/binaries';
 import { AbstractBinary, FetchResult, BinaryItem, BinaryAdapter } from './AbstractBinary';
 
 @SingletonProto()

--- a/app/common/adapter/binary/NodeBinary.ts
+++ b/app/common/adapter/binary/NodeBinary.ts
@@ -1,6 +1,6 @@
 import { SingletonProto } from '@eggjs/tegg';
 import { BinaryType } from '../../enum/Binary';
-import binaries from 'config/binaries';
+import binaries from '../../../../config/binaries';
 import { AbstractBinary, FetchResult, BinaryItem, BinaryAdapter } from './AbstractBinary';
 
 @SingletonProto()

--- a/app/common/adapter/binary/NodePreGypBinary.ts
+++ b/app/common/adapter/binary/NodePreGypBinary.ts
@@ -1,6 +1,6 @@
 import { SingletonProto } from '@eggjs/tegg';
 import { BinaryType } from '../../enum/Binary';
-import binaries from 'config/binaries';
+import binaries from '../../../../config/binaries';
 import { join } from 'path';
 import { AbstractBinary, FetchResult, BinaryItem, BinaryAdapter } from './AbstractBinary';
 

--- a/app/common/adapter/binary/NwjsBinary.ts
+++ b/app/common/adapter/binary/NwjsBinary.ts
@@ -1,6 +1,6 @@
 import { SingletonProto } from '@eggjs/tegg';
 import { BinaryType } from '../../enum/Binary';
-import binaries from 'config/binaries';
+import binaries from '../../../../config/binaries';
 import { FetchResult, BinaryItem, BinaryAdapter } from './AbstractBinary';
 import { BucketBinary } from './BucketBinary';
 


### PR DESCRIPTION
Fix partial `config/binaries` file path in binary.
Prevent js parsing issues when cnpmcore is required as an npm module.
This is the part that was missed in the previous pr . https://github.com/cnpm/cnpmcore/pull/384 

