### PR TITLE
fix: distinct processing task

### DIFF
--- a/app/core/service/TaskService.ts
+++ b/app/core/service/TaskService.ts
@@ -41,8 +41,8 @@ export class TaskService extends AbstractService {
               task.type, task.targetName, task.taskId, queueLength);
           }
         }
-        return existsTask;
       }
+      return existsTask;
     }
     await this.taskRepository.saveTask(task);
     await this.queueAdapter.push<string>(task.type, task.taskId);

--- a/test/core/service/PackageSyncerService/createTask.test.ts
+++ b/test/core/service/PackageSyncerService/createTask.test.ts
@@ -59,7 +59,7 @@ describe('test/core/service/PackageSyncerService/createTask.test.ts', () => {
     assert(task);
   });
 
-  it('should create task when processing', async () => {
+  it('should merge task when processing', async () => {
     mock(packageSyncerService, 'executeTask', async (task: Task) => {
       task.state = TaskState.Processing;
       await taskRepository.saveTask(task);
@@ -71,7 +71,7 @@ describe('test/core/service/PackageSyncerService/createTask.test.ts', () => {
       await setTimeout(1);
       return await packageSyncerService.createTask(pkgName);
     })() ]);
-    assert(res[1].taskId !== task.taskId);
+    assert(res[1].taskId === task.taskId);
   });
 
   it('should not duplicate task when waiting', async () => {


### PR DESCRIPTION
> 相同任务并发执行时，如果上游有 changesStream 事件，可能会导致版本被错误删除。
* 撤销 https://github.com/cnpm/cnpmcore/pull/352 的变更，我们已在 https://github.com/cnpm/cnpmcore/pull/361 中解决了事件实时性问题

------------

> Concurrent execution of the same task with changesStream events may cause versions to be deleted incorrectly.
* revert https://github.com/cnpm/cnpmcore/pull/352, since we have fixed in https://github.com/cnpm/cnpmcore/pull/361


