### PR TITLE
feat: misc router

### DIFF
--- a/app/port/controller/HomeController.ts
+++ b/app/port/controller/HomeController.ts
@@ -9,8 +9,11 @@ import {
 } from '@eggjs/tegg';
 import { AbstractController } from './AbstractController';
 import { CacheService, DownloadInfo, UpstreamRegistryInfo } from '../../core/service/CacheService';
+import { NotFoundError, NotImplementedError } from 'egg-errors';
 
 const startTime = new Date();
+
+const NOT_IMPLEMENTED = [ '/-/npm/v1/security/audits/quick', '/-/npm/v1/security/advisories/bulk' ];
 
 // registry 站点信息数据 SiteTotalData
 // SiteEnvInfo: 环境、运行时相关信息，实时查询
@@ -96,5 +99,19 @@ export class HomeController extends AbstractController {
       pong: true,
       use: performance.now() - ctx.performanceStarttime!,
     };
+  }
+
+  @HTTPMethod({
+    path: '/*',
+    method: HTTPMethodEnum.POST,
+    priority: -Infinity,
+  })
+  async misc(@Context() ctx: EggContext) {
+    const { path } = ctx;
+    if (NOT_IMPLEMENTED.includes(path)) {
+      throw new NotImplementedError(`${ctx.path} not implemented yet`);
+    }
+
+    throw new NotFoundError(`${ctx.path} not found`);
   }
 }

--- a/test/port/controller/HomeController/misc.test.ts
+++ b/test/port/controller/HomeController/misc.test.ts
@@ -1,0 +1,20 @@
+import { app, assert } from 'egg-mock/bootstrap';
+
+describe('test/port/controller/HomeController/misc.test.ts', () => {
+  describe('[POST /*] misc()', () => {
+    it('should 501', async () => {
+      const res = await app.httpRequest()
+        .post('/-/npm/v1/security/audits/quick')
+        .expect(501);
+      assert.equal(res.body.error, '[NOT_IMPLEMENTED] /-/npm/v1/security/audits/quick not implemented yet');
+    });
+
+    it('should 404', async () => {
+      const res = await app.httpRequest()
+        .post('/-/greed/is/good')
+        .expect(404);
+      assert.equal(res.body.error, '[NOT_FOUND] /-/greed/is/good not found');
+    });
+  });
+
+});


### PR DESCRIPTION

![image](https://github.com/cnpm/cnpmcore/assets/5574625/d158e354-d390-4835-91de-7aa9f5104e49)


> close #551 , 针对未实现的 post 请求添加错误码

1. 🧶 拦截 audit 相关接口 [ref](https://docs.npmjs.com/cli/v9/commands/npm-audit)
2. ♻️ 默认 404 GET 接口不做额外处理

-----

> close #551, add error code for unimplemented post requests

1. 🧶 Intercept audit-related interfaces [ref](https://docs.npmjs.com/cli/v9/commands/npm-audit)
2. ♻️ No additional processing for default 404 GET interfaces.
