### PR TITLE
feat: Support environment variable for config :rocket: 

### DIFF
--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -118,7 +118,7 @@ export default (appInfo: EggAppConfig) => {
       },
     });
   }
-  
+
   config.logger = {
     enablePerformanceTimer: true,
     enableFastContextLogger: true,

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -68,11 +68,11 @@ export default (appInfo: EggAppConfig) => {
 
   config.orm = {
     client: 'mysql',
-    database: process.env.MYSQL_DATABASE || process.env.CNPMCORE_MYSQL_DATABASE || 'cnpmcore',
-    host: process.env.MYSQL_HOST || process.env.CNPMCORE_MYSQL_HOST || '127.0.0.1',
-    port: process.env.MYSQL_PORT || process.env.CNPMCORE_MYSQL_PORT || 3306,
-    user: process.env.MYSQL_USER || process.env.CNPMCORE_MYSQL_USER || 'root',
-    password: process.env.MYSQL_PASSWORD || process.env.CNPMCORE_MYSQL_PASSWORD,
+    database: process.env.CNPMCORE_MYSQL_DATABASE || process.env.MYSQL_DATABASE || 'cnpmcore',
+    host: process.env.CNPMCORE_MYSQL_HOST || process.env.MYSQL_HOST || '127.0.0.1',
+    port: process.env.CNPMCORE_MYSQL_PORT || process.env.MYSQL_PORT || 3306,
+    user: process.env.CNPMCORE_MYSQL_USER || process.env.MYSQL_USER || 'root',
+    password: process.env.CNPMCORE_MYSQL_PASSWORD || process.env.MYSQL_PASSWORD,
     charset: 'utf8mb4',
     logger: {},
   };

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -7,8 +7,6 @@ import { ChangesStreamMode, SyncDeleteMode, SyncMode } from '../app/common/const
 import { CnpmcoreConfig } from '../app/port/config';
 import { LoggerLevel } from 'egg-logger';
 
-console.log(process.env);
-
 export const cnpmcoreConfig: CnpmcoreConfig = {
   name: 'cnpm',
   hookEnable: false,

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -54,10 +54,6 @@ export const cnpmcoreConfig: CnpmcoreConfig = {
   enableUnpkg: true,
 };
 
-function getUserHome():string {
-  return process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'] || '';
-}
-
 export default (appInfo: EggAppConfig) => {
   const config = {} as PowerPartial<EggAppConfig>;
 

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -5,7 +5,6 @@ import OSSClient from 'oss-cnpm';
 import { patchAjv } from '../app/port/typebox';
 import { ChangesStreamMode, SyncDeleteMode, SyncMode } from '../app/common/constants';
 import { CnpmcoreConfig } from '../app/port/config';
-import { LoggerLevel } from 'egg-logger';
 
 export const cnpmcoreConfig: CnpmcoreConfig = {
   name: 'cnpm',
@@ -133,7 +132,6 @@ export default (appInfo: EggAppConfig) => {
     agentLogName: process.env.CNPMCORE_AGENT_LOG_NAME || 'egg-agent.log',
     errorLogName: process.env.CNPMCORE_ERROR_LOG_NAME || 'common-error.log',
     outputJSON: Boolean(process.env.CNPMCORE_LOG_JSON_OUTPUT || false),
-    consoleLevel: (process.env.CNPMCORE_LOG_CONSOLE_LEVEL || 'INFO') as LoggerLevel,
   };
 
   config.logrotator = {

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -122,17 +122,22 @@ export default (appInfo: EggAppConfig) => {
       },
     });
   }
-
+  
   config.logger = {
     enablePerformanceTimer: true,
     enableFastContextLogger: true,
-    dir: process.env.CNPMCORE_LOG_DIR || join(getUserHome(), 'log1'),
     appLogName: process.env.CNPMCORE_APP_LOG_NAME || `${appInfo.name}-web.log`,
     coreLogName: process.env.CNPMCORE_CORE_LOG_NAME || 'egg-web.log',
     agentLogName: process.env.CNPMCORE_AGENT_LOG_NAME || 'egg-agent.log',
     errorLogName: process.env.CNPMCORE_ERROR_LOG_NAME || 'common-error.log',
     outputJSON: Boolean(process.env.CNPMCORE_LOG_JSON_OUTPUT || false),
   };
+  if (process.env.CNPMCORE_LOG_DIR) {
+    config.logger.dir = process.env.CNPMCORE_LOG_DIR;
+  }
+  if (process.env.CNPMCORE_LOG_JSON_OUTPUT) {
+    config.logger.outputJSON = Boolean(process.env.CNPMCORE_LOG_JSON_OUTPUT),
+  }
 
   config.logrotator = {
     // only keep 1 days log files

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -132,7 +132,7 @@ export default (appInfo: EggAppConfig) => {
     config.logger.dir = process.env.CNPMCORE_LOG_DIR;
   }
   if (process.env.CNPMCORE_LOG_JSON_OUTPUT) {
-    config.logger.outputJSON = Boolean(process.env.CNPMCORE_LOG_JSON_OUTPUT),
+    config.logger.outputJSON = Boolean(process.env.CNPMCORE_LOG_JSON_OUTPUT);
   }
 
   config.logrotator = {


### PR DESCRIPTION
作为 #465 的实现

1. 将一些常见配置抽出来支持环境变量
2. 将 MYSQL 之类的已有的环境变量统一前缀为 `CNPMCORE`