### PR TITLE
feat: sync delete mode

### DIFF
--- a/app/common/constants.ts
+++ b/app/common/constants.ts
@@ -1,3 +1,13 @@
 export const BUG_VERSIONS = 'bug-versions';
 export const LATEST_TAG = 'latest';
 export const GLOBAL_WORKER = 'GLOBAL_WORKER';
+export enum SyncMode {
+  none = 'none',
+  exist = 'exist',
+  all = 'all',
+}
+export enum SyncDeleteMode {
+  ignore = 'ignore',
+  block = 'block',
+  delete = 'delete',
+}

--- a/app/core/service/PackageSyncerService.ts
+++ b/app/core/service/PackageSyncerService.ts
@@ -257,7 +257,7 @@ export class PackageSyncerService extends AbstractService {
   private async syncDeletePkg({ task, pkg, logUrl, url, logs, data }: syncDeletePkgOptions) {
     const fullname = task.targetName;
     const failEnd = `❌❌❌❌❌ ${url || fullname} ❌❌❌❌❌`;
-    const { syncDeleteMode = SyncDeleteMode } = this.config.cnpmcore;
+    const syncDeleteMode: SyncDeleteMode = this.config.cnpmcore.syncDeleteMode;
     logs.push(`[${isoNow()}] 🟢 Package "${fullname}" was removed in remote registry, response data: ${JSON.stringify(data)}, config.syncDeleteMode = ${syncDeleteMode}`);
 
     // pkg not exists in local registry
@@ -271,19 +271,15 @@ export class PackageSyncerService extends AbstractService {
       return;
     }
 
-    // ignore deleted package
     if (syncDeleteMode === SyncDeleteMode.ignore) {
+      // ignore deleted package
       logs.push(`[${isoNow()}] 🟢 Skip remove since config.syncDeleteMode = ignore`);
-    }
-
-    // block deleted package
-    if (syncDeleteMode === SyncDeleteMode.block) {
+    } else if (syncDeleteMode === SyncDeleteMode.block) {
+      // block deleted package
       await this.packageManagerService.blockPackage(pkg, 'Removed in remote registry');
       logs.push(`[${isoNow()}] 🟢 Block the package since config.syncDeleteMode = block`);
-    }
-
-    // delete package
-    if (syncDeleteMode === SyncDeleteMode.delete) {
+    } else if (syncDeleteMode === SyncDeleteMode.delete) {
+      // delete package
       await this.packageManagerService.unpublishPackage(pkg);
       logs.push(`[${isoNow()}] 🟢 Delete the package since config.syncDeleteMode = delete`);
     }

--- a/app/core/service/PackageSyncerService.ts
+++ b/app/core/service/PackageSyncerService.ts
@@ -227,9 +227,9 @@ export class PackageSyncerService extends AbstractService {
       return true;
     }
 
-    const noMaintainers = data?.maintainers?.length === 0;
-    if (!noMaintainers) {
-      return true;
+    const hasMaintainers = data?.maintainers && data?.maintainers.length !== 0;
+    if (hasMaintainers) {
+      return false;
     }
 
     // unpublished
@@ -242,6 +242,8 @@ export class PackageSyncerService extends AbstractService {
     if (data?.repository === 'npm/security-holder') {
       return true;
     }
+
+    return false;
   }
 
   // sync deleted package, deps on the syncDeleteMode
@@ -255,7 +257,7 @@ export class PackageSyncerService extends AbstractService {
   private async syncDeletePkg({ task, pkg, logUrl, url, logs, data }: syncDeletePkgOptions) {
     const fullname = task.targetName;
     const failEnd = `❌❌❌❌❌ ${url || fullname} ❌❌❌❌❌`;
-    const { syncDeleteMode } = this.config;
+    const { syncDeleteMode = SyncDeleteMode } = this.config.cnpmcore;
     logs.push(`[${isoNow()}] 🟢 Package "${fullname}" was removed in remote registry, response data: ${JSON.stringify(data)}, config.syncDeleteMode = ${syncDeleteMode}`);
 
     // pkg not exists in local registry

--- a/app/infra/NFSClientAdapter.ts
+++ b/app/infra/NFSClientAdapter.ts
@@ -1,10 +1,10 @@
 import {
   AccessLevel,
   EggObjectLifecycle,
-  InitTypeQualifier,
   Inject,
-  ObjectInitType,
   SingletonProto,
+  EggQualifier,
+  EggType,
 } from '@eggjs/tegg';
 import { EggAppConfig, EggLogger } from 'egg';
 import FSClient from 'fs-cnpm';
@@ -17,7 +17,7 @@ import { Readable } from 'stream';
 })
 export class NFSClientAdapter implements EggObjectLifecycle, NFSClient {
   @Inject()
-  @InitTypeQualifier(ObjectInitType.SINGLETON)
+  @EggQualifier(EggType.APP)
   private logger: EggLogger;
 
   @Inject()

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { EggAppConfig, PowerPartial } from 'egg';
 import OSSClient from 'oss-cnpm';
 import { patchAjv } from '../app/port/typebox';
+import { SyncDeleteMode, SyncMode } from '../app/common/constants';
 
 export default (appInfo: EggAppConfig) => {
   const config = {} as PowerPartial<EggAppConfig>;
@@ -22,7 +23,8 @@ export default (appInfo: EggAppConfig) => {
     //  - none: don't sync npm package, just redirect it to sourceRegistry
     //  - all: sync all npm packages
     //  - exist: only sync exist packages, effected when `enableCheckRecentlyUpdated` or `enableChangesStream` is enabled
-    syncMode: 'none',
+    syncMode: SyncMode.none,
+    syncDeleteMode: SyncDeleteMode.delete,
     hookEnable: false,
     syncPackageWorkerMaxConcurrentTasks: 10,
     triggerHookWorkerMaxConcurrentTasks: 10,

--- a/test/common/adapter/binary/ImageminBinary.test.ts
+++ b/test/common/adapter/binary/ImageminBinary.test.ts
@@ -80,7 +80,7 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
       data: await TestUtil.readFixturesFile('registry.npmjs.com/advpng-bin.json'),
     });
     let result = await binary.fetch('/', 'advpng-bin');
-    console.log(result?.items.map(_ => _.name));
+    // console.log(result?.items.map(_ => _.name));
     assert(result);
     assert(result.items.length > 0);
     let matchDir1 = false;
@@ -308,7 +308,7 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
       data: await TestUtil.readFixturesFile('registry.npmjs.com/guetzli.json'),
     });
     const result = await binary.fetch('/', 'guetzli-bin');
-    console.log(result);
+    // console.log(result);
     assert(result);
     // console.log(result.items);
     assert(result.items.length > 0);

--- a/test/core/service/PackageSyncerService/executeTask.test.ts
+++ b/test/core/service/PackageSyncerService/executeTask.test.ts
@@ -218,7 +218,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       assert(stream);
       let log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes(`] 🟢 Package "${name}" was unpublished caused by 404 response`));
+      assert(log.includes(`] 🟢 Package "${name}" was removed in remote registry`));
 
       manifests = await packageManagerService.listPackageFullManifests('', name);
       assert(manifests.data.time.unpublished);
@@ -887,7 +887,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       assert(stream);
       let log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('] 📖 Ignore unpublished package: {'));
