### PR TITLE
feat: source registry manifest

### DIFF
--- a/test/port/controller/package/ShowPackageController.test.ts
+++ b/test/port/controller/package/ShowPackageController.test.ts
@@ -784,6 +784,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .expect('content-type', 'application/json; charset=utf-8');
 
       const data = res.body as PackageManifestType;
+      assert(data._source_registry_name === 'self');
       assert(Object.values(data.versions).every(v => v!._source_registry_name === 'self'));
     });
 


### PR DESCRIPTION
> Add the `_source_registry_manifest` in pkgFullManifest.
* 🧶 Set registryInfo during reading because of the excessive existing data.
* ♻️ The change takes effect when redis cache expired.
----------

> 在 pkgFullManifest 中添加 _source_registry_manifest 相关字段
1. 🧶 存量数据过多，在读取时统一设置，展示当前对应 registryId
2. ♻️ 在读取 db 时生效，需要等缓存过期