### PR TITLE
fix: unpkg redirect

### DIFF
--- a/app/port/controller/PackageVersionFileController.ts
+++ b/app/port/controller/PackageVersionFileController.ts
@@ -109,7 +109,8 @@ export class PackageVersionFileController extends AbstractController {
     }
     const { manifest } = await this.packageManagerService.showPackageVersionManifest(scope, name, versionOrTag);
     // GET /foo/1.0.0/files => /foo/1.0.0/files/{main}
-    const indexFile = manifest?.main ?? 'index.js';
+    // ignore empty entry exp: @types/node@20.2.5/
+    const indexFile = manifest?.main || 'index.js';
     ctx.redirect(join(ctx.path, indexFile));
   }
 


### PR DESCRIPTION
> @types packages generally don't configure the main field, will cause infinite loops [exp](https://registry.npmmirror.com/@types/node/20.2.5/files)
1. 🧶 Change the default logic when processing main field
2. 📦 Keep operational logic consistent with unpkg [ref](https://unpkg.com/@types/node@20.2.5/)
--------

> @types 包一般没有配置 main 字段，会导致无限循环 [exp](https://registry.npmmirror.com/@types/node/20.2.5/files)
1. 🧶 修改 main 字段默认逻辑判断口径
2. 📦 操作逻辑和 unpkg 保持一致 [ref](https://unpkg.com/@types/node@20.2.5/)