### PR TITLE
fix: cnpmcore publish time

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,11 +3,7 @@
 
 name: Node.js CI
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   test-mysql57-fs-nfs:

--- a/.github/workflows/sql-review.yml
+++ b/.github/workflows/sql-review.yml
@@ -2,7 +2,7 @@
 
 name: SQL Review
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   sql-review:

--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -134,8 +134,8 @@ export class PackageManagerService extends AbstractService {
     const publishTime = cmd.publishTime || new Date();
 
     // add _cnpmcore_publish_time field to cmd.packageJson
-    if (!cmd.packageJson._cnpmcore_publish_time) {
-      cmd.packageJson._cnpmcore_publish_time = publishTime;
+    if (typeof cmd.packageJson._cnpmcore_publish_time !== 'number') {
+      cmd.packageJson._cnpmcore_publish_time = publishTime.getTime();
     }
     if (!cmd.packageJson.publish_time) {
       cmd.packageJson.publish_time = publishTime.getTime();

--- a/test/port/controller/package/ShowPackageController.test.ts
+++ b/test/port/controller/package/ShowPackageController.test.ts
@@ -237,7 +237,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
       const versionOne = pkg.versions['1.0.0'];
       assert(versionOne.dist.unpackedSize === 6497043);
       assert(versionOne._cnpmcore_publish_time);
-      assert.equal(typeof versionOne._cnpmcore_publish_time, 'string');
+      assert.equal(typeof versionOne._cnpmcore_publish_time, 'number');
       assert(versionOne.publish_time);
       assert.equal(typeof versionOne.publish_time, 'number');
       assert(pkg._id === scopedName);


### PR DESCRIPTION
> Fix the data type of the _cnpmcore_publish_time field to timestamp to align it with other fields.

* 🤖 Modify the CI configuration to trigger only on push events
* 📝 Check the _cnpmcore_publish_time field and convert it if it is not a timestamp.
----------

> 修复 _cnpmcore_publish_time 字段类型为时间戳，和其他时间保持一致

* 🤖 调整 CI 配置，改为 `push` 即触发
* 📝 判断 _cnpmcore_publish_time 字段，非时间戳则进行转换

