### PR TITLE
fix: changesStream suspend

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { readFile } from 'fs/promises';
 import { Application } from 'egg';
+import { ChangesStreamService } from './app/core/service/ChangesStreamService';
 declare module 'egg' {
   interface Application {
     binaryHTML: string;
@@ -26,10 +27,7 @@ export default class CnpmcoreAppHook {
   // 应用退出时执行
   // 需要暂停当前执行的 changesStream task
   async beforeClose() {
-    await this.app.runInAnonymousContextScope(async ctx => {
-      await ctx.beginModuleScope(async () => {
-        await ctx.module.cnpmcoreCore.changesStreamService.suspendTaskWhenExit();
-      });
-    });
+    const changesStreamService = await this.app.getEggObject(ChangesStreamService);
+    await changesStreamService.suspendTaskWhenExit();
   }
 }

--- a/app/core/typing.ts
+++ b/app/core/typing.ts
@@ -1,5 +1,0 @@
-import { ChangesStreamService } from './service/ChangesStreamService';
-
-export interface ContextCnpmcore {
-  changesStreamService: ChangesStreamService;
-}


### PR DESCRIPTION
> https://github.com/cnpm/cnpmcore/pull/367 tegg-v3 升级后，service 改为 Singleton，无法通过 ctx 上下文获取
* 修改 app 内 Service 获取方式
* 移除废弃的 typing.ts 声明

------------

> https://github.com/cnpm/cnpmcore/pull/367 Service has been refactored to Singleton in tegg-v3 , which can't be inited with context anymore.
* Update Service init logic in appHook
* Remove the deprecated typing.ts

![image](https://user-images.githubusercontent.com/5574625/218919092-4a6b7353-7234-47f4-af99-9bf16846c2f1.png)

