### PR TITLE
fix: _npmUser info in fullManifest

### DIFF
--- a/app/core/service/PackageSyncerService.ts
+++ b/app/core/service/PackageSyncerService.ts
@@ -605,9 +605,8 @@ export class PackageSyncerService extends AbstractService {
         // check metaDataKeys, if different value, override exists one
         // https://github.com/cnpm/cnpmjs.org/issues/1667
         // need libc field https://github.com/cnpm/cnpmcore/issues/187
-        const metaDataKeys = [
-          'peerDependenciesMeta', 'os', 'cpu', 'libc', 'workspaces', 'hasInstallScript', 'deprecated',
-        ];
+        // fix _npmUser field since https://github.com/cnpm/cnpmcore/issues/553
+        const metaDataKeys = [ 'peerDependenciesMeta', 'os', 'cpu', 'libc', 'workspaces', 'hasInstallScript', 'deprecated', '_npmUser' ];
         let diffMeta: any;
         for (const key of metaDataKeys) {
           let remoteItemValue = item[key];
@@ -691,7 +690,8 @@ export class PackageSyncerService extends AbstractService {
       };
       try {
         // 当 version 记录已经存在时，还需要校验一下 pkg.manifests 是否存在
-        const pkgVersion = await this.packageManagerService.publish(publishCmd, users[0]);
+        const publisher = users.find(user => user.name === item._npmUser?.name) || users[0];
+        const pkgVersion = await this.packageManagerService.publish(publishCmd, publisher);
         updateVersions.push(pkgVersion.version);
         logs.push(`[${isoNow()}] 🟢 [${syncIndex}] Synced version ${version} success, packageVersionId: ${pkgVersion.packageVersionId}, db id: ${pkgVersion.id}`);
       } catch (err: any) {


### PR DESCRIPTION
> closes #553, fixing the issue introduced by https://github.com/cnpm/cnpmcore/pull/491, which caused an abnormality in the _npmUser field in fullManifest.
1. 🧶 Update the `publish` method to pass in the actual operating publisher information.
2. 🧶 Update the diffMeta function to compare the _npmUser as well.
3. ♻️ Existing data needs to be resynchronized, from 6.2 to 7.20.
-----
> closes #553 , 修复由 https://github.com/cnpm/cnpmcore/pull/491 引入问题，导致 fullManifest 中  _npmUser 字段异常
1. 🧶 更新 .publish 方法，传入实际操作的 publisher 信息
2. 🧶 更新 diffMeta 算法，将 _npmUser 也进行比对
3. ♻️ 存量数据需要重新进行同步，6.2 -> 7.20
