### PR TITLE
feat: bulk update maintainers

### DIFF
--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -329,9 +329,9 @@ export class PackageManagerService extends AbstractService {
     }
   }
 
-  async replacePackageMaintainers(pkg: Package, maintainers: User[]) {
+  async replacePackageMaintainersAndDist(pkg: Package, maintainers: User[]) {
     await this.packageRepository.replacePackageMaintainers(pkg.packageId, maintainers.map(m => m.userId));
-    await this._refreshPackageManifestRootAttributeOnlyToDists(pkg, 'maintainers');
+    await this.refreshPackageMaintainersToDists(pkg);
     this.eventBus.emit(PACKAGE_MAINTAINER_CHANGED, pkg.fullname, maintainers);
   }
 
@@ -344,14 +344,12 @@ export class PackageManagerService extends AbstractService {
       }
     }
     if (hasNewRecord) {
-      await this._refreshPackageManifestRootAttributeOnlyToDists(pkg, 'maintainers');
       this.eventBus.emit(PACKAGE_MAINTAINER_CHANGED, pkg.fullname, maintainers);
     }
   }
 
   async removePackageMaintainer(pkg: Package, maintainer: User) {
     await this.packageRepository.removePackageMaintainer(pkg.packageId, maintainer.userId);
-    await this._refreshPackageManifestRootAttributeOnlyToDists(pkg, 'maintainers');
     this.eventBus.emit(PACKAGE_MAINTAINER_REMOVED, pkg.fullname, maintainer.name);
   }
 

--- a/app/core/service/PackageSyncerService.ts
+++ b/app/core/service/PackageSyncerService.ts
@@ -819,7 +819,9 @@ export class PackageSyncerService extends AbstractService {
     // The event is initialized in the repository and distributed after uncork.
     // maintainers' information is updated in bulk to ensure consistency.
     if (!isEqual(maintainers, existsMaintainers)) {
+      logs.push(`[${isoNow()}] 🚧 Syncing maintainers to package manifest, from: ${JSON.stringify(maintainers)} to: ${JSON.stringify(existsMaintainers)}`);
       await this.packageManagerService.refreshPackageMaintainersToDists(pkg);
+      logs.push(`[${isoNow()}] 🟢 Syncing maintainers to package manifest done`);
     }
 
     // 5. add deps sync task

--- a/app/core/service/PackageSyncerService.ts
+++ b/app/core/service/PackageSyncerService.ts
@@ -10,6 +10,7 @@ import {
 } from 'egg';
 import { setTimeout } from 'timers/promises';
 import { rm } from 'fs/promises';
+import { isEqual } from 'lodash';
 import semver from 'semver';
 import { NPMRegistry, RegistryResponse } from '../../common/adapter/NPMRegistry';
 import { detectInstallScript, getScopeAndName } from '../../common/PackageUtil';
@@ -812,6 +813,13 @@ export class PackageSyncerService extends AbstractService {
     }
     if (removedMaintainers.length > 0) {
       logs.push(`[${isoNow()}] 🟢 Removed ${removedMaintainers.length} maintainers: ${JSON.stringify(removedMaintainers)}`);
+    }
+
+    // 4.2 update package maintainers in dist
+    // The event is initialized in the repository and distributed after uncork.
+    // maintainers' information is updated in bulk to ensure consistency.
+    if (!isEqual(maintainers, existsMaintainers)) {
+      await this.packageManagerService.refreshPackageMaintainersToDists(pkg);
     }
 
     // 5. add deps sync task

--- a/app/port/controller/package/UpdatePackageController.ts
+++ b/app/port/controller/package/UpdatePackageController.ts
@@ -64,7 +64,7 @@ export class UpdatePackageController extends AbstractController {
       users.push(user);
     }
 
-    await this.packageManagerService.replacePackageMaintainers(pkg, users);
+    await this.packageManagerService.replacePackageMaintainersAndDist(pkg, users);
     return { ok: true };
   }
 


### PR DESCRIPTION
> Some dirty data of userPrefix in the maintainers cannot be cleared during synchronization. Adjust the synchronization logic for maintainers.
1. 🧶 When synchronizing packages, uniformly update the manifest dist.
2. 🛠️ `replacereplacePackageMaintainers` => `replacePackageMaintainersAndDist`
-----
> 部分旧包 maintainer 中的 userPrefix 脏数据同步时由于没有成员变更，无法清除，调整 maintainer 同步逻辑
1. 🧶 包同步时，统一更新 maintainer 对应的 manifest dist
2. 🛠️ `replacereplacePackageMaintainers` => `replacePackageMaintainersAndDist` 