### PR TITLE
feat: token last used at

### DIFF
--- a/app/core/entity/Token.ts
+++ b/app/core/entity/Token.ts
@@ -14,6 +14,7 @@ interface BaseTokenData extends EntityData {
   userId: string;
   isReadonly?: boolean;
   type?: TokenType;
+  lastUsedAt?: Date;
 }
 
 interface ClassicTokenData extends BaseTokenData{
@@ -30,7 +31,7 @@ interface GranularTokenData extends BaseTokenData {
 
 type TokenData = ClassicTokenData | GranularTokenData;
 
-export function isGranularToken(data: TokenData): data is GranularTokenData {
+export function isGranularToken(data: TokenData | Token): data is GranularTokenData {
   return data.type === TokenType.granular;
 }
 
@@ -48,6 +49,7 @@ export class Token extends Entity {
   readonly allowedScopes?: string[];
   readonly expiredAt?: Date;
   readonly expires?: number;
+  lastUsedAt: Date | null;
   allowedPackages?: string[];
   token?: string;
 
@@ -60,6 +62,7 @@ export class Token extends Entity {
     this.cidrWhitelist = data.cidrWhitelist || [];
     this.isReadonly = data.isReadonly || false;
     this.type = data.type || TokenType.classic;
+    this.lastUsedAt = data.lastUsedAt || null;
 
     if (isGranularToken(data)) {
       this.name = data.name;
@@ -67,6 +70,7 @@ export class Token extends Entity {
       this.allowedScopes = data.allowedScopes;
       this.expiredAt = data.expiredAt;
       this.allowedPackages = data.allowedPackages;
+      this.isAutomation = false;
     } else {
       this.isAutomation = data.isAutomation || false;
     }

--- a/app/core/service/TokenService.ts
+++ b/app/core/service/TokenService.ts
@@ -36,7 +36,7 @@ export class TokenService extends AbstractService {
     return null;
   }
 
-  public async checkGranularTokenAccess(token: Token, fullname: string) {
+  public async checkTokenExpired(token: Token) {
     // skip classic token
     if (!isGranularToken(token)) {
       return true;
@@ -47,6 +47,11 @@ export class TokenService extends AbstractService {
       throw new UnauthorizedError('Token expired');
     }
 
+    token.lastUsedAt = new Date();
+    this.userRepository.saveToken(token);
+  }
+
+  public async checkGranularTokenAccess(token: Token, fullname: string) {
     // check for scope whitelist
     const [ scope, name ] = getScopeAndName(fullname);
     // check for packages whitelist

--- a/app/port/UserRoleManager.ts
+++ b/app/port/UserRoleManager.ts
@@ -111,6 +111,9 @@ export class UserRoleManager {
     if (!authorizedUserAndToken) {
       return null;
     }
+
+    // check token expired & set lastUsedAt
+    await this.tokenService.checkTokenExpired(authorizedUserAndToken.token);
     this.currentAuthorizedToken = authorizedUserAndToken.token;
     this.currentAuthorizedUser = authorizedUserAndToken.user;
     ctx.userId = authorizedUserAndToken.user.userId;

--- a/app/port/controller/TokenController.ts
+++ b/app/port/controller/TokenController.ts
@@ -127,6 +127,7 @@ export class TokenController extends AbstractController {
           readonly: token.isReadonly,
           automation: token.isAutomation,
           created: token.createdAt,
+          lastUsedAt: token.lastUsedAt,
           updated: token.updatedAt,
         };
       });
@@ -204,12 +205,13 @@ export class TokenController extends AbstractController {
       }
     }
     const objects = granularTokens.map(token => {
-      const { name, description, expiredAt, allowedPackages, allowedScopes } = token;
+      const { name, description, expiredAt, allowedPackages, allowedScopes, lastUsedAt, type } = token;
       return {
         name,
         description,
         allowedPackages,
         allowedScopes,
+        lastUsedAt,
         expiredAt,
         token: token.tokenMark,
         key: token.tokenKey,
@@ -217,6 +219,7 @@ export class TokenController extends AbstractController {
         readonly: token.isReadonly,
         created: token.createdAt,
         updated: token.updatedAt,
+        type,
       };
     });
     return { objects, total: granularTokens.length, urls: {} };

--- a/app/repository/model/Token.ts
+++ b/app/repository/model/Token.ts
@@ -54,4 +54,7 @@ export class Token extends Bone {
 
   @Attribute(DataTypes.DATE)
   expiredAt: Date;
+
+  @Attribute(DataTypes.DATE)
+  lastUsedAt: Date;
 }

--- a/sql/1.16.0.sql
+++ b/sql/1.16.0.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+  `tokens`
+ADD
+  COLUMN `last_used_at` datetime(3) DEFAULT NULL COMMENT 'token last used time';


### PR DESCRIPTION
> Add the lastUsedBy field to the Token model

* 🧶 Add `lastUsedBy` field to the token, for platform display.
* 🐞 Fix the issue where the graunlarToken is not expired in read-only scenarios.
------
> 为 Token 模型添加 lastUsedBy 字段
* 🧶 新增 lastUsedBy 字段，记录 token 最近使用时间，用于平台展示
* 🐞 修复 graunlarToken 过期时，只读场景没有禁用的问题
