### PR TITLE
feat: add lastUsedAt for classic token

### DIFF
--- a/app/core/service/TokenService.ts
+++ b/app/core/service/TokenService.ts
@@ -36,14 +36,9 @@ export class TokenService extends AbstractService {
     return null;
   }
 
-  public async checkTokenExpired(token: Token) {
-    // skip classic token
-    if (!isGranularToken(token)) {
-      return true;
-    }
-
+  public async checkTokenStatus(token: Token) {
     // check for expires
-    if (dayjs(token.expiredAt).isBefore(new Date())) {
+    if (isGranularToken(token) && dayjs(token.expiredAt).isBefore(new Date())) {
       throw new UnauthorizedError('Token expired');
     }
 

--- a/app/port/UserRoleManager.ts
+++ b/app/port/UserRoleManager.ts
@@ -113,7 +113,7 @@ export class UserRoleManager {
     }
 
     // check token expired & set lastUsedAt
-    await this.tokenService.checkTokenExpired(authorizedUserAndToken.token);
+    await this.tokenService.checkTokenStatus(authorizedUserAndToken.token);
     this.currentAuthorizedToken = authorizedUserAndToken.token;
     this.currentAuthorizedUser = authorizedUserAndToken.user;
     ctx.userId = authorizedUserAndToken.user.userId;

--- a/test/port/controller/TokenController/listTokens.test.ts
+++ b/test/port/controller/TokenController/listTokens.test.ts
@@ -4,6 +4,7 @@ import { AuthAdapter } from '../../../../app/infra/AuthAdapter';
 import assert from 'assert';
 import { app, mock } from 'egg-mock/bootstrap';
 import { TestUtil } from '../../../../test/TestUtil';
+import dayjs from 'dayjs';
 
 describe('test/port/controller/TokenController/listTokens.test.ts', () => {
   describe('[GET /-/npm/v1/tokens] listTokens()', () => {
@@ -33,6 +34,24 @@ describe('test/port/controller/TokenController/listTokens.test.ts', () => {
       assert.equal(tokens[0].automation, false);
       assert(tokens[0].created);
       assert(tokens[0].updated);
+    });
+
+    it('should update lastUsedAt', async () => {
+      const { authorization } = await TestUtil.createUser();
+      const now = Date.now();
+
+      let res = await app.httpRequest()
+        .get('/-/whoami')
+        .set('authorization', authorization)
+        .expect(200);
+
+      res = await app.httpRequest()
+        .get('/-/npm/v1/tokens')
+        .set('authorization', authorization)
+        .expect(200);
+
+      const lastUsedAt = res.body.objects[0].lastUsedAt;
+      assert(dayjs(lastUsedAt).isAfter(now));
     });
 
     it('should 401 when readonly token access', async () => {


### PR DESCRIPTION
> Follow https://github.com/cnpm/cnpmcore/pull/488 , add lastUsedAt for classic tokens.
1. 🧶 Modify the `checkTokenExpired` method to `checkTokenStatus` which update the token field internally.
2. ♻️ No compensation will be made for existing data, and it should be updated by the consuming end.
---------
> Follow https://github.com/cnpm/cnpmcore/pull/488, 为 classic token 也添加 lastUsedAt 信息
1. 🧶 修改 `checkTokenExpired` 方法为 `checkTokenStatus`，内部进行 token 字段更新
2. ♻️ 存量数据不做补偿，由消费端控制