### PR TITLE
fix: timeout handler not work

### DIFF
--- a/app/repository/util/ModelConvertor.ts
+++ b/app/repository/util/ModelConvertor.ts
@@ -61,12 +61,14 @@ export class ModelConvertor {
       const modelPropertyName = attributeMeta.propertyName;
       const entityPropertyName = ModelConvertorUtil.getEntityPropertyName(ModelClazz, modelPropertyName);
       if (entityPropertyName === CREATED_AT) continue;
+      // Restricted updates to the primary key
+      if (entityPropertyName === ID && model[ID]) continue;
       const attributeValue = _.get(entity, entityPropertyName);
       model[modelPropertyName] = attributeValue;
     }
 
-    // 不允许设置 UPDATED_AT
-    // 通过 leoric 进行更新
+    // Restricted updates to the UPDATED_AT
+    // Leoric will set by default
     model[UPDATED_AT] = undefined;
     await model.save(options);
     entity[UPDATED_AT] = model[UPDATED_AT];

--- a/test/schedule/TaskTimeoutHandler.test.ts
+++ b/test/schedule/TaskTimeoutHandler.test.ts
@@ -1,10 +1,4 @@
-import { app, mock } from 'egg-mock/bootstrap';
-import { TaskState } from 'app/common/enum/Task';
-import { PackageSyncerService } from 'app/core/service/PackageSyncerService';
-import { HistoryTask } from '../../app/repository/model/HistoryTask';
-import { ModelConvertor } from '../../app/repository/util/ModelConvertor';
-import { Task as TaskModel } from '../../app/repository/model/Task';
-import { TaskService } from '../../app/core/service/TaskService';
+import { app } from 'egg-mock/bootstrap';
 
 const TaskTimeoutHandlerPath = require.resolve('../../app/port/schedule/TaskTimeoutHandler');
 
@@ -15,50 +9,5 @@ describe('test/schedule/TaskTimeoutHandler.test.ts', () => {
     app.expectLog('[TaskTimeoutHandler:subscribe] retry execute timeout tasks: {"processing":0,"waiting":0}');
     // again should work
     await app.runSchedule(TaskTimeoutHandlerPath);
-  });
-
-  it('should skip task when retry error', async () => {
-
-    const packageSyncerService = await app.getEggObject(PackageSyncerService);
-
-    const apple = await packageSyncerService.createTask('apple');
-    const banana = await packageSyncerService.createTask('banana');
-
-    // mock timeout 10mins
-    await TaskModel.update({ id: apple.id }, {
-      updatedAt: new Date(apple.updatedAt.getTime() - 60000 * 30 - 1),
-      state: TaskState.Processing,
-    });
-    await TaskModel.update({ id: banana.id }, {
-      updatedAt: new Date(banana.updatedAt.getTime() - 60000 * 40),
-    });
-
-    app.mockLog();
-    mock(TaskService.prototype, 'retryTask', async () => {
-      throw new Error('aba aba');
-    });
-    await app.runSchedule(TaskTimeoutHandlerPath);
-    app.expectLog('[TaskService.retryExecuteTimeoutTasks:error] processing task');
-    app.expectLog('[TaskService.retryExecuteTimeoutTasks:error] waiting task');
-  });
-
-  it('should modify history task', async () => {
-
-    const packageSyncerService = await app.getEggObject(PackageSyncerService);
-
-    await packageSyncerService.createTask('boo');
-    const task = await packageSyncerService.createTask('foo');
-
-    // mock task has been finished success
-    await ModelConvertor.convertEntityToModel({ ...task, state: TaskState.Success, id: 9527 }, HistoryTask);
-
-    // mock timeout 10mins
-    await TaskModel.update({ id: task.id }, {
-      updatedAt: new Date(task.updatedAt.getTime() - 60000 * 30 - 1),
-    });
-
-    app.mockLog();
-    await app.runSchedule(TaskTimeoutHandlerPath);
-    app.expectLog('[TaskTimeoutHandler:subscribe] retry execute timeout tasks');
   });
 });

--- a/test/schedule/TaskTimeoutHandler.test.ts
+++ b/test/schedule/TaskTimeoutHandler.test.ts
@@ -1,4 +1,10 @@
-import { app } from 'egg-mock/bootstrap';
+import { app, mock } from 'egg-mock/bootstrap';
+import { TaskState } from 'app/common/enum/Task';
+import { PackageSyncerService } from 'app/core/service/PackageSyncerService';
+import { HistoryTask } from '../../app/repository/model/HistoryTask';
+import { ModelConvertor } from '../../app/repository/util/ModelConvertor';
+import { Task as TaskModel } from '../../app/repository/model/Task';
+import { TaskService } from '../../app/core/service/TaskService';
 
 const TaskTimeoutHandlerPath = require.resolve('../../app/port/schedule/TaskTimeoutHandler');
 
@@ -9,5 +15,50 @@ describe('test/schedule/TaskTimeoutHandler.test.ts', () => {
     app.expectLog('[TaskTimeoutHandler:subscribe] retry execute timeout tasks: {"processing":0,"waiting":0}');
     // again should work
     await app.runSchedule(TaskTimeoutHandlerPath);
+  });
+
+  it('should skip task when retry error', async () => {
+
+    const packageSyncerService = await app.getEggObject(PackageSyncerService);
+
+    const apple = await packageSyncerService.createTask('apple');
+    const banana = await packageSyncerService.createTask('banana');
+
+    // mock timeout 10mins
+    await TaskModel.update({ id: apple.id }, {
+      updatedAt: new Date(apple.updatedAt.getTime() - 60000 * 30 - 1),
+      state: TaskState.Processing,
+    });
+    await TaskModel.update({ id: banana.id }, {
+      updatedAt: new Date(banana.updatedAt.getTime() - 60000 * 40),
+    });
+
+    app.mockLog();
+    mock(TaskService.prototype, 'retryTask', async () => {
+      throw new Error('aba aba');
+    });
+    await app.runSchedule(TaskTimeoutHandlerPath);
+    app.expectLog('[TaskService.retryExecuteTimeoutTasks:error] processing task');
+    app.expectLog('[TaskService.retryExecuteTimeoutTasks:error] waiting task');
+  });
+
+  it('should modify history task', async () => {
+
+    const packageSyncerService = await app.getEggObject(PackageSyncerService);
+
+    await packageSyncerService.createTask('boo');
+    const task = await packageSyncerService.createTask('foo');
+
+    // mock task has been finished success
+    await ModelConvertor.convertEntityToModel({ ...task, state: TaskState.Success, id: 9527 }, HistoryTask);
+
+    // mock timeout 10mins
+    await TaskModel.update({ id: task.id }, {
+      updatedAt: new Date(task.updatedAt.getTime() - 60000 * 30 - 1),
+    });
+
+    app.mockLog();
+    await app.runSchedule(TaskTimeoutHandlerPath);
+    app.expectLog('[TaskTimeoutHandler:subscribe] retry execute timeout tasks');
   });
 });


### PR DESCRIPTION
> 💥 TaskTimeoutHandler did not have try-catch, the redis lock will cause all queues to fail when a single task update failed.

* 🛡️ Added try-catch statements in TaskTimeoutHandler.
* 🚧 Restricted updates to the primary key when updating the model in ModelConvertor.

---------------

> 💥 TaskTimeoutHandler 未添加 try-catch，且有同步锁，导致单个任务更新异常时，所有队列不生效

* 🛡️ TaskTimeoutHandler 统一添加 try-catch
* 🚧 ModelConvertor 更新模型时，统一限制不允许更新主键