### PR TITLE
refactor: validate spec

### DIFF
--- a/app/port/controller/PackageVersionFileController.ts
+++ b/app/port/controller/PackageVersionFileController.ts
@@ -72,7 +72,7 @@ export class PackageVersionFileController extends AbstractController {
   })
   @Middleware(AdminAccess)
   async sync(@Context() ctx: EggContext, @HTTPParam() fullname: string, @HTTPParam() versionSpec: string) {
-    ctx.tValidate(Spec, versionSpec);
+    ctx.tValidate(Spec, `${fullname}@${versionSpec}`);
     this.#requireUnpkgEnable();
     const [ scope, name ] = getScopeAndName(fullname);
     const { packageVersion } = await this.packageManagerService.showPackageVersionByVersionOrTag(
@@ -96,7 +96,7 @@ export class PackageVersionFileController extends AbstractController {
       @HTTPParam() versionSpec: string,
       @HTTPQuery() meta: string) {
     this.#requireUnpkgEnable();
-    ctx.tValidate(Spec, versionSpec);
+    ctx.tValidate(Spec, `${fullname}@${versionSpec}`);
     ctx.vary(this.config.cnpmcore.cdnVaryHeader);
     const [ scope, name ] = getScopeAndName(fullname);
     const packageVersion = await this.#getPackageVersion(ctx, fullname, scope, name, versionSpec);
@@ -129,7 +129,7 @@ export class PackageVersionFileController extends AbstractController {
       @HTTPParam() path: string,
       @HTTPQuery() meta: string) {
     this.#requireUnpkgEnable();
-    ctx.tValidate(Spec, versionSpec);
+    ctx.tValidate(Spec, `${fullname}@${versionSpec}`);
     ctx.vary(this.config.cnpmcore.cdnVaryHeader);
     const [ scope, name ] = getScopeAndName(fullname);
     path = `/${path}`;

--- a/app/port/controller/package/ShowPackageVersionController.ts
+++ b/app/port/controller/package/ShowPackageVersionController.ts
@@ -12,6 +12,7 @@ import { AbstractController } from '../AbstractController';
 import { getScopeAndName, FULLNAME_REG_STRING } from '../../../common/PackageUtil';
 import { isSyncWorkerRequest } from '../../../common/SyncUtil';
 import { PackageManagerService } from '../../../core/service/PackageManagerService';
+import { Spec } from 'app/port/typebox';
 
 @HTTPController()
 export class ShowPackageVersionController extends AbstractController {
@@ -19,28 +20,29 @@ export class ShowPackageVersionController extends AbstractController {
   private packageManagerService: PackageManagerService;
 
   @HTTPMethod({
-    // GET /:fullname/:versionOrTag
-    path: `/:fullname(${FULLNAME_REG_STRING})/:versionOrTag`,
+    // GET /:fullname/:versionSpec
+    path: `/:fullname(${FULLNAME_REG_STRING})/:versionSpec`,
     method: HTTPMethodEnum.GET,
   })
-  async show(@Context() ctx: EggContext, @HTTPParam() fullname: string, @HTTPParam() versionOrTag: string) {
+  async show(@Context() ctx: EggContext, @HTTPParam() fullname: string, @HTTPParam() versionSpec: string) {
     // https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#full-metadata-format
+    ctx.tValidate(Spec, versionSpec);
     const [ scope, name ] = getScopeAndName(fullname);
     const isSync = isSyncWorkerRequest(ctx);
     const abbreviatedMetaType = 'application/vnd.npm.install-v1+json';
     const isFullManifests = ctx.accepts([ 'json', abbreviatedMetaType ]) !== abbreviatedMetaType;
 
-    const { blockReason, manifest, pkg } = await this.packageManagerService.showPackageVersionManifest(scope, name, versionOrTag, isSync, isFullManifests);
+    const { blockReason, manifest, pkg } = await this.packageManagerService.showPackageVersionManifest(scope, name, versionSpec, isSync, isFullManifests);
     if (!pkg) {
       const allowSync = this.getAllowSync(ctx);
       throw this.createPackageNotFoundErrorWithRedirect(fullname, undefined, allowSync);
     }
     if (blockReason) {
       this.setCDNHeaders(ctx);
-      throw this.createPackageBlockError(blockReason, fullname, versionOrTag);
+      throw this.createPackageBlockError(blockReason, fullname, versionSpec);
     }
     if (!manifest) {
-      throw new NotFoundError(`${fullname}@${versionOrTag} not found`);
+      throw new NotFoundError(`${fullname}@${versionSpec} not found`);
     }
     this.setCDNHeaders(ctx);
     return manifest;

--- a/app/port/controller/package/ShowPackageVersionController.ts
+++ b/app/port/controller/package/ShowPackageVersionController.ts
@@ -26,7 +26,7 @@ export class ShowPackageVersionController extends AbstractController {
   })
   async show(@Context() ctx: EggContext, @HTTPParam() fullname: string, @HTTPParam() versionSpec: string) {
     // https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#full-metadata-format
-    ctx.tValidate(Spec, versionSpec);
+    ctx.tValidate(Spec, `${fullname}@${versionSpec}`);
     const [ scope, name ] = getScopeAndName(fullname);
     const isSync = isSyncWorkerRequest(ctx);
     const abbreviatedMetaType = 'application/vnd.npm.install-v1+json';

--- a/app/port/typebox.ts
+++ b/app/port/typebox.ts
@@ -53,6 +53,11 @@ export const Version = Type.String({
   maxLength: 256,
 });
 
+export const Spec = Type.String({
+  format: 'semver-spec',
+  minLength: 1,
+});
+
 export const Description = Type.String({ maxLength: 10240, transform: [ 'trim' ] });
 
 export const TagRule = Type.Object({
@@ -125,6 +130,16 @@ export function patchAjv(ajv: any) {
       return !semver.validRange(tag);
     },
   });
+  ajv.addFormat('semver-spec', {
+    type: 'string',
+    validate: (spec: string) => {
+      try {
+        return !!semver.parse(spec);
+      } catch (e) {
+        return false;
+      }
+    }
+  })
   ajv.addFormat('binary-name', {
     type: 'string',
     validate: (binaryName: string) => {

--- a/app/port/typebox.ts
+++ b/app/port/typebox.ts
@@ -1,6 +1,7 @@
 import { Type, Static } from '@sinclair/typebox';
 import { RegistryType } from '../common/enum/Registry';
 import semver from 'semver';
+import npa from 'npm-package-arg';
 import { HookType } from '../common/enum/Hook';
 import binaryConfig from '../../config/binaries';
 
@@ -134,12 +135,12 @@ export function patchAjv(ajv: any) {
     type: 'string',
     validate: (spec: string) => {
       try {
-        return !!semver.parse(spec);
+        return !!npa(spec);
       } catch (e) {
         return false;
       }
-    }
-  })
+    },
+  });
   ajv.addFormat('binary-name', {
     type: 'string',
     validate: (binaryName: string) => {

--- a/test/port/controller/PackageVersionFileController/listFiles.test.ts
+++ b/test/port/controller/PackageVersionFileController/listFiles.test.ts
@@ -10,7 +10,7 @@ describe('test/port/controller/PackageVersionFileController/listFiles.test.ts', 
     publisher = await TestUtil.createUser();
   });
 
-  describe('[GET /:fullname/:versionOrTag/files] listFiles()', () => {
+  describe('[GET /:fullname/:versionSpec/files] listFiles()', () => {
     it('should 404 when enableUnpkg = false', async () => {
       mock(app.config.cnpmcore, 'allowPublishNonScopePackage', true);
       mock(app.config.cnpmcore, 'enableUnpkg', false);
@@ -66,6 +66,15 @@ describe('test/port/controller/PackageVersionFileController/listFiles.test.ts', 
         .expect(404)
         .expect('content-type', 'application/json; charset=utf-8');
       assert.equal(res.body.error, '[NOT_FOUND] File foo@1.0.0/index.js not found');
+    });
+
+    it('should 422 when invalid spec', async () => {
+      mock(app.config.cnpmcore, 'enableUnpkg', true);
+      const res = await app.httpRequest()
+        .get('/foo/@invalid-spec/files')
+        .expect(422);
+
+      assert.equal(res.body.error, '[INVALID_PARAM] must match format "semver-spec"');
     });
 
     it('should list one package version files', async () => {

--- a/test/port/controller/PackageVersionFileController/raw.test.ts
+++ b/test/port/controller/PackageVersionFileController/raw.test.ts
@@ -11,7 +11,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
     publisher = await TestUtil.createUser();
   });
 
-  describe('[GET /:fullname/:versionOrTag/files/:path] raw()', () => {
+  describe('[GET /:fullname/:versionSpec/files/:path] raw()', () => {
     it('should show one package version raw file', async () => {
       mock(app.config.cnpmcore, 'allowPublishNonScopePackage', true);
       const pkg = await TestUtil.getFullPackage({
@@ -135,6 +135,15 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
       assert(!res.headers.etag);
       assert(!res.headers['cache-control']);
       assert.equal(res.body.error, `[NOT_FOUND] File ${pkg.name}@1.0.0/package2.json not found`);
+    });
+
+    it('should 422 when invalid spec', async () => {
+      mock(app.config.cnpmcore, 'enableUnpkg', true);
+      const res = await app.httpRequest()
+        .get(`/foo/@invalid-spec/files/package.json?meta`)
+        .expect(422);
+
+      assert.equal(res.body.error, '[INVALID_PARAM] must match format "semver-spec"');
     });
 
     it('should ignore not exists file on tar onentry', async () => {

--- a/test/port/controller/PackageVersionFileController/raw.test.ts
+++ b/test/port/controller/PackageVersionFileController/raw.test.ts
@@ -140,7 +140,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
     it('should 422 when invalid spec', async () => {
       mock(app.config.cnpmcore, 'enableUnpkg', true);
       const res = await app.httpRequest()
-        .get(`/foo/@invalid-spec/files/package.json?meta`)
+        .get('/foo/@invalid-spec/files/package.json?meta')
         .expect(422);
 
       assert.equal(res.body.error, '[INVALID_PARAM] must match format "semver-spec"');

--- a/test/port/controller/PackageVersionFileController/sync.test.ts
+++ b/test/port/controller/PackageVersionFileController/sync.test.ts
@@ -10,7 +10,7 @@ describe('test/port/controller/PackageVersionFileController/sync.test.ts', () =>
     adminUser = await TestUtil.createAdmin();
   });
 
-  describe('[PUT /:fullname/:versionOrTag/files] sync()', () => {
+  describe('[PUT /:fullname/:versionSpec/files] sync()', () => {
     it('should 404 when enableUnpkg = false', async () => {
       mock(app.config.cnpmcore, 'allowPublishNonScopePackage', true);
       mock(app.config.cnpmcore, 'enableUnpkg', false);

--- a/test/port/controller/package/ShowPackageVersionController.test.ts
+++ b/test/port/controller/package/ShowPackageVersionController.test.ts
@@ -37,6 +37,15 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
       assert.equal(res.body.dist.integrity, 'sha512-n+4CQg0Rp1Qo0p9a0R5E5io67T9iD3Lcgg6exmpmt0s8kd4XcOoHu2kiu6U7xd69cGq0efkNGWUBP229ObfRSA==');
       assert.equal(res.body.dist.size, 251);
       assert.equal(res.body.description, 'work with utf8mb4 💩, 𝌆 utf8_unicode_ci, foo𝌆bar 🍻');
+
+      // support semver spec
+      await app.httpRequest()
+        .get('/foo/%5E1.0')
+        .expect(200);
+
+      await app.httpRequest()
+        .get('/foo/^1.0')
+        .expect(200);
     });
 
     it('should fix bug version', async () => {

--- a/test/port/controller/package/ShowPackageVersionController.test.ts
+++ b/test/port/controller/package/ShowPackageVersionController.test.ts
@@ -10,7 +10,7 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
     publisher = await TestUtil.createUser();
   });
 
-  describe('[GET /:fullname/:versionOrTag] show()', () => {
+  describe('[GET /:fullname/:versionSpec] show()', () => {
     it('should show one package version', async () => {
       mock(app.config.cnpmcore, 'allowPublishNonScopePackage', true);
       const pkg = await TestUtil.getFullPackage({
@@ -123,6 +123,14 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
       assert(new URL(res.body.dist.tarball).pathname === '/foo/-/foo-2.0.0.tgz');
       assert(!res.body.deprecated);
       assert(res.body.version === '2.0.0');
+    });
+
+    it('should 422 with invalid spec', async () => {
+      const res = await app.httpRequest()
+        .get('/foo/@invalid-spec')
+        .expect(422)
+        .expect('content-type', 'application/json; charset=utf-8');
+      assert(res.error, '[INVALID_PARAM] must match format "semver-spec"');
     });
 
     it('should work with scoped package', async () => {


### PR DESCRIPTION
> follow https://github.com/cnpm/cnpmcore/pull/495 after supporting spec, adjust the parameter validation rules
1. 🆕 Add `Spec` validation rule, validating the spec by npa
2. 🛠️ Upgrade versionOrTag to versionSpec to support semver expressions, such as `^2.x || > 3.x`
---------

> follow https://github.com/cnpm/cnpmcore/pull/495 支持 spec 后，调整参数校验规则
1. 🆕 新增 `Sepc` 校验规则，使用 npa 拼接包名进行验证
2. 🛠️ versionOrTag 升级为 versionSpec 支持 semver 表达式，例如 `^2.x || > 3.x`

