### PR TITLE
feat: redirect not found can be false when syncMode='none'

### DIFF
--- a/app/port/controller/AbstractController.ts
+++ b/app/port/controller/AbstractController.ts
@@ -106,7 +106,11 @@ export abstract class AbstractController extends MiddlewareController {
     if (!this.isPrivateScope(scope)) {
       // syncMode = none, redirect public package to source registry
       if (!this.enableSync) {
-        err.redirectToSourceRegistry = this.sourceRegistry;
+        if (this.redirectNotFound) {
+          err.redirectToSourceRegistry = this.sourceRegistry;
+        } else {
+          return err;
+        }
       // syncMode = all/exist
       } else {
         if (allowSync && this.syncNotFound) {

--- a/app/port/controller/AbstractController.ts
+++ b/app/port/controller/AbstractController.ts
@@ -108,11 +108,9 @@ export abstract class AbstractController extends MiddlewareController {
       if (!this.enableSync) {
         if (this.redirectNotFound) {
           err.redirectToSourceRegistry = this.sourceRegistry;
-        } else {
-          return err;
         }
-      // syncMode = all/exist
       } else {
+        // syncMode = all/exist
         if (allowSync && this.syncNotFound) {
           // ErrorHandler will use syncPackage to create sync task
           err.syncPackage = {

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -81,7 +81,7 @@ export default (appInfo: EggAppConfig) => {
     enableNpmClientAndVersionCheck: true,
     // sync when package not found, only effect when syncMode = all/exist
     syncNotFound: false,
-    // redirect to source registry when package not found, only effect when syncMode = all/exist
+    // redirect to source registry when package not found
     redirectNotFound: true,
   };
 

--- a/test/port/controller/package/ShowPackageController.test.ts
+++ b/test/port/controller/package/ShowPackageController.test.ts
@@ -718,6 +718,15 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
       assert(res.headers.location === 'https://registry.npmjs.org/@eggjs/tegg-metadata?t=0123123&foo=bar');
     });
 
+    it('should not redirect to source registry when redirectNotFound is false and sync mode is none', async () => {
+      mock(app.config.cnpmcore, 'syncMode', 'none');
+      mock(app.config.cnpmcore, 'redirectNotFound', false);
+      const res = await app.httpRequest()
+        .get('/@eggjs/tegg-metadata')
+        .set('Accept', 'application/vnd.npm.install-v1+json');
+      assert(res.status === 404);
+    });
+
     it('should redirect public non-scope package to source registry if package not exists when syncMode=none', async () => {
       mock(app.config.cnpmcore, 'syncMode', 'none');
       let res = await app.httpRequest()


### PR DESCRIPTION
> 在禁止自动创建同步任务时也可以关闭 redirectNotFound，实现在私有化部署时用户仅能使用当前仓库内已有的依赖

--------------

> Allow to turn off redirectNotFound when disabling the automatic creation of sync tasks, enabling users to use only existing dependencies in the current repository when deploying privately.