### PR TITLE
fix: update source registry

### DIFF
--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -163,11 +163,9 @@ export class PackageManagerService extends AbstractService {
     };
 
     // add _registry_name field to cmd.packageJson
-    if (!cmd.packageJson._source_registry_name) {
-      const registry = await this.getSourceRegistry(pkg);
-      if (registry) {
-        cmd.packageJson._source_registry_name = registry.name;
-      }
+    const registry = await this.getSourceRegistry(pkg);
+    if (registry) {
+      cmd.packageJson._source_registry_name = registry.name;
     }
 
     // https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#abbreviated-version-object
@@ -832,11 +830,10 @@ export class PackageManagerService extends AbstractService {
         await this.bugVersionService.fixPackageBugVersions(bugVersion, fullname, data.versions);
       }
       // set _source_registry_name in full manifestDist
-      if (!data._source_registry_name && isFullManifests) {
-        if (registry) {
-          data._source_registry_name = registry?.name;
-        }
+      if (registry) {
+        data._source_registry_name = registry?.name;
       }
+
       const distBytes = Buffer.from(JSON.stringify(data));
       const distIntegrity = await calculateIntegrity(distBytes);
       etag = `"${distIntegrity.shasum}"`;

--- a/test/port/controller/package/SavePackageVersionController.test.ts
+++ b/test/port/controller/package/SavePackageVersionController.test.ts
@@ -179,6 +179,10 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
       pkgEntity.registryId = '';
       await packageRepository.savePackage(pkgEntity!);
 
+      res = await app.httpRequest()
+        .get(`/${pkg.name}`);
+      assert.equal(res.body._source_registry_name, 'default');
+
       pkg = await TestUtil.getFullPackage({ name, version: '2.0.0' });
       res = await app.httpRequest()
         .put(`/${pkg.name}`)
@@ -189,6 +193,10 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
 
       pkgEntity = await packageRepository.findPackage('@cnpm', 'publish-package-test');
       assert(pkgEntity?.registryId);
+
+      res = await app.httpRequest()
+        .get(`/${pkg.name}`);
+      assert.equal(res.body._source_registry_name, 'self');
     });
 
     it('should publish on user custom scopes', async () => {


### PR DESCRIPTION
> the registryInfo in pkg fullManifest should be updated when the package is migrated to another registry.

1. 🐞 when query from DB, dynamically add registry information.
2. ♻️ when hit cache, updating metadata should already trigger cache modifications.
--------

> 当包从属 registryId 发生变化时，包 manifest 内的信息也需要同步更新
1. 🐞 从 db 读取元信息时，实时添加 registry 信息
2. ♻️ 从缓存读取元信息时，发布或修改元信息时已触发缓存修改