### PR TITLE
test: use @cnpmjs/npm-cli-login instead of npm-cli-login

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "eslint": "^8.29.0",
     "eslint-config-egg": "^12.1.0",
     "git-contributor": "2",
-    "npm-cli-login": "^1.0.0",
+    "@cnpmjs/npm-cli-login": "^1.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"
   },


### PR DESCRIPTION
skip snyk download

```
[09:07:45] [4/4] scripts.postinstall npm-cli-login@1.0.0 › snyk@^1.124.1 run "node wrapper_dist/bootstrap.js exec", root: "/root/workspace/npmmirror-registry_main/node_modules/_snyk@1.1117.0@snyk"
[09:07:45] Downloading from 'https://static.snyk.io/cli/v1.1117.0/snyk-linux' to '/root/workspace/npmmirror-registry_main/node_modules/_snyk@1.1117.0@snyk/wrapper_dist/snyk-linux'
```