### PR TITLE
fix: update webauth default URL to registry

### DIFF
--- a/app/infra/AuthAdapter.ts
+++ b/app/infra/AuthAdapter.ts
@@ -32,9 +32,12 @@ export class AuthAdapter implements AuthClient {
   async getAuthUrl(ctx: EggContext): Promise<AuthUrlResult> {
     const sessionId = randomUUID();
     await this.redis.setex(sessionId, ONE_DAY, '');
+
+    // INTEGRATE.md
+    const registry = ctx.app.config.cnpmcore.registry;
     return {
-      loginUrl: `${ctx.href}/request/session/${sessionId}`,
-      doneUrl: `${ctx.href}/done/session/${sessionId}`,
+      loginUrl: `${registry}/-/v1/login/request/session/${sessionId}`,
+      doneUrl: `${registry}/-/v1/login/done/session/${sessionId}`,
     };
   }
 


### PR DESCRIPTION
默认自带的`authUrl` 更新为配置为 `registry` 会更合理，这里更多考虑到私有部署的情况下一般会有多层反向代理，直接使用 `ctx.href` 意义不大