### PR TITLE
feat: add _npmUser

### DIFF
--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -155,6 +155,13 @@ export class PackageManagerService extends AbstractService {
       cmd.packageJson._hasShrinkwrap = await hasShrinkWrapInTgz(cmd.dist.content || cmd.dist.localFile!);
     }
 
+    // set _npmUser field to cmd.packageJson
+    cmd.packageJson._npmUser = {
+      // clean user scope prefix
+      name: publisher.displayName,
+      email: publisher.email,
+    };
+
     // add _registry_name field to cmd.packageJson
     if (!cmd.packageJson._source_registry_name) {
       let registry: Registry | null;


### PR DESCRIPTION
> For private packages published in the current registry, add the "_npmUser" field to align with the npm registry.

* 🧶 Add the "_npmUser" field for new scenarios, without modifying the abbreviated data. Use the following command: curl -H 'Accept: application/vnd.npm.install-v1+json' 'https://registry.npmjs.org/cnpmcore'
* ♻️ Existing data cannot be traced and will not be compensated.
-----

> 对于在当前 registry 发布的私有包，添加 _npmUser 字段，和公网 registry 保持一致
* 🧶 新增 _npmUser 字段，abbreviated 场景不做修改, (via `curl  -H 'Accept: application/vnd.npm.install-v1+json' 'https://registry.npmjs.org/cnpmcore'`)
* ♻️ 存量数据无法回溯，不做补偿
