### PR TITLE
fix: set cache-control default value to "public, max-age=300"

### DIFF
--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -74,9 +74,9 @@ export default (appInfo: EggAppConfig) => {
     enableWebAuthn: false,
     // http response cache control header
     enableCDN: false,
-    // if you are using CDN, can set it to 'max-age=0, s-maxage=120, must-revalidate'
-    // it meaning cache 10s on CDN server and no cache on client side.
-    cdnCacheControlHeader: 'max-age=0, s-maxage=120, must-revalidate',
+    // if you are using CDN, can override it
+    // it meaning cache 300s on CDN server and client side.
+    cdnCacheControlHeader: 'public, max-age=300',
     // if you are using CDN, can set it to 'Accept, Accept-Encoding'
     cdnVaryHeader: 'Accept, Accept-Encoding',
     // store full package version manifests data to database table(package_version_manifests), default is false

--- a/test/port/controller/PackageBlockController/blockPackage.test.ts
+++ b/test/port/controller/PackageBlockController/blockPackage.test.ts
@@ -69,7 +69,7 @@ describe('test/port/controller/PackageBlockController/blockPackage.test.ts', () 
         .get(`/${pkg.name}`);
       assert(res.status === 451);
       assert(!res.headers.etag);
-      assert(res.headers['cache-control'] === 'max-age=0, s-maxage=120, must-revalidate');
+      assert.equal(res.headers['cache-control'], 'public, max-age=300');
       assert(res.body.error);
       assert(res.body.error.startsWith('[UNAVAILABLE_FOR_LEGAL_REASONS] @cnpm/testmodule was blocked, reason: '));
       assert(res.body.error.includes('only for tests again (operator: cnpmcore_admin/'));
@@ -78,7 +78,7 @@ describe('test/port/controller/PackageBlockController/blockPackage.test.ts', () 
         .get(`/${pkg.name}/1.0.0`);
       assert.equal(res.status, 451);
       assert(!res.headers.etag);
-      assert(res.headers['cache-control'] === 'max-age=0, s-maxage=120, must-revalidate');
+      assert.equal(res.headers['cache-control'], 'public, max-age=300');
       assert(res.body.error);
       assert(res.body.error.startsWith('[UNAVAILABLE_FOR_LEGAL_REASONS] @cnpm/testmodule@1.0.0 was blocked, reason: '));
       assert(res.body.error.includes('only for tests again (operator: cnpmcore_admin/'));

--- a/test/port/controller/package/ShowPackageController.test.ts
+++ b/test/port/controller/package/ShowPackageController.test.ts
@@ -265,8 +265,8 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
       assert(pkg._rev);
       assert(versionOne._id);
       assert(versionOne.dist.tarball === `https://registry.example.com/${scopedName}/-/${name}-1.0.0.tgz`);
-      assert(res.headers['cache-control'] === 'max-age=0, s-maxage=120, must-revalidate');
-      assert(res.headers.vary === 'Origin, Accept, Accept-Encoding');
+      assert.equal(res.headers['cache-control'], 'public, max-age=300');
+      assert.equal(res.headers.vary, 'Origin, Accept, Accept-Encoding');
     });
 
     it('should show one package with abbreviated manifests', async () => {
@@ -378,8 +378,8 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
       assert(!pkg._id);
       assert(!versionOne._id);
       assert(versionOne.dist.tarball === `https://registry.example.com/${scopedName}/-/${name}-2.0.0.tgz`);
-      assert(res.headers['cache-control'] === 'max-age=0, s-maxage=120, must-revalidate');
-      assert(res.headers.vary === 'Origin, Accept, Accept-Encoding');
+      assert.equal(res.headers['cache-control'], 'public, max-age=300');
+      assert.equal(res.headers.vary, 'Origin, Accept, Accept-Encoding');
     });
 
     it('should 404 when package not exists on abbreviated manifest', async () => {

--- a/test/port/controller/package/ShowPackageVersionController.test.ts
+++ b/test/port/controller/package/ShowPackageVersionController.test.ts
@@ -174,8 +174,8 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
         .get(`/${pkg.name}/latest`);
       assert(res.status === 200);
       assert(res.body.version === '1.0.0');
-      assert(res.headers['cache-control'] === 'max-age=0, s-maxage=120, must-revalidate');
-      assert(res.headers.vary === 'Origin, Accept, Accept-Encoding');
+      assert.equal(res.headers['cache-control'], 'public, max-age=300');
+      assert.equal(res.headers.vary, 'Origin, Accept, Accept-Encoding');
     });
 
     it('should latest tag with not scoped package', async () => {


### PR DESCRIPTION
follow registry.npmjs.org default value