### PR TITLE
feat: support npm access command

### DIFF
--- a/app/common/constants.ts
+++ b/app/common/constants.ts
@@ -17,3 +17,8 @@ export enum PresetRegistryName {
   default = 'default',
   self = 'self',
 }
+
+export enum PackageAccessLevel {
+  write = 'write',
+  read = 'read',
+}

--- a/app/port/controller/AccessController.ts
+++ b/app/port/controller/AccessController.ts
@@ -33,7 +33,7 @@ export class AccessController extends AbstractController {
   }
 
   @HTTPMethod({
-    path: `/-/org/:username/package`,
+    path: '/-/org/:username/package',
     method: HTTPMethodEnum.GET,
   })
   async listPackagesByUser(@HTTPParam() username: string) {

--- a/app/port/controller/AccessController.ts
+++ b/app/port/controller/AccessController.ts
@@ -1,0 +1,59 @@
+import {
+  HTTPController,
+  HTTPMethod,
+  HTTPMethodEnum,
+  HTTPParam,
+} from '@eggjs/tegg';
+import { AbstractController } from './AbstractController';
+import { FULLNAME_REG_STRING, getScopeAndName } from '../../common/PackageUtil';
+import { PackageAccessLevel } from '../../common/constants';
+import { ForbiddenError, NotFoundError } from 'egg-errors';
+
+
+@HTTPController()
+export class AccessController extends AbstractController {
+  @HTTPMethod({
+    path: `/-/package/:fullname(${FULLNAME_REG_STRING})/collaborators`,
+    method: HTTPMethodEnum.GET,
+  })
+  async listCollaborators(@HTTPParam() fullname: string) {
+    const [ scope, name ] = getScopeAndName(fullname);
+    const pkg = await this.packageRepository.findPackage(scope, name);
+
+    // return 403 if pkg not exists
+    if (!pkg) {
+      throw new ForbiddenError('Forbidden');
+    }
+
+    const maintainers = await this.packageRepository.listPackageMaintainers(pkg!.packageId);
+    const res: Record<string, string> = {};
+    maintainers.forEach(maintainer => {
+      res[maintainer.displayName] = PackageAccessLevel.write;
+    });
+
+    return res;
+  }
+
+  @HTTPMethod({
+    path: `/-/org/:username/package`,
+    method: HTTPMethodEnum.GET,
+  })
+  async listUserPackages(@HTTPParam() username: string) {
+    const user = await this.userRepository.findUserByName(username);
+    if (!user) {
+      throw new NotFoundError(`User "${username}" not found`);
+    }
+
+    const pkgs = await this.packageRepository.listPackagesByUserId(user.userId);
+
+    const res: Record<string, string> = {};
+
+    pkgs.forEach(pkg => {
+      res[pkg.name] = PackageAccessLevel.write;
+    });
+
+    return res;
+  }
+
+
+}

--- a/test/TestUtil.ts
+++ b/test/TestUtil.ts
@@ -1,4 +1,5 @@
 import fs from 'fs/promises';
+import coffee from 'coffee';
 import { tmpdir } from 'os';
 import { rmSync, mkdtempSync } from 'fs';
 import { Readable } from 'stream';
@@ -52,6 +53,11 @@ export class TestUtil {
 
   static getDatabase() {
     return process.env.MYSQL_DATABASE || 'cnpmcore_unittest';
+  }
+
+  static async getNpmVersion() {
+    const res = await coffee.spawn('npm', [ '-v' ]).end();
+    return semver.clean(res.stdout);
   }
 
   static async getTableSqls(): Promise<string> {

--- a/test/cli/npm/access.test.ts
+++ b/test/cli/npm/access.test.ts
@@ -1,0 +1,121 @@
+// import assert from 'assert';
+import path from 'path';
+import { app } from 'egg-mock/bootstrap';
+import coffee from 'coffee';
+import { TestUtil } from 'test/TestUtil';
+import { npmLogin } from '../CliUtil';
+
+describe('test/cli/npm/access.test.ts', () => {
+  let server;
+  let registry;
+  let fooPkgDir;
+  let demoDir;
+  let userconfig;
+  let cacheDir;
+  before(async () => {
+    cacheDir = TestUtil.mkdtemp();
+    fooPkgDir = TestUtil.getFixtures('@cnpm/foo');
+    demoDir = TestUtil.getFixtures('demo');
+    userconfig = path.join(fooPkgDir, '.npmrc');
+    TestUtil.rm(userconfig);
+    TestUtil.rm(path.join(demoDir, 'node_modules'));
+
+    return new Promise(resolve => {
+      server = app.listen(0, () => {
+        registry = `http://localhost:${server.address().port}`;
+        console.log(`registry ${registry} ready`);
+        resolve();
+      });
+    });
+  });
+
+  after(() => {
+    TestUtil.rm(userconfig);
+    TestUtil.rm(cacheDir);
+    TestUtil.rm(path.join(demoDir, 'node_modules'));
+    server && server.close();
+  });
+
+  beforeEach(async () => {
+    await npmLogin(registry, userconfig);
+    await coffee
+      .spawn('npm', [
+        'publish',
+        `--registry=${registry}`,
+        `--userconfig=${userconfig}`,
+        `--cache=${cacheDir}`,
+      ], {
+        cwd: fooPkgDir,
+      })
+      .debug()
+      .expect('code', 0)
+      .end();
+  });
+
+  describe('npm access', () => {
+
+    it('should work for list collaborators', async () => {
+      await coffee
+        .spawn('npm', [
+          'access',
+          'list',
+          'collaborators',
+          '@cnpm/foo',
+          `--registry=${registry}`,
+          `--userconfig=${userconfig}`,
+          `--cache=${cacheDir}`,
+          // '--json',
+        ], {
+          cwd: demoDir,
+        })
+        .debug()
+        .expect('stdout', /testuser: read-write/)
+        .expect('code', 0)
+        .end();
+
+    });
+
+    it('should work for list all packages', async () => {
+      await coffee
+        .spawn('npm', [
+          'access',
+          'list',
+          'packages',
+          'testuser',
+          `--registry=${registry}`,
+          `--userconfig=${userconfig}`,
+          `--cache=${cacheDir}`,
+          // '--json',
+        ], {
+          cwd: demoDir,
+        })
+        .debug()
+        .expect('stdout', /@cnpm\/foo: read-write/)
+        .expect('code', 0)
+        .end();
+
+    });
+
+    it('should work for list single package', async () => {
+      await coffee
+        .spawn('npm', [
+          'access',
+          'list',
+          'packages',
+          'testuser',
+          '@cnpm/foo',
+          `--registry=${registry}`,
+          `--userconfig=${userconfig}`,
+          `--cache=${cacheDir}`,
+          // '--json',
+        ], {
+          cwd: demoDir,
+        })
+        .debug()
+        .expect('stdout', /@cnpm\/foo: read-write/)
+        .expect('code', 0)
+        .end();
+
+    });
+  });
+});

--- a/test/cli/npm/access.test.ts
+++ b/test/cli/npm/access.test.ts
@@ -19,23 +19,23 @@ describe('test/cli/npm/access.test.ts', () => {
     fooPkgDir = TestUtil.getFixtures('@cnpm/foo');
     demoDir = TestUtil.getFixtures('demo');
     userconfig = path.join(fooPkgDir, '.npmrc');
-    TestUtil.rm(userconfig);
-    TestUtil.rm(path.join(demoDir, 'node_modules'));
+    await TestUtil.rm(userconfig);
+    await TestUtil.rm(path.join(demoDir, 'node_modules'));
     const npmVersion = await TestUtil.getNpmVersion();
     useLegacyCommands = semver.lt(String(npmVersion), '9.0.0');
-    return new Promise(resolve => {
+    await new Promise(resolve => {
       server = app.listen(0, () => {
         registry = `http://localhost:${server.address().port}`;
         console.log(`registry ${registry} ready`);
-        resolve();
+        resolve(void 0);
       });
     });
   });
 
-  after(() => {
-    TestUtil.rm(userconfig);
-    TestUtil.rm(cacheDir);
-    TestUtil.rm(path.join(demoDir, 'node_modules'));
+  after(async () => {
+    await TestUtil.rm(userconfig);
+    await TestUtil.rm(cacheDir);
+    await TestUtil.rm(path.join(demoDir, 'node_modules'));
     server && server.close();
   });
 
@@ -72,7 +72,7 @@ describe('test/cli/npm/access.test.ts', () => {
           cwd: demoDir,
         })
         .debug()
-        .expect('stdout', /testuser: read-write/)
+        .expect('stdout', /testuser:\sread-write|\"testuser\":\s\"read-write\"/)
         .expect('code', 0)
         .end();
 
@@ -93,7 +93,7 @@ describe('test/cli/npm/access.test.ts', () => {
           cwd: demoDir,
         })
         .debug()
-        .expect('stdout', /@cnpm\/foo: read-write/)
+        .expect('stdout', /@cnpm\/foo: read-write|\"@cnpm\/foo\":\s\"read-write"/)
         .expect('code', 0)
         .end();
 

--- a/test/cli/npm/install.test.ts
+++ b/test/cli/npm/install.test.ts
@@ -17,22 +17,22 @@ describe('test/cli/npm/install.test.ts', () => {
     fooPkgDir = TestUtil.getFixtures('@cnpm/foo');
     demoDir = TestUtil.getFixtures('demo');
     userconfig = path.join(fooPkgDir, '.npmrc');
-    TestUtil.rm(userconfig);
-    TestUtil.rm(path.join(demoDir, 'node_modules'));
+    await TestUtil.rm(userconfig);
+    await TestUtil.rm(path.join(demoDir, 'node_modules'));
 
-    return new Promise(resolve => {
+    await new Promise(resolve => {
       server = app.listen(0, () => {
         registry = `http://localhost:${server.address().port}`;
         console.log(`registry ${registry} ready`);
-        resolve();
+        resolve(void 0);
       });
     });
   });
 
-  after(() => {
-    TestUtil.rm(userconfig);
-    TestUtil.rm(cacheDir);
-    TestUtil.rm(path.join(demoDir, 'node_modules'));
+  after(async () => {
+    await TestUtil.rm(userconfig);
+    await TestUtil.rm(cacheDir);
+    await TestUtil.rm(path.join(demoDir, 'node_modules'));
     server && server.close();
   });
 

--- a/test/port/controller/AccessController/listCollaborators.test.ts
+++ b/test/port/controller/AccessController/listCollaborators.test.ts
@@ -27,7 +27,7 @@ describe('test/port/controller/AccessController/listCollaborators.test.ts', () =
 
 
       // create pkg
-      const pkg = await TestUtil.getFullPackage({ name: '@cnpm/banana'});
+      const pkg = await TestUtil.getFullPackage({ name: '@cnpm/banana' });
       const createRes = await app.httpRequest()
         .put(`/${pkg.name}`)
         .set('authorization', owner.authorization)
@@ -40,15 +40,15 @@ describe('test/port/controller/AccessController/listCollaborators.test.ts', () =
 
       // updateMaintainers
       await app.httpRequest()
-      .put(`/${pkg.name}/-rev/${rev}`)
-      .set('authorization', owner.authorization)
-      .set('user-agent', owner.ua)
-      .set('npm-command', 'owner')
-      .send({
-        ...pkg,
-        maintainers: [{ name: maintainer.name, email: maintainer.email }, { name: owner.name, email: owner.email }],
-      })
-      .expect(200);
+        .put(`/${pkg.name}/-rev/${rev}`)
+        .set('authorization', owner.authorization)
+        .set('user-agent', owner.ua)
+        .set('npm-command', 'owner')
+        .send({
+          ...pkg,
+          maintainers: [{ name: maintainer.name, email: maintainer.email }, { name: owner.name, email: owner.email }],
+        })
+        .expect(200);
 
       const res = await app.httpRequest()
         .get(`/-/package/${pkg.name}/collaborators`)

--- a/test/port/controller/AccessController/listCollaborators.test.ts
+++ b/test/port/controller/AccessController/listCollaborators.test.ts
@@ -1,0 +1,62 @@
+import assert from 'assert';
+import { app } from 'egg-mock/bootstrap';
+import { TestUtil } from 'test/TestUtil';
+
+describe('test/port/controller/AccessController/listCollaborators.test.ts', () => {
+  describe('[GET /-/package/:fullname/collaborators] listCollaborators()', () => {
+
+    it('should work', async () => {
+      const { pkg } = await TestUtil.createPackage({ version: '1.0.0' }, { name: 'banana-owner' });
+      const res = await app.httpRequest()
+        .get(`/-/package/${pkg.name}/collaborators`)
+        .expect(200);
+
+      assert(res.body['banana-owner'] === 'write');
+    });
+
+    it('should 403 when pkg not exists', async () => {
+      const res = await app.httpRequest()
+        .get('/-/package/banana/collaborators')
+        .expect(403);
+      assert.equal(res.body.error, '[FORBIDDEN] Forbidden');
+    });
+
+    it('should refresh when maintainer updated', async () => {
+      const owner = await TestUtil.createUser({ name: 'banana-owner' });
+      const maintainer = await TestUtil.createUser({ name: 'banana-maintainer' });
+
+
+      // create pkg
+      const pkg = await TestUtil.getFullPackage({ name: '@cnpm/banana'});
+      const createRes = await app.httpRequest()
+        .put(`/${pkg.name}`)
+        .set('authorization', owner.authorization)
+        .set('user-agent', owner.ua)
+        .send(pkg)
+        .expect(201);
+      assert.equal(createRes.body.ok, true);
+      assert.match(createRes.body.rev, /^\d+\-\w{24}$/);
+      const rev = createRes.body.rev;
+
+      // updateMaintainers
+      await app.httpRequest()
+      .put(`/${pkg.name}/-rev/${rev}`)
+      .set('authorization', owner.authorization)
+      .set('user-agent', owner.ua)
+      .set('npm-command', 'owner')
+      .send({
+        ...pkg,
+        maintainers: [{ name: maintainer.name, email: maintainer.email }, { name: owner.name, email: owner.email }],
+      })
+      .expect(200);
+
+      const res = await app.httpRequest()
+        .get(`/-/package/${pkg.name}/collaborators`)
+        .expect(200);
+
+      assert(res.body['banana-owner'] === 'write');
+      assert(res.body['banana-maintainer'] === 'write');
+    });
+
+  });
+});

--- a/test/port/controller/AccessController/listPackagesByUser.test.ts
+++ b/test/port/controller/AccessController/listPackagesByUser.test.ts
@@ -8,7 +8,7 @@ describe('test/port/controller/AccessController/listPackagesByUser.test.ts', () 
     it('should work', async () => {
       const { pkg } = await TestUtil.createPackage({ version: '1.0.0' }, { name: 'banana' });
       const res = await app.httpRequest()
-        .get(`/-/org/banana/package`)
+        .get('/-/org/banana/package')
         .expect(200);
 
       assert.equal(res.body[pkg.name], 'write');

--- a/test/port/controller/AccessController/listPackagesByUser.test.ts
+++ b/test/port/controller/AccessController/listPackagesByUser.test.ts
@@ -1,0 +1,25 @@
+import assert from 'assert';
+import { app } from 'egg-mock/bootstrap';
+import { TestUtil } from 'test/TestUtil';
+
+describe('test/port/controller/AccessController/listPackagesByUser.test.ts', () => {
+  describe('[GET /-/org/:username/package] listPackagesByUser()', () => {
+
+    it('should work', async () => {
+      const { pkg } = await TestUtil.createPackage({ version: '1.0.0' }, { name: 'banana' });
+      const res = await app.httpRequest()
+        .get(`/-/org/banana/package`)
+        .expect(200);
+
+      assert.equal(res.body[pkg.name], 'write');
+    });
+
+    it('should 404 when user not exists', async () => {
+      const res = await app.httpRequest()
+        .get('/-/org/banana-disappear/package')
+        .expect(404);
+      assert.equal(res.body.error, '[NOT_FOUND] User "banana-disappear" not found');
+    });
+
+  });
+});


### PR DESCRIPTION
> Supports partial npm access query commands. https://github.com/cnpm/cnpmcore/issues/64

* The following commands are supported:
  * `npm access list packages [<user>|<scope>|<scope:team> [<package>]`
  * `npm access list collaborators [<package> [<user>]]`
* Added `/-/package/:fullname/collaborators` and `/-/org/:username/package` interfaces.
* Error code logic is consistent with the npm registry.

--------------

> 支持部分 npm access 查询命令 https://github.com/cnpm/cnpmcore/issues/64
* 支持如下命令:
  * `npm access list packages [<user>|<scope>|<scope:team> [<package>]`
  * `npm access list collaborators [<package> [<user>]]`
* 新增 `/-/package/:fullname/collaborators` 及 `/-/org/:username/package`  接口
* 错误码逻辑和 npm registry 保持一致