### PR TITLE
fix: init sync spec registry

### DIFF
--- a/app/core/service/PackageSyncerService.ts
+++ b/app/core/service/PackageSyncerService.ts
@@ -308,7 +308,7 @@ export class PackageSyncerService extends AbstractService {
   // 1. 其次从 task.data.registryId (创建单包同步任务时传入)
   // 2. 接着根据 scope 进行计算 (作为子包依赖同步时候，无 registryId)
   // 3. 最后返回 default registryId (可能 default registry 也不存在)
-  public async initSpecRegistry(task: Task, pkg: Package | null = null): Promise<Registry | null> {
+  public async initSpecRegistry(task: Task, pkg: Package | null = null, scope?: string): Promise<Registry | null> {
     const registryId = pkg?.registryId || (task.data as SyncPackageTaskOptions).registryId;
     let targetHost: string = this.config.cnpmcore.sourceRegistry;
     let registry: Registry | null = null;
@@ -317,8 +317,8 @@ export class PackageSyncerService extends AbstractService {
     // 历史 Task 可能没有配置 registryId
     if (registryId) {
       registry = await this.registryManagerService.findByRegistryId(registryId);
-    } else if (pkg?.scope) {
-      const scopeModel = await this.scopeManagerService.findByName(pkg?.scope);
+    } else if (scope) {
+      const scopeModel = await this.scopeManagerService.findByName(scope);
       if (scopeModel?.registryId) {
         registry = await this.registryManagerService.findByRegistryId(scopeModel?.registryId);
       }
@@ -349,7 +349,7 @@ export class PackageSyncerService extends AbstractService {
     const [ scope, name ] = getScopeAndName(fullname);
     const { tips, skipDependencies: originSkipDependencies, syncDownloadData, forceSyncHistory } = task.data as SyncPackageTaskOptions;
     let pkg = await this.packageRepository.findPackage(scope, name);
-    const registry = await this.initSpecRegistry(task, pkg);
+    const registry = await this.initSpecRegistry(task, pkg, scope);
     const registryHost = this.npmRegistry.registry;
     let logs: string[] = [];
     if (tips) {

--- a/test/core/service/PackageSyncerService/getTaskRegistry.test.ts
+++ b/test/core/service/PackageSyncerService/getTaskRegistry.test.ts
@@ -34,7 +34,7 @@ describe('test/core/service/PackageSyncerService/getTaskRegistry.test.ts', () =>
 
   describe('getTaskRegistry()', () => {
     it('should work', async () => {
-      const taskRegistry = await packageSyncerService.initSpecRegistry(task);
+      const taskRegistry = await packageSyncerService.initSpecRegistry(task, null, '@cnpm');
       assert(taskRegistry);
       assert(taskRegistry.registryId === registry.registryId);
     });
@@ -46,7 +46,7 @@ describe('test/core/service/PackageSyncerService/getTaskRegistry.test.ts', () =>
         tips: `Sync cause by changes_stream(${registry.changeStream}) update seq: 1`,
       });
 
-      const taskRegistry = await packageSyncerService.initSpecRegistry(task);
+      const taskRegistry = await packageSyncerService.initSpecRegistry(task, null, '@cnpm');
       assert(taskRegistry === null);
     });
   });


### PR DESCRIPTION
> Fixed the issue where the registry was not correctly matched when synchronizing scoped packages for the first time
* Add scope params in initSpecRegistry
------------
> 修复初次同步 scope 包，未正确匹配 registry 的问题
* 修改 initSpecRegistry 方法，统一传入 scope 参数

