### PR TITLE
fix: sync self pkg

### DIFF
--- a/app/core/service/PackageSyncerService.ts
+++ b/app/core/service/PackageSyncerService.ts
@@ -33,7 +33,7 @@ import { Registry } from '../entity/Registry';
 import { BadRequestError } from 'egg-errors';
 import { ScopeManagerService } from './ScopeManagerService';
 import { EventCorkAdvice } from './EventCorkerAdvice';
-import { SyncDeleteMode } from '../../common/constants';
+import { PresetRegistryName, SyncDeleteMode } from '../../common/constants';
 
 type syncDeletePkgOptions = {
   task: Task,
@@ -371,6 +371,14 @@ export class PackageSyncerService extends AbstractService {
       logs.push(`[${isoNow()}] 👉 syncing specific versions: ${specificVersions.join(' | ')} 👈`);
     }
     logs.push(`[${isoNow()}] 🚧 log: ${logUrl}`);
+
+    if (registry?.name === PresetRegistryName.self) {
+      logs.push(`[${isoNow()}] ❌❌❌❌❌ ${fullname} has been published to the self registry, skip sync ❌❌❌❌❌`);
+      await this.taskService.finishTask(task, TaskState.Fail, logs.join('\n'));
+      this.logger.info('[PackageSyncerService.executeTask:fail] taskId: %s, targetName: %s, invalid registryId',
+        task.taskId, task.targetName);
+      return;
+    }
 
     if (pkg && pkg?.registryId !== registry?.registryId) {
       if (pkg.registryId) {


### PR DESCRIPTION
> During the syncUpstream process, it will attempt to create sync repeatedly until it times out, when the pkg has been published in the self registry.
1. 🐞 When executing the syncTask, filter out scenarios where the target registry is the self registry.
-------

> 包迁移至当前 registry 时，收到同步请求会产生无效的同步任务，当 `syncUpstream` 时，会尝试重复创建 sync 直到超时。
1. 🐞 syncTask 执行时，先过滤目标 registry 是当前 registry 的场景。