### PR TITLE
feat: whoami granular

### DIFF
--- a/app/core/entity/Token.ts
+++ b/app/core/entity/Token.ts
@@ -13,7 +13,7 @@ interface BaseTokenData extends EntityData {
   cidrWhitelist?: string[];
   userId: string;
   isReadonly?: boolean;
-  type?: TokenType;
+  type?: TokenType | string;
   lastUsedAt?: Date;
 }
 
@@ -61,7 +61,7 @@ export class Token extends Entity {
     this.tokenKey = data.tokenKey;
     this.cidrWhitelist = data.cidrWhitelist || [];
     this.isReadonly = data.isReadonly || false;
-    this.type = data.type || TokenType.classic;
+    this.type = (data.type as TokenType) || TokenType.classic;
     this.lastUsedAt = data.lastUsedAt || null;
 
     if (isGranularToken(data)) {

--- a/app/port/controller/TokenController.ts
+++ b/app/port/controller/TokenController.ts
@@ -13,8 +13,6 @@ import {
 import { Static, Type } from '@sinclair/typebox';
 import { AbstractController } from './AbstractController';
 import { TokenType, isGranularToken } from '../../core/entity/Token';
-import { TokenService } from '../../../app/core/service/TokenService';
-import { getFullname } from '../../../app/common/PackageUtil';
 
 // Creating and viewing access tokens
 // https://docs.npmjs.com/creating-and-viewing-access-tokens#viewing-access-tokens
@@ -44,8 +42,6 @@ type GranularTokenOptions = Static<typeof GranularTokenOptionsRule>;
 export class TokenController extends AbstractController {
   @Inject()
   private readonly authAdapter: AuthAdapter;
-  @Inject()
-  private readonly tokenService: TokenService;
   // https://github.com/npm/npm-profile/blob/main/lib/index.js#L233
   @HTTPMethod({
     path: '/-/npm/v1/tokens',
@@ -198,12 +194,6 @@ export class TokenController extends AbstractController {
     const tokens = await this.userRepository.listTokens(user.userId);
     const granularTokens = tokens.filter(token => isGranularToken(token));
 
-    for (const token of granularTokens) {
-      const packages = await this.tokenService.listTokenPackages(token);
-      if (Array.isArray(packages)) {
-        token.allowedPackages = packages.map(p => getFullname(p.scope, p.name));
-      }
-    }
     const objects = granularTokens.map(token => {
       const { name, description, expiredAt, allowedPackages, allowedScopes, lastUsedAt, type } = token;
       return {

--- a/test/port/controller/UserController/whoami.test.ts
+++ b/test/port/controller/UserController/whoami.test.ts
@@ -1,5 +1,7 @@
+import { AuthAdapter } from 'app/infra/AuthAdapter';
 import assert from 'assert';
-import { app } from 'egg-mock/bootstrap';
+import dayjs from 'dayjs';
+import { app, mock } from 'egg-mock/bootstrap';
 import { TestUtil } from 'test/TestUtil';
 
 describe('test/port/controller/UserController/whoami.test.ts', () => {
@@ -10,7 +12,7 @@ describe('test/port/controller/UserController/whoami.test.ts', () => {
         .get('/-/whoami')
         .set('authorization', authorization)
         .expect(200);
-      assert.equal(res.body.username, name);
+      assert.deepStrictEqual(res.body, { username: name });
     });
 
     it('should unauthorized', async () => {
@@ -24,6 +26,39 @@ describe('test/port/controller/UserController/whoami.test.ts', () => {
         .set('authorization', 'Bearer foo-token')
         .expect(401);
       assert.equal(res.body.error, '[UNAUTHORIZED] Invalid token');
+    });
+
+    it('should return granular token info', async () => {
+      const { name, email } = await TestUtil.createUser({ name: 'banana' });
+      await TestUtil.createPackage({ name: '@cnpm/banana' });
+      mock(AuthAdapter.prototype, 'ensureCurrentUser', async () => {
+        return {
+          name,
+          email,
+        };
+      });
+      let res = await app.httpRequest()
+        .post('/-/npm/v1/tokens/gat')
+        .send({
+          name: 'apple',
+          description: 'lets play',
+          allowedPackages: [ '@cnpm/banana' ],
+          allowedScopes: [ '@banana' ],
+          expires: 30,
+        })
+        .expect(200);
+
+      res = await app.httpRequest()
+        .get('/-/whoami')
+        .set('authorization', `Bearer ${res.body.token}`)
+        .expect(200);
+
+      assert.equal(res.body.username, name);
+      assert.equal(res.body.name, 'apple');
+      assert.equal(res.body.description, 'lets play');
+      assert.deepEqual(res.body.allowedPackages, [ '@cnpm/banana' ]);
+      assert.deepEqual(res.body.allowedScopes, [ '@banana' ]);
+      assert(dayjs(res.body.expires).isBefore(dayjs().add(30, 'days')));
     });
   });
 });


### PR DESCRIPTION
> add token info when invoke `whoami` to notify the caller about the token's current status.

* 🧶 Add token information to the "whoami" interface.
* 🔨 Modify the query logic for allowedPackages uniformly within the repository.
-----------

> 当使用 granularToken 调用 whoami 信息时，返回当前 token 信息，告知调用方当前 token 状态
* 🧶 在whoami 接口中添加 token 信息
* 🔨 修改 allowedPackages 查询逻辑，统一在 repository 中集成