### PR TITLE
fix: unpublish idempotent

### DIFF
--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -506,6 +506,11 @@ export class PackageManagerService extends AbstractService {
 
   public async unpublishPackage(pkg: Package) {
     const pkgVersions = await this.packageRepository.listPackageVersions(pkg.packageId);
+    // already unpublished
+    if (pkgVersions.length === 0) {
+      this.logger.info('[packageManagerService.unpublishPackage:skip] already unpublished');
+      return;
+    }
     for (const pkgVersion of pkgVersions) {
       await this._removePackageVersionAndDist(pkgVersion);
     }

--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -508,7 +508,7 @@ export class PackageManagerService extends AbstractService {
     const pkgVersions = await this.packageRepository.listPackageVersions(pkg.packageId);
     // already unpublished
     if (pkgVersions.length === 0) {
-      this.logger.info('[packageManagerService.unpublishPackage:skip] already unpublished');
+      this.logger.info(`[packageManagerService.unpublishPackage:skip] ${pkg.packageId} already unpublished`);
       return;
     }
     for (const pkgVersion of pkgVersions) {

--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -504,10 +504,10 @@ export class PackageManagerService extends AbstractService {
     await this.packageRepository.removePackageVersion(pkgVersion);
   }
 
-  public async unpublishPackage(pkg: Package) {
+  public async unpublishPackage(pkg: Package, forceRefresh = false) {
     const pkgVersions = await this.packageRepository.listPackageVersions(pkg.packageId);
     // already unpublished
-    if (pkgVersions.length === 0) {
+    if (pkgVersions.length === 0 && !forceRefresh) {
       this.logger.info(`[packageManagerService.unpublishPackage:skip] ${pkg.packageId} already unpublished`);
       return;
     }
@@ -556,7 +556,7 @@ export class PackageManagerService extends AbstractService {
       return;
     }
     // unpublish
-    await this.unpublishPackage(pkg);
+    await this.unpublishPackage(pkg, true);
   }
 
   public async savePackageTag(pkg: Package, tag: string, version: string, skipEvent = false) {

--- a/test/core/service/PackageSyncerService/executeTask.test.ts
+++ b/test/core/service/PackageSyncerService/executeTask.test.ts
@@ -2215,6 +2215,37 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
           .expect(200);
 
       });
+
+      it('unpublish package idempotent', async () => {
+        app.mockHttpclient('https://registry.npmjs.org/foobar', 'GET', {
+          data: await TestUtil.readFixturesFile('registry.npmjs.org/security-holding-package.json'),
+        });
+        await packageSyncerService.createTask('foobar', { skipDependencies: true });
+        let task = await packageSyncerService.findExecuteTask();
+        assert(task);
+        await packageSyncerService.executeTask(task);
+        assert(!await TaskModel.findOne({ taskId: task.taskId }));
+        assert(await HistoryTaskModel.findOne({ taskId: task.taskId }));
+        const stream = await packageSyncerService.findTaskLog(task);
+        assert(stream);
+        const log = await TestUtil.readStreamToLog(stream);
+        assert(log);
+        // console.log(log);
+        const model = await PackageModel.findOne({ scope: '', name: 'foobar' });
+        assert(model);
+        const versions = await PackageVersion.find({ packageId: model.packageId });
+        assert(versions.length === 0);
+
+        // resync
+        app.mockLog();
+        await packageSyncerService.createTask('foobar', { skipDependencies: true });
+        task = await packageSyncerService.findExecuteTask();
+        await packageSyncerService.executeTask(task);
+        assert(task);
+        app.expectLog('[packageManagerService.unpublishPackage:skip] already unpublished');
+
+
+      });
     });
   });
 });

--- a/test/core/service/PackageSyncerService/executeTask.test.ts
+++ b/test/core/service/PackageSyncerService/executeTask.test.ts
@@ -2242,7 +2242,8 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         task = await packageSyncerService.findExecuteTask();
         await packageSyncerService.executeTask(task);
         assert(task);
-        app.expectLog('[packageManagerService.unpublishPackage:skip] already unpublished');
+        const pkg = await packageRepository.findPackage('', 'foobar');
+        app.expectLog(`[packageManagerService.unpublishPackage:skip] ${pkg?.packageId} already unpublished`);
 
 
       });


### PR DESCRIPTION
> Fixed the idempotent issue during unpublish pkg, which caused repeated triggering of change events and endless sync loops for downstream registries.
* 🐞 Add idempotent check during unpublish; skip when the package has already been unpublished.
-------------
> 修复 unpublish 时未做幂等控制，导致删包时，不断触发 change 事件，下游 registry 不断 sync 导致任务循环
* 🐞 统一在 unpublish 进行幂等判断，如果该包已 unpublish，则跳过
