### PR TITLE
feat: support strictValidateTarballPkg

### DIFF
--- a/app/common/PackageUtil.ts
+++ b/app/common/PackageUtil.ts
@@ -110,8 +110,8 @@ export async function extractPackageJSON(tarballBytes: Buffer): Promise<PackageJ
       .pipe(tar.t({
         filter: name => name === 'package/package.json',
         onentry: async entry => {
-          let chunks: Buffer[] = [];
-          for await (let chunk of entry) {
+          const chunks: Buffer[] = [];
+          for await (const chunk of entry) {
             chunks.push(chunk);
           }
           try {

--- a/app/port/config.ts
+++ b/app/port/config.ts
@@ -150,4 +150,9 @@ export type CnpmcoreConfig = {
    * in most cases, you should set to false to keep the same behavior as source registry.
    */
   strictSyncSpecivicVersion: boolean,
+
+  /**
+   * strictly enforces/validates manifest and tgz when publish, https://github.com/cnpm/cnpmcore/issues/542
+   */
+  strictValidateTarballPkg?: boolean,
 };

--- a/app/port/controller/package/SavePackageVersionController.ts
+++ b/app/port/controller/package/SavePackageVersionController.ts
@@ -179,11 +179,11 @@ export class SavePackageVersionController extends AbstractController {
     if (this.config.cnpmcore.strictValidateTarballPkg) {
       const tarballPkg = await extractPackageJSON(tarballBytes);
       const versionManifest = pkg.versions[tarballPkg.version];
-      const diffKey = STRICT_CHECK_TARBALL_FIELDS.find(key => {
+      const diffKeys = STRICT_CHECK_TARBALL_FIELDS.filter(key => {
         return !isEqual(tarballPkg[key], versionManifest[key]);
       });
-      if (diffKey) {
-        throw new UnprocessableEntityError(`${diffKey} mismatch between tarball and manifest`);
+      if (diffKeys.length > 0) {
+        throw new UnprocessableEntityError(`${diffKeys} mismatch between tarball and manifest`);
       }
     }
 

--- a/app/port/controller/package/SavePackageVersionController.ts
+++ b/app/port/controller/package/SavePackageVersionController.ts
@@ -1,4 +1,5 @@
 import { PackageJson, Simplify } from 'type-fest';
+import { isEqual } from 'lodash';
 import {
   UnprocessableEntityError,
   ForbiddenError,
@@ -17,7 +18,7 @@ import * as ssri from 'ssri';
 import validateNpmPackageName from 'validate-npm-package-name';
 import { Static, Type } from '@sinclair/typebox';
 import { AbstractController } from '../AbstractController';
-import { getScopeAndName, FULLNAME_REG_STRING } from '../../../common/PackageUtil';
+import { getScopeAndName, FULLNAME_REG_STRING, extractPackageJSON } from '../../../common/PackageUtil';
 import { PackageManagerService } from '../../../core/service/PackageManagerService';
 import {
   VersionRule,
@@ -27,6 +28,8 @@ import {
 } from '../../typebox';
 import { RegistryManagerService } from '../../../core/service/RegistryManagerService';
 import { PackageJSONType } from '../../../repository/PackageRepository';
+
+const STRICT_CHECK_TARBALL_FIELDS: (keyof PackageJson)[] = [ 'name', 'version', 'scripts', 'dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies', 'license', 'licenses', 'bin' ];
 
 type PackageVersion = Simplify<PackageJson.PackageJsonStandard & {
   name: 'string';
@@ -168,6 +171,19 @@ export class SavePackageVersionController extends AbstractController {
       if (packageVersion.dist?.shasum && packageVersion.dist.shasum !== shasum) {
         // if integrity not exists, check shasum
         throw new UnprocessableEntityError('dist.shasum invalid');
+      }
+    }
+
+    // https://github.com/cnpm/cnpmcore/issues/542
+    // check tgz & manifests
+    if (this.config.cnpmcore.strictValidateTarballPkg) {
+      const tarballPkg = await extractPackageJSON(tarballBytes);
+      const versionManifest = pkg.versions[tarballPkg.version];
+      const diffKey = STRICT_CHECK_TARBALL_FIELDS.find(key => {
+        return !isEqual(tarballPkg[key], versionManifest[key]);
+      });
+      if (diffKey) {
+        throw new UnprocessableEntityError(`${diffKey} mismatch between tarball and manifest`);
       }
     }
 

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -54,6 +54,7 @@ export const cnpmcoreConfig: CnpmcoreConfig = {
   redirectNotFound: true,
   enableUnpkg: true,
   strictSyncSpecivicVersion: false,
+  strictValidateTarballPkg: false,
 };
 
 export default (appInfo: EggAppConfig) => {

--- a/test/port/controller/package/SavePackageVersionController.test.ts
+++ b/test/port/controller/package/SavePackageVersionController.test.ts
@@ -21,7 +21,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
   });
 
   describe('[PUT /:fullname] save()', () => {
-    it('should set registry filed after publish', async () => {
+    it('should set registry field after publish', async () => {
       mock(app.config.cnpmcore, 'allowPublishNonScopePackage', true);
       const { pkg, user } = await TestUtil.createPackage({ name: 'non_scope_pkg', version: '1.0.0' });
       const pkg2 = await TestUtil.getFullPackage({ name: pkg.name, version: '2.0.0' });
@@ -85,6 +85,21 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
 
       assert(pkgEntity);
       assert.equal(pkgEntity.registryId, selfRegistry.registryId);
+    });
+    it('should verify tgz and manifest', async () => {
+      mock(app.config.cnpmcore, 'allowPublishNonScopePackage', true);
+      const { pkg, user } = await TestUtil.createPackage({ name: 'non_scope_pkg', version: '1.0.0' });
+      const pkg2 = await TestUtil.getFullPackage({ name: pkg.name, version: '2.0.0' });
+
+      mock(app.config.cnpmcore, 'strictValidateTarballPkg', true);
+      const res = await app.httpRequest()
+        .put(`/${pkg2.name}`)
+        .set('authorization', user.authorization)
+        .set('user-agent', user.ua)
+        .send(pkg2)
+        .expect(422);
+
+      assert.equal(res.body.error, '[UNPROCESSABLE_ENTITY] name mismatch between tarball and manifest');
     });
 
     it('should add new version success on scoped package', async () => {


### PR DESCRIPTION
> Validate the manifest and tarball info to prevent contamination during consumption, closes #542.
1. 🔨 Added the "strictValidateTarballPkg" mode to enable validation, only applicable to the slef registry scenario.
2. 🧶 When the configuration is enabled, validate the relevant fields during publishing, currently only validating the fields affecting consumption.
3. ♻️ No corrective actions will be taken for existing scenario data.
-----

> 发布时校验 manifest 和 tarball 字段是否陪陪，防止消费时被污染 closes #542
1. 🔨 新增 strictValidateTarballPkg 配置，仅对在发布当前 registry 场景下生效
2. 🧶 配置开启时，发布时校验相关字段，目前仅校验影响消费相关字段
3. ♻️ 存量场景数据不做订正处理