### PR TITLE
feat: signup on auth

### DIFF
--- a/app/core/service/UserService.ts
+++ b/app/core/service/UserService.ts
@@ -106,19 +106,23 @@ export class UserService extends AbstractService {
     return { code: LoginResultCode.Success, user, token };
   }
 
-  async ensureTokenByUser({ name, email, password = crypto.randomUUID(), ip }: Optional<CreateUser, 'password'>) {
+  async findOrCreateUser({ name, email, ip, password = crypto.randomUUID() }: Optional<CreateUser, 'password'>) {
     let user = await this.userRepository.findUserByName(name);
     if (!user) {
       const createRes = await this.create({
         name,
         email,
-        // Authentication via sso
-        // should use token instead of password
         password,
         ip,
       });
       user = createRes.user;
     }
+
+    return user;
+  }
+
+  async ensureTokenByUser(opts: Optional<CreateUser, 'password'>) {
+    const user = await this.findOrCreateUser(opts);
     const token = await this.createToken(user.userId);
     return { user, token };
   }

--- a/test/port/controller/TokenController/createToken.test.ts
+++ b/test/port/controller/TokenController/createToken.test.ts
@@ -135,21 +135,20 @@ describe('test/port/controller/TokenController/createToken.test.ts', () => {
       assert.match(res.body.error, /\[FORBIDDEN\] need login first/);
     });
 
-    it('should 403 when no user info', async () => {
+    it('should auto create when no user info', async () => {
       mock(AuthAdapter.prototype, 'ensureCurrentUser', async () => {
         return {
           name: 'banana',
           email: 'banana@fruits.com',
         };
       });
-      const res = await app.httpRequest()
+      await app.httpRequest()
         .post('/-/npm/v1/tokens/gat')
         .send({
           name: 'banana',
           expires: 30,
         })
-        .expect(403);
-      assert.match(res.body.error, /\[FORBIDDEN\] invalid user info/);
+        .expect(200);
     });
 
     describe('should 200', () => {


### PR DESCRIPTION
> Auto init the account when auth

* 🧶 Added `findOrCreateUser` method. Initialize account on both login and authorization, as per the submitted GitHub."
------

> 授权时，默认进行账户初始化
* 🧶 新增 `findOrCreateUser` 方法，登录和授权时均初始化账户