### PR TITLE
fix: refactor config type

### DIFF
--- a/app/common/constants.ts
+++ b/app/common/constants.ts
@@ -7,6 +7,10 @@ export enum SyncMode {
   exist = 'exist',
   all = 'all',
 }
+export enum ChangesStreamMode {
+  json = 'json',
+  streaming = 'streaming',
+}
 export enum SyncDeleteMode {
   ignore = 'ignore',
   block = 'block',

--- a/app/common/typing.ts
+++ b/app/common/typing.ts
@@ -1,4 +1,4 @@
-import { cnpmcoreConfig } from '../port/config';
+import { CnpmcoreConfig } from '../port/config';
 import { Readable } from 'stream';
 import { IncomingHttpHeaders } from 'http';
 import { EggContext } from '@eggjs/tegg';
@@ -69,6 +69,6 @@ declare module 'egg' {
   // @ts-ignore
   // avoid TS2310 Type 'EggAppConfig' recursively references itself as a base type.
   interface EggAppConfig {
-    cnpmcore: typeof cnpmcoreConfig;
+    cnpmcore: CnpmcoreConfig;
   }
 }

--- a/app/core/service/RegistryManagerService.ts
+++ b/app/core/service/RegistryManagerService.ts
@@ -11,7 +11,7 @@ import { PageOptions, PageResult } from '../util/EntityUtil';
 import { ScopeManagerService } from './ScopeManagerService';
 import { TaskService } from './TaskService';
 import { Task } from '../entity/Task';
-import { PresetRegistryName } from '../../common/constants';
+import { ChangesStreamMode, PresetRegistryName } from '../../common/constants';
 import { RegistryType } from '../../common/enum/Registry';
 
 export interface CreateRegistryCmd extends Pick<Registry, 'changeStream' | 'host' | 'userPrefix' | 'type' | 'name'> {
@@ -143,7 +143,7 @@ export class RegistryManagerService extends AbstractService {
 
     // 从配置文件默认生成
     const { changesStreamRegistryMode, changesStreamRegistry: changesStreamHost, sourceRegistry: host } = this.config.cnpmcore;
-    const type = changesStreamRegistryMode === 'json' ? RegistryType.Cnpmcore : RegistryType.Npm;
+    const type = changesStreamRegistryMode === ChangesStreamMode.json ? RegistryType.Cnpmcore : RegistryType.Npm;
     const registry = await this.createRegistry({
       name: PresetRegistryName.default,
       type,

--- a/app/port/config.ts
+++ b/app/port/config.ts
@@ -1,1 +1,148 @@
+import { SyncDeleteMode, SyncMode, ChangesStreamMode } from '../common/constants';
+
 export { cnpmcoreConfig } from '../../config/config.default';
+
+export type CnpmcoreConfig = {
+  name: string,
+  /**
+   * enable hook or not
+   */
+  hookEnable: boolean,
+  /**
+   * mac custom hooks count
+   */
+  hooksLimit: number,
+  /**
+   * upstream registry url
+   */
+  sourceRegistry: string,
+  /**
+   * upstream registry is base on `cnpmcore` or not
+   * if your upstream is official npm registry, please turn it off
+   */
+  sourceRegistryIsCNpm: boolean,
+  /**
+   * sync upstream first
+   */
+  syncUpstreamFirst: boolean,
+  /**
+   * sync upstream timeout, default is 3mins
+   */
+  sourceRegistrySyncTimeout: number,
+  /**
+   * sync task high water size, default is 100
+   */
+  taskQueueHighWaterSize: number,
+  /**
+   * sync mode
+   * - none: don't sync npm package
+   * - admin: don't sync npm package,only admin can create sync task by sync contorller.
+   * - all: sync all npm packages
+   * - exist: only sync exist packages, effected when `enableCheckRecentlyUpdated` or `enableChangesStream` is enabled
+   */
+  syncMode: SyncMode,
+  syncDeleteMode: SyncDeleteMode,
+  syncPackageWorkerMaxConcurrentTasks: number,
+  triggerHookWorkerMaxConcurrentTasks: number,
+  createTriggerHookWorkerMaxConcurrentTasks: number,
+  /**
+   * stop syncing these packages in future
+   */
+  syncPackageBlockList: string[],
+  /**
+   * check recently from https://www.npmjs.com/browse/updated, if use set changesStreamRegistry to cnpmcore,
+   * maybe you should disable it
+   */
+  enableCheckRecentlyUpdated: boolean,
+  /**
+   * mirror binary, default is false
+   */
+  enableSyncBinary: boolean,
+  /**
+   * sync binary source api, default is `${sourceRegistry}/-/binary`
+   */
+  syncBinaryFromAPISource: string,
+  /**
+   * enable sync downloads data from source registry https://github.com/cnpm/cnpmcore/issues/108
+   * all three parameters must be configured at the same time to take effect
+   */
+  enableSyncDownloadData: boolean,
+  syncDownloadDataSourceRegistry: string,
+  /**
+   * should be YYYY-MM-DD format
+   */
+  syncDownloadDataMaxDate: string,
+  /**
+   * @see https://github.com/npm/registry-follower-tutorial
+   */
+  enableChangesStream: boolean,
+  checkChangesStreamInterval: number,
+  changesStreamRegistry: string,
+  /**
+   * handle _changes request mode, default is 'streaming', please set it to 'json' when on cnpmcore registry
+   */
+  changesStreamRegistryMode: ChangesStreamMode,
+  /**
+   * registry url
+   */
+  registry: string,
+  /**
+   * https://docs.npmjs.com/cli/v6/using-npm/config#always-auth npm <= 6
+   * if `alwaysAuth=true`, all api request required access token
+   */
+  alwaysAuth: boolean,
+  /**
+   * white scope list
+   */
+  allowScopes: string [],
+  /**
+   * allow publish non-scope package, disable by default
+   */
+  allowPublishNonScopePackage: boolean,
+  /**
+   * Public registration is allowed, otherwise only admins can login
+   */
+  allowPublicRegistration: boolean,
+  /**
+   * default system admins
+   */
+  admins: Record<string, string>,
+  /**
+   * use webauthn for login, https://webauthn.guide/
+   * only support platform authenticators, browser support: https://webauthn.me/browser-support
+   */
+  enableWebAuthn: boolean,
+  /**
+   * http response cache control header
+   */
+  enableCDN: boolean,
+  /**
+   * if you are using CDN, can override it
+   * it meaning cache 300s on CDN server and client side.
+   */
+  cdnCacheControlHeader: string,
+  /**
+   * if you are using CDN, can set it to 'Accept, Accept-Encoding'
+   */
+  cdnVaryHeader: string,
+  /**
+   * store full package version manifests data to database table(package_version_manifests), default is false
+   */
+  enableStoreFullPackageVersionManifestsToDatabase: boolean,
+  /**
+   * only support npm as client and npm >= 7.0.0 allow publish action
+   */
+  enableNpmClientAndVersionCheck: boolean,
+  /**
+   * sync when package not found, only effect when syncMode = all/exist
+   */
+  syncNotFound: boolean,
+  /**
+   * redirect to source registry when package not found
+   */
+  redirectNotFound: boolean,
+  /**
+   * enable unpkg features, https://github.com/cnpm/cnpmcore/issues/452
+   */
+  enableUnpkg: boolean,
+};

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -3,157 +3,54 @@ import { join } from 'path';
 import { EggAppConfig, PowerPartial } from 'egg';
 import OSSClient from 'oss-cnpm';
 import { patchAjv } from '../app/port/typebox';
-import { SyncDeleteMode, SyncMode } from '../app/common/constants';
+import { ChangesStreamMode, SyncDeleteMode, SyncMode } from '../app/common/constants';
+import { CnpmcoreConfig } from '../app/port/config';
 
-export const cnpmcoreConfig = {
+export const cnpmcoreConfig: CnpmcoreConfig = {
   name: 'cnpm',
-  /**
-   * enable hook or not
-   */
   hookEnable: false,
-  /**
-   * mac custom hooks count
-   */
   hooksLimit: 20,
-  /**
-   * upstream registry url
-   */
   sourceRegistry: 'https://registry.npmjs.org',
-  /**
-   * upstream registry is base on `cnpmcore` or not
-   * if your upstream is official npm registry, please turn it off
-   */
   sourceRegistryIsCNpm: false,
-  /**
-   * sync upstream first
-   */
   syncUpstreamFirst: false,
-  /**
-   * sync upstream timeout, default is 3mins
-   */
   sourceRegistrySyncTimeout: 180000,
-  /**
-   * sync task high water size, default is 100
-   */
   taskQueueHighWaterSize: 100,
-  /**
-   * sync mode
-   * - none: don't sync npm package
-   * - admin: don't sync npm package,only admin can create sync task by sync contorller.
-   * - all: sync all npm packages
-   * - exist: only sync exist packages, effected when `enableCheckRecentlyUpdated` or `enableChangesStream` is enabled
-   */
   syncMode: SyncMode.none,
   syncDeleteMode: SyncDeleteMode.delete,
   syncPackageWorkerMaxConcurrentTasks: 10,
   triggerHookWorkerMaxConcurrentTasks: 10,
   createTriggerHookWorkerMaxConcurrentTasks: 10,
-  /**
-   * stop syncing these packages in future
-   */
-  syncPackageBlockList: [] as string[],
-  /**
-   * check recently from https://www.npmjs.com/browse/updated, if use set changesStreamRegistry to cnpmcore,
-   * maybe you should disable it
-   */
+  syncPackageBlockList: [],
   enableCheckRecentlyUpdated: true,
-  /**
-   * mirror binary, default is false
-   */
   enableSyncBinary: false,
-  /**
-   * sync binary source api, default is `${sourceRegistry}/-/binary`
-   */
   syncBinaryFromAPISource: '',
-  /**
-   * enable sync downloads data from source registry https://github.com/cnpm/cnpmcore/issues/108
-   * all three parameters must be configured at the same time to take effect
-   */
   enableSyncDownloadData: false,
   syncDownloadDataSourceRegistry: '',
-  /**
-   * should be YYYY-MM-DD format
-   */
   syncDownloadDataMaxDate: '',
-  /**
-   * @see https://github.com/npm/registry-follower-tutorial
-   */
   enableChangesStream: false,
   checkChangesStreamInterval: 500,
   changesStreamRegistry: 'https://replicate.npmjs.com',
-  /**
-   * handle _changes request mode, default is 'streaming', please set it to 'json' when on cnpmcore registry
-   */
-  changesStreamRegistryMode: 'streaming',
-  /**
-   * registry url
-   */
+  changesStreamRegistryMode: ChangesStreamMode.streaming,
   registry: 'http://localhost:7001',
-  /**
-   * https://docs.npmjs.com/cli/v6/using-npm/config#always-auth npm <= 6
-   * if `alwaysAuth=true`, all api request required access token
-   */
   alwaysAuth: false,
-  /**
-   * white scope list
-   */
   allowScopes: [
     '@cnpm',
     '@cnpmcore',
     '@example',
   ],
-  /**
-   * allow publish non-scope package, disable by default
-   */
   allowPublishNonScopePackage: false,
-  /**
-   * Public registration is allowed, otherwise only admins can login
-   */
   allowPublicRegistration: true,
-  /**
-   * default system admins
-   */
   admins: {
-    // name: email
     cnpmcore_admin: 'admin@cnpmjs.org',
   },
-  /**
-   * use webauthn for login, https://webauthn.guide/
-   * only support platform authenticators, browser support: https://webauthn.me/browser-support
-   */
   enableWebAuthn: false,
-  /**
-   * http response cache control header
-   */
   enableCDN: false,
-  /**
-   * if you are using CDN, can override it
-   * it meaning cache 300s on CDN server and client side.
-   */
   cdnCacheControlHeader: 'public, max-age=300',
-  /**
-   * if you are using CDN, can set it to 'Accept, Accept-Encoding'
-   */
   cdnVaryHeader: 'Accept, Accept-Encoding',
-  /**
-   * store full package version manifests data to database table(package_version_manifests), default is false
-   */
   enableStoreFullPackageVersionManifestsToDatabase: false,
-  /**
-   * only support npm as client and npm >= 7.0.0 allow publish action
-   */
   enableNpmClientAndVersionCheck: true,
-  /**
-   * sync when package not found, only effect when syncMode = all/exist
-   */
   syncNotFound: false,
-  /**
-   * redirect to source registry when package not found
-   */
   redirectNotFound: true,
-  /**
-   * enable unpkg features, https://github.com/cnpm/cnpmcore/issues/452
-   */
   enableUnpkg: true,
 };
 


### PR DESCRIPTION
> New CnpmcoreConfig type to handle compatibility issues https://github.com/cnpm/cnpmcore/pull/475
1. 🆕 add a new CnpmcoreConfig in port/config, referenced in config.default.ts
2. 🆕 add `ChangesStreamMode` enums.
-------------
> 新增 CnpmcoreConfig 类型处理兼容问题 https://github.com/cnpm/cnpmcore/pull/475
1. 🆕 新增 CnpmcoreConfig，config.default.ts 中进行引用
2. 🆕 新增 `ChangesStreamMode` 枚举

![image](https://github.com/cnpm/cnpmcore/assets/5574625/1fd4afd0-0739-4021-a134-2311bbf78713)
