### PR TITLE
fix: publisher info

### DIFF
--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -53,7 +53,7 @@ export interface PublishPackageCmd {
   // name don't include scope
   name: string;
   version: string;
-  description: string;
+  description?: string;
   packageJson: PackageJSONType;
   registryId?: string;
   readme: string;
@@ -107,14 +107,14 @@ export class PackageManagerService extends AbstractService {
         scope: cmd.scope,
         name: cmd.name,
         isPrivate: cmd.isPrivate,
-        description: cmd.description,
+        description: cmd.description || '',
         registryId: cmd.registryId,
       });
     } else {
       // update description
       // will read database twice to update description by model to entity and entity to model
       if (pkg.description !== cmd.description) {
-        pkg.description = cmd.description;
+        pkg.description = cmd.description || '';
       }
 
       /* c8 ignore next 3 */

--- a/app/core/service/PackageSyncerService.ts
+++ b/app/core/service/PackageSyncerService.ts
@@ -571,7 +571,7 @@ export class PackageSyncerService extends AbstractService {
       }
     }
     const updateVersions: string[] = [];
-    const differentMetas: any[] = [];
+    const differentMetas: [PackageJSONType, Partial<PackageJSONType>][] = [];
     let syncIndex = 0;
     for (const item of versions) {
       const version: string = item.version;
@@ -608,7 +608,7 @@ export class PackageSyncerService extends AbstractService {
         // fix _npmUser field since https://github.com/cnpm/cnpmcore/issues/553
         const metaDataKeys = [ 'peerDependenciesMeta', 'os', 'cpu', 'libc', 'workspaces', 'hasInstallScript', 'deprecated', '_npmUser' ];
         const ignoreInAbbreviated = ['_npmUser'];
-        let diffMeta: any;
+        let diffMeta: Partial<PackageJSONType>;
         for (const key of metaDataKeys) {
           let remoteItemValue = item[key];
           // make sure hasInstallScript exists

--- a/app/repository/PackageRepository.ts
+++ b/app/repository/PackageRepository.ts
@@ -95,6 +95,10 @@ export type PackageJSONType = CnpmcorePatchInfo & {
   hasInstallScript?: boolean;
   dist?: DistType;
   workspace?: string[];
+  _npmUser?: {
+    name: string;
+    email: string;
+  };
   [key: string]: unknown;
 };
 


### PR DESCRIPTION
> Fixed an issue with the `_npmUser` field setting during the initial sync.
1. 🧶 Fixed _npmUser field setting issue during initial sync, should use displayName.
2. 🧶 skip diff abbreviated meta for _npmUser
3. 🤖 Refined some TypeScript definitions, use isEqual to diff metas

-------

> 修复首次同步时，`_npmUser` 字段设置异常
1. 🧶 修复 publisher 匹配，获取逻辑，应当用 displayName 进行匹配
2. 🧶 精简 meta 信息，跳过比较不存在的 _npmUser 字段
2. 🤖 调整部分 ts 定义，使用 isEqual 来进行 diff 比较