### PR TITLE
feat: easy config

### DIFF
--- a/INTEGRATE.md
+++ b/INTEGRATE.md
@@ -76,7 +76,21 @@
     }
     ```
 
-3. 修改 `config.default.ts` 文件，可以直接复制 cnpmcore 中的内容
+3. 修改 `config.default.ts` 文件，可以直接覆盖默认配置
+```typescript
+import { SyncMode } from 'cnpmcore/common/constants';
+import { cnpmcoreConfig } from 'cnpmcore/common/config';
+
+export default () => {
+  const config = {};
+  config.cnpmcore = {
+    ...cnpmcoreConfig,
+    enableChangesStream: false,
+    syncMode: SyncMode.all,
+  };
+  return config;
+}
+```
 
 ### 🧑‍🤝‍🧑 集成 cnpmcore
 

--- a/app/common/typing.ts
+++ b/app/common/typing.ts
@@ -1,3 +1,4 @@
+import { cnpmcoreConfig } from '../port/config';
 import { Readable } from 'stream';
 import { IncomingHttpHeaders } from 'http';
 import { EggContext } from '@eggjs/tegg';
@@ -61,4 +62,13 @@ export interface userResult {
 export interface AuthClient {
   getAuthUrl(ctx: EggContext): Promise<AuthUrlResult>;
   ensureCurrentUser(): Promise<userResult | null>;
+}
+
+declare module 'egg' {
+  // eslint-disable-next-line
+  // @ts-ignore
+  // avoid TS2310 Type 'EggAppConfig' recursively references itself as a base type.
+  interface EggAppConfig {
+    cnpmcore: typeof cnpmcoreConfig;
+  }
 }

--- a/app/port/config.ts
+++ b/app/port/config.ts
@@ -1,0 +1,1 @@
+export { cnpmcoreConfig } from '../../config/config.default';

--- a/app/port/controller/HomeController.ts
+++ b/app/port/controller/HomeController.ts
@@ -27,7 +27,7 @@ type LegacyInfo = {
 
 type SiteEnvInfo = {
   sync_model: string;
-  sync_binary: string;
+  sync_binary: boolean;
   instance_start_time: Date;
   node_version: string;
   app_version: string;

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -7,84 +7,153 @@ import { SyncDeleteMode, SyncMode } from '../app/common/constants';
 
 export const cnpmcoreConfig = {
   name: 'cnpm',
+  /**
+   * enable hook or not
+   */
+  hookEnable: false,
+  /**
+   * mac custom hooks count
+   */
   hooksLimit: 20,
+  /**
+   * upstream registry url
+   */
   sourceRegistry: 'https://registry.npmjs.org',
-  // upstream registry is base on `cnpmcore` or not
-  // if your upstream is official npm registry, please turn it off
+  /**
+   * upstream registry is base on `cnpmcore` or not
+   * if your upstream is official npm registry, please turn it off
+   */
   sourceRegistryIsCNpm: false,
+  /**
+   * sync upstream first
+   */
   syncUpstreamFirst: false,
-  // 3 mins
+  /**
+   * sync upstream timeout, default is 3mins
+   */
   sourceRegistrySyncTimeout: 180000,
+  /**
+   * sync task high water size, default is 100
+   */
   taskQueueHighWaterSize: 100,
-  // sync mode
-  //  - none: don't sync npm package
-  //  - admin: don't sync npm package,only admin can create sync task by sync contorller.
-  //  - all: sync all npm packages
-  //  - exist: only sync exist packages, effected when `enableCheckRecentlyUpdated` or `enableChangesStream` is enabled
+  /**
+   * sync mode
+   * - none: don't sync npm package
+   * - admin: don't sync npm package,only admin can create sync task by sync contorller.
+   * - all: sync all npm packages
+   * - exist: only sync exist packages, effected when `enableCheckRecentlyUpdated` or `enableChangesStream` is enabled
+   */
   syncMode: SyncMode.none,
   syncDeleteMode: SyncDeleteMode.delete,
-  hookEnable: false,
   syncPackageWorkerMaxConcurrentTasks: 10,
   triggerHookWorkerMaxConcurrentTasks: 10,
   createTriggerHookWorkerMaxConcurrentTasks: 10,
-  // stop syncing these packages in future
+  /**
+   * stop syncing these packages in future
+   */
   syncPackageBlockList: [] as string[],
-  // check recently from https://www.npmjs.com/browse/updated, if use set changesStreamRegistry to cnpmcore,
-  // maybe you should disable it
+  /**
+   * check recently from https://www.npmjs.com/browse/updated, if use set changesStreamRegistry to cnpmcore,
+   * maybe you should disable it
+   */
   enableCheckRecentlyUpdated: true,
-  // mirror binary, default is false
+  /**
+   * mirror binary, default is false
+   */
   enableSyncBinary: false,
-  // cnpmcore api: https://r.cnpmjs.org/-/binary
+  /**
+   * sync binary source api, default is `${sourceRegistry}/-/binary`
+   */
   syncBinaryFromAPISource: '',
-  // enable sync downloads data from source registry https://github.com/cnpm/cnpmcore/issues/108
-  // all three parameters must be configured at the same time to take effect
+  /**
+   * enable sync downloads data from source registry https://github.com/cnpm/cnpmcore/issues/108
+   * all three parameters must be configured at the same time to take effect
+   */
   enableSyncDownloadData: false,
   syncDownloadDataSourceRegistry: '',
-  syncDownloadDataMaxDate: '', // should be YYYY-MM-DD format
-  // https://github.com/npm/registry-follower-tutorial
+  /**
+   * should be YYYY-MM-DD format
+   */
+  syncDownloadDataMaxDate: '',
+  /**
+   * @see https://github.com/npm/registry-follower-tutorial
+   */
   enableChangesStream: false,
   checkChangesStreamInterval: 500,
   changesStreamRegistry: 'https://replicate.npmjs.com',
-  // handle _changes request mode, default is 'streaming', please set it to 'json' when on cnpmcore registry
+  /**
+   * handle _changes request mode, default is 'streaming', please set it to 'json' when on cnpmcore registry
+   */
   changesStreamRegistryMode: 'streaming',
+  /**
+   * registry url
+   */
   registry: 'http://localhost:7001',
-  // https://docs.npmjs.com/cli/v6/using-npm/config#always-auth npm <= 6
-  // if `alwaysAuth=true`, all api request required access token
+  /**
+   * https://docs.npmjs.com/cli/v6/using-npm/config#always-auth npm <= 6
+   * if `alwaysAuth=true`, all api request required access token
+   */
   alwaysAuth: false,
-  // white scope list
+  /**
+   * white scope list
+   */
   allowScopes: [
     '@cnpm',
     '@cnpmcore',
     '@example',
   ],
-  // allow publish non-scope package, disable by default
+  /**
+   * allow publish non-scope package, disable by default
+   */
   allowPublishNonScopePackage: false,
-  // Public registration is allowed, otherwise only admins can login
+  /**
+   * Public registration is allowed, otherwise only admins can login
+   */
   allowPublicRegistration: true,
-  // default system admins
+  /**
+   * default system admins
+   */
   admins: {
     // name: email
     cnpmcore_admin: 'admin@cnpmjs.org',
   },
-  // use webauthn for login, https://webauthn.guide/
-  // only support platform authenticators, browser support: https://webauthn.me/browser-support
+  /**
+   * use webauthn for login, https://webauthn.guide/
+   * only support platform authenticators, browser support: https://webauthn.me/browser-support
+   */
   enableWebAuthn: false,
-  // http response cache control header
+  /**
+   * http response cache control header
+   */
   enableCDN: false,
-  // if you are using CDN, can override it
-  // it meaning cache 300s on CDN server and client side.
+  /**
+   * if you are using CDN, can override it
+   * it meaning cache 300s on CDN server and client side.
+   */
   cdnCacheControlHeader: 'public, max-age=300',
-  // if you are using CDN, can set it to 'Accept, Accept-Encoding'
+  /**
+   * if you are using CDN, can set it to 'Accept, Accept-Encoding'
+   */
   cdnVaryHeader: 'Accept, Accept-Encoding',
-  // store full package version manifests data to database table(package_version_manifests), default is false
+  /**
+   * store full package version manifests data to database table(package_version_manifests), default is false
+   */
   enableStoreFullPackageVersionManifestsToDatabase: false,
-  // only support npm as client and npm >= 7.0.0 allow publish action
+  /**
+   * only support npm as client and npm >= 7.0.0 allow publish action
+   */
   enableNpmClientAndVersionCheck: true,
-  // sync when package not found, only effect when syncMode = all/exist
+  /**
+   * sync when package not found, only effect when syncMode = all/exist
+   */
   syncNotFound: false,
-  // redirect to source registry when package not found
+  /**
+   * redirect to source registry when package not found
+   */
   redirectNotFound: true,
-  // enable unpkg features, https://github.com/cnpm/cnpmcore/issues/452
+  /**
+   * enable unpkg features, https://github.com/cnpm/cnpmcore/issues/452
+   */
   enableUnpkg: true,
 };
 

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -5,91 +5,93 @@ import OSSClient from 'oss-cnpm';
 import { patchAjv } from '../app/port/typebox';
 import { SyncDeleteMode, SyncMode } from '../app/common/constants';
 
+export const cnpmcoreConfig = {
+  name: 'cnpm',
+  hooksLimit: 20,
+  sourceRegistry: 'https://registry.npmjs.org',
+  // upstream registry is base on `cnpmcore` or not
+  // if your upstream is official npm registry, please turn it off
+  sourceRegistryIsCNpm: false,
+  syncUpstreamFirst: false,
+  // 3 mins
+  sourceRegistrySyncTimeout: 180000,
+  taskQueueHighWaterSize: 100,
+  // sync mode
+  //  - none: don't sync npm package
+  //  - admin: don't sync npm package,only admin can create sync task by sync contorller.
+  //  - all: sync all npm packages
+  //  - exist: only sync exist packages, effected when `enableCheckRecentlyUpdated` or `enableChangesStream` is enabled
+  syncMode: SyncMode.none,
+  syncDeleteMode: SyncDeleteMode.delete,
+  hookEnable: false,
+  syncPackageWorkerMaxConcurrentTasks: 10,
+  triggerHookWorkerMaxConcurrentTasks: 10,
+  createTriggerHookWorkerMaxConcurrentTasks: 10,
+  // stop syncing these packages in future
+  syncPackageBlockList: [] as string[],
+  // check recently from https://www.npmjs.com/browse/updated, if use set changesStreamRegistry to cnpmcore,
+  // maybe you should disable it
+  enableCheckRecentlyUpdated: true,
+  // mirror binary, default is false
+  enableSyncBinary: false,
+  // cnpmcore api: https://r.cnpmjs.org/-/binary
+  syncBinaryFromAPISource: '',
+  // enable sync downloads data from source registry https://github.com/cnpm/cnpmcore/issues/108
+  // all three parameters must be configured at the same time to take effect
+  enableSyncDownloadData: false,
+  syncDownloadDataSourceRegistry: '',
+  syncDownloadDataMaxDate: '', // should be YYYY-MM-DD format
+  // https://github.com/npm/registry-follower-tutorial
+  enableChangesStream: false,
+  checkChangesStreamInterval: 500,
+  changesStreamRegistry: 'https://replicate.npmjs.com',
+  // handle _changes request mode, default is 'streaming', please set it to 'json' when on cnpmcore registry
+  changesStreamRegistryMode: 'streaming',
+  registry: 'http://localhost:7001',
+  // https://docs.npmjs.com/cli/v6/using-npm/config#always-auth npm <= 6
+  // if `alwaysAuth=true`, all api request required access token
+  alwaysAuth: false,
+  // white scope list
+  allowScopes: [
+    '@cnpm',
+    '@cnpmcore',
+    '@example',
+  ],
+  // allow publish non-scope package, disable by default
+  allowPublishNonScopePackage: false,
+  // Public registration is allowed, otherwise only admins can login
+  allowPublicRegistration: true,
+  // default system admins
+  admins: {
+    // name: email
+    cnpmcore_admin: 'admin@cnpmjs.org',
+  },
+  // use webauthn for login, https://webauthn.guide/
+  // only support platform authenticators, browser support: https://webauthn.me/browser-support
+  enableWebAuthn: false,
+  // http response cache control header
+  enableCDN: false,
+  // if you are using CDN, can override it
+  // it meaning cache 300s on CDN server and client side.
+  cdnCacheControlHeader: 'public, max-age=300',
+  // if you are using CDN, can set it to 'Accept, Accept-Encoding'
+  cdnVaryHeader: 'Accept, Accept-Encoding',
+  // store full package version manifests data to database table(package_version_manifests), default is false
+  enableStoreFullPackageVersionManifestsToDatabase: false,
+  // only support npm as client and npm >= 7.0.0 allow publish action
+  enableNpmClientAndVersionCheck: true,
+  // sync when package not found, only effect when syncMode = all/exist
+  syncNotFound: false,
+  // redirect to source registry when package not found
+  redirectNotFound: true,
+  // enable unpkg features, https://github.com/cnpm/cnpmcore/issues/452
+  enableUnpkg: true,
+};
+
 export default (appInfo: EggAppConfig) => {
   const config = {} as PowerPartial<EggAppConfig>;
 
-  config.cnpmcore = {
-    name: 'cnpm',
-    hooksLimit: 20,
-    sourceRegistry: 'https://registry.npmjs.org',
-    // upstream registry is base on `cnpmcore` or not
-    // if your upstream is official npm registry, please turn it off
-    sourceRegistryIsCNpm: false,
-    syncUpstreamFirst: false,
-    // 3 mins
-    sourceRegistrySyncTimeout: 180000,
-    taskQueueHighWaterSize: 100,
-    // sync mode
-    //  - none: don't sync npm package
-    //  - admin: don't sync npm package,only admin can create sync task by sync contorller.
-    //  - all: sync all npm packages
-    //  - exist: only sync exist packages, effected when `enableCheckRecentlyUpdated` or `enableChangesStream` is enabled
-    syncMode: SyncMode.none,
-    syncDeleteMode: SyncDeleteMode.delete,
-    hookEnable: false,
-    syncPackageWorkerMaxConcurrentTasks: 10,
-    triggerHookWorkerMaxConcurrentTasks: 10,
-    createTriggerHookWorkerMaxConcurrentTasks: 10,
-    // stop syncing these packages in future
-    syncPackageBlockList: [],
-    // check recently from https://www.npmjs.com/browse/updated, if use set changesStreamRegistry to cnpmcore,
-    // maybe you should disable it
-    enableCheckRecentlyUpdated: true,
-    // mirror binary, default is false
-    enableSyncBinary: false,
-    // cnpmcore api: https://r.cnpmjs.org/-/binary
-    syncBinaryFromAPISource: '',
-    // enable sync downloads data from source registry https://github.com/cnpm/cnpmcore/issues/108
-    // all three parameters must be configured at the same time to take effect
-    enableSyncDownloadData: false,
-    syncDownloadDataSourceRegistry: '',
-    syncDownloadDataMaxDate: '', // should be YYYY-MM-DD format
-    // https://github.com/npm/registry-follower-tutorial
-    enableChangesStream: false,
-    checkChangesStreamInterval: 500,
-    changesStreamRegistry: 'https://replicate.npmjs.com',
-    // handle _changes request mode, default is 'streaming', please set it to 'json' when on cnpmcore registry
-    changesStreamRegistryMode: 'streaming',
-    registry: 'http://localhost:7001',
-    // https://docs.npmjs.com/cli/v6/using-npm/config#always-auth npm <= 6
-    // if `alwaysAuth=true`, all api request required access token
-    alwaysAuth: false,
-    // white scope list
-    allowScopes: [
-      '@cnpm',
-      '@cnpmcore',
-      '@example',
-    ],
-    // allow publish non-scope package, disable by default
-    allowPublishNonScopePackage: false,
-    // Public registration is allowed, otherwise only admins can login
-    allowPublicRegistration: true,
-    // default system admins
-    admins: {
-      // name: email
-      cnpmcore_admin: 'admin@cnpmjs.org',
-    },
-    // use webauthn for login, https://webauthn.guide/
-    // only support platform authenticators, browser support: https://webauthn.me/browser-support
-    enableWebAuthn: false,
-    // http response cache control header
-    enableCDN: false,
-    // if you are using CDN, can override it
-    // it meaning cache 300s on CDN server and client side.
-    cdnCacheControlHeader: 'public, max-age=300',
-    // if you are using CDN, can set it to 'Accept, Accept-Encoding'
-    cdnVaryHeader: 'Accept, Accept-Encoding',
-    // store full package version manifests data to database table(package_version_manifests), default is false
-    enableStoreFullPackageVersionManifestsToDatabase: false,
-    // only support npm as client and npm >= 7.0.0 allow publish action
-    enableNpmClientAndVersionCheck: true,
-    // sync when package not found, only effect when syncMode = all/exist
-    syncNotFound: false,
-    // redirect to source registry when package not found
-    redirectNotFound: true,
-    // enable unpkg features, https://github.com/cnpm/cnpmcore/issues/452
-    enableUnpkg: true,
-  };
+  config.cnpmcore = cnpmcoreConfig;
 
   // override config from framework / plugin
   config.dataDir = join(appInfo.root, '.cnpmcore');


### PR DESCRIPTION
> Make the method for tegg integration mode to be more user-friendly.

* 🤖 Automatically add config.cnpmcore type hints.
* 🧶 Export the default `cnpmcoreConfig` , which needs to be explicitly declared for app config.
* 📚 Supplement the documentation and field definitions.
------

> 对于 egg 集成模式，提供更加友好的自定义配置方式。
* 🤖 自动添加 config.cnpmcore 类型提示
* 🧶 输出默认的 cnpmcoreConfig 对象，应用集成需显式声明，防止新增配置丢失
* 📚 补充文档及字段定义信息

![image](https://github.com/cnpm/cnpmcore/assets/5574625/98d3e0df-32f5-4de5-990a-bc1561cd73be)