+      assert(log.includes(`] 🟢 Package "${name}" was removed in remote registry`));
       let data = await packageManagerService.listPackageFullManifests('', name);
       assert(data.data === null);
 
@@ -928,7 +928,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       assert(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('] 🟢 Sync unpublished package: {'));
+      assert(log.includes(`] 🟢 Package "${name}" was removed in remote registry`));
       data = await packageManagerService.listPackageFullManifests('', name);
       // console.log(data.data);
       assert(data.data.time.unpublished);
@@ -1544,7 +1544,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
 
-      assert(log.includes(`🟢 Package "${name}" was unpublished caused by 451 response`));
+      assert(log.includes(`] 🟢 Package "${name}" was removed in remote registry`));
     });
 
     it('should stop sync by block list', async () => {
@@ -1649,9 +1649,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       assert(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('🟢🟢🟢🟢🟢'));
-      assert(log.includes('🟢 [1] Synced version 0.0.1-security success'));
-      assert(log.includes('Syncing maintainers: [{\"name\":\"npm\",\"email\":\"npm@npmjs.com\"}]'));
+      assert(log.includes(`] 🟢 Package "${name}" was removed in remote registry`));
     });
 
     it('should mock getFullManifests missing tarball error and downloadTarball error', async () => {


### PR DESCRIPTION
> 为了避免部分 npm 包误封、误删，导致生产环境影响，新增 syncDeleteMode 配置，允许自定义同步策略

* 新增 `syncDeleteMode` : 'ignore' | 'block' | 'delete'
  * delete: 目前默认值，同步删包事件
  * ignore: 忽略 upstream 所有删包事件
  * block: 不做物理删除，只新增 block 记录，不允许访问，除非管理员手动恢复并更新 `syncPackageBlockList`
* `npm-security-holder` 场景也判断为删包事件
* 更新原有删包流程，统一处理，调整部分日志输出

---------------

> New `syncDeleteMode` to allow custom syncing policy to avoid some npm packages being blocked or deleted by mistake.

* Add `syncDeleteMode` : 'ignore' | 'block' | 'delete'
  * delete: by default, sync delete events
  * ignore: ignore all upstream delete events
  * block: only add block records, cant access unless the administrator manually restores and update `syncPackageBlockList`.
* `npm-security-holder` event is also determined to be a delete event
* Update the original packet deletion process, update log output by the way




Translated with www.DeepL.com/Translator (free version)


