### PR TITLE
feat: retry changes task when current work error

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -28,6 +28,6 @@ export default class CnpmcoreAppHook {
   // 需要暂停当前执行的 changesStream task
   async beforeClose() {
     const changesStreamService = await this.app.getEggObject(ChangesStreamService);
-    await changesStreamService.suspendTaskWhenExit();
+    await changesStreamService.suspendSync(true);
   }
 }


### PR DESCRIPTION
> 当前请求 changesStream 失败时，需等待 15 分钟超时调度。
* 原 suspendTaskWhenExit 重构为 suspendSync ，支持传入 exit 参数，控制是否继续等待
* 请求 changesStream 失败时，主动挂起任务

------

> Wait 15 minutes for timeout scheduling if the current request changesStream fails
* `suspendTaskWhenExit` is refactored to `suspendSync`, add exit parameter to control whether to exiting the queue
* Suspend task when request changesStream fails
