### PR TITLE
feat: infer userPrefix when update maintainers 

### DIFF
--- a/app/port/controller/package/UpdatePackageController.ts
+++ b/app/port/controller/package/UpdatePackageController.ts
@@ -50,16 +50,20 @@ export class UpdatePackageController extends AbstractController {
     ctx.tValidate(MaintainerDataRule, data);
     const ensureRes = await this.ensurePublishAccess(ctx, fullname, true);
     const pkg = ensureRes.pkg!;
+    const registry = await this.packageManagerService.getSourceRegistry(pkg);
     // make sure all maintainers exists
     const users: UserEntity[] = [];
     for (const maintainer of data.maintainers) {
-      // TODO check userPrefix
+      if (registry?.userPrefix && !maintainer.name.startsWith(registry.userPrefix)) {
+        maintainer.name = `${registry?.userPrefix}${maintainer.name}`;
+      }
       const user = await this.userRepository.findUserByName(maintainer.name);
       if (!user) {
         throw new UnprocessableEntityError(`Maintainer "${maintainer.name}" not exists`);
       }
       users.push(user);
     }
+
     await this.packageManagerService.replacePackageMaintainers(pkg, users);
     return { ok: true };
   }

--- a/test/TestUtil.ts
+++ b/test/TestUtil.ts
@@ -7,7 +7,7 @@ import { Readable } from 'stream';
 import mysql from 'mysql';
 import path from 'path';
 import crypto from 'crypto';
-import { getScopeAndName } from '../app/common/PackageUtil';
+import { cleanUserPrefix, getScopeAndName } from '../app/common/PackageUtil';
 import semver from 'semver';
 import { PackageJSONType } from '../app/repository/PackageRepository';
 
@@ -242,7 +242,7 @@ export class TestUtil {
       user.name = `testuser-${crypto.randomBytes(20).toString('hex')}`;
     }
     const password = user.password ?? 'password-is-here';
-    const email = user.email ?? `${user.name}@example.com`;
+    const email = cleanUserPrefix(user.email ?? `${user.name}@example.com`);
     let res = await this.app.httpRequest()
       .put(`/-/user/org.couchdb.user:${user.name}`)
       .send({
@@ -266,6 +266,7 @@ export class TestUtil {
     }
     return {
       name: user.name,
+      displayName: cleanUserPrefix(user.name),
       token,
       authorization: `Bearer ${token}`,
       password,

--- a/test/port/controller/package/UpdatePackageController.test.ts
+++ b/test/port/controller/package/UpdatePackageController.test.ts
@@ -1,3 +1,5 @@
+import { RegistryType } from 'app/common/enum/Registry';
+import { RegistryManagerService } from 'app/core/service/RegistryManagerService';
 import assert from 'assert';
 import { app, mock } from 'egg-mock/bootstrap';
 import { TestUtil } from 'test/TestUtil';
@@ -114,6 +116,45 @@ describe('test/port/controller/package/UpdatePackageController.test.ts', () => {
         .expect(200);
       assert.equal(res.statusCode, 200);
       assert.deepEqual(res.body, { ok: true });
+    });
+
+    it('should 200 when without userPrefix', async () => {
+      const user = await TestUtil.createUser();
+      await TestUtil.createUser({
+        name: 'dnpm:banana',
+      });
+
+      const registryManagerService = await app.getEggObject(RegistryManagerService);
+      const registry = await registryManagerService.createRegistry({
+        name: 'dnpmcore',
+        changeStream: 'https://d.cnpmjs.org/_changes',
+        host: 'https://registry.dnpmmirror.com',
+        userPrefix: 'dnpm:',
+        type: RegistryType.Cnpmcore,
+      });
+
+      await TestUtil.createPackage({
+        name: '@cnpm/banana',
+        isPrivate: false,
+        registryId: registry.registryId,
+      });
+
+      mock(app.config.cnpmcore, 'admins', { [user.name]: user.email });
+      const updateRes = await app.httpRequest()
+        .put('/@cnpm/banana/-rev/1')
+        .set('authorization', user.authorization)
+        .set('user-agent', publisher.ua)
+        .set('npm-command', 'owner')
+        .send({
+          _id: rev,
+          _rev: rev,
+          maintainers: [
+            { name: 'banana', email: user.email },
+          ],
+        });
+
+      assert.equal(updateRes.statusCode, 200);
+      assert.deepEqual(updateRes.body, { ok: true });
     });
 
     it('should 400 when npm-command invalid', async () => {


### PR DESCRIPTION
> When update members , infer the userPrefix by default to be compatible with the default npm cli.
* 🧶 When adding a member, query the userPrefix corresponding to the registry.
```
✅ $ npm owner add elrrrrrrr @cnpm/example --registry=http://127.0.0.1:7001
✅ $ npm owner add cnpm:elrrrrrrr @cnpm/example --registry=http://127.0.0.1:7001
```

-------
> 使用 cli 更新成员时，默认推导 userPrefix 信息，兼容 npm 客户端默认流程
* 🧶 添加成员时，查询 registry 对应的 userPrefix
```
✅ $ npm owner add elrrrrrrr @cnpm/example --registry=http://127.0.0.1:7001               
✅ $ npm owner add cnpm:elrrrrrrr @cnpm/example --registry=http://127.0.0.1:7001
```

