### PR TITLE
fix: default latest tag

### DIFF
--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -64,7 +64,7 @@ export interface PublishPackageCmd {
     // sync worker will use localFile field
     localFile?: string;
   }, 'content' | 'localFile'>;
-  tag?: string;
+  tags?: string[];
   isPrivate: boolean;
   // only use on sync package
   publishTime?: Date;
@@ -270,10 +270,15 @@ export class PackageManagerService extends AbstractService {
     if (cmd.skipRefreshPackageManifests !== true) {
       await this.refreshPackageChangeVersionsToDists(pkg, [ pkgVersion.version ]);
     }
-    if (cmd.tag) {
-      await this.savePackageTag(pkg, cmd.tag, cmd.version, true);
+    if (cmd.tags) {
+      for (const tag of cmd.tags) {
+        await this.savePackageTag(pkg, tag, cmd.version, true);
+        this.eventBus.emit(PACKAGE_VERSION_ADDED, pkg.fullname, pkgVersion.version, tag);
+      }
+    } else {
+      this.eventBus.emit(PACKAGE_VERSION_ADDED, pkg.fullname, pkgVersion.version, undefined);
     }
-    this.eventBus.emit(PACKAGE_VERSION_ADDED, pkg.fullname, pkgVersion.version, cmd.tag);
+
     return pkgVersion;
   }
 

--- a/test/core/service/PackageManagerService/publish.test.ts
+++ b/test/core/service/PackageManagerService/publish.test.ts
@@ -37,7 +37,7 @@ describe('test/core/service/PackageManagerService/publish.test.ts', () => {
         dist: {
           content: Buffer.alloc(0),
         },
-        tag: '',
+        tags: [ '' ],
         scope: '',
         name: 'foo',
         description: 'foo description',
@@ -54,7 +54,7 @@ describe('test/core/service/PackageManagerService/publish.test.ts', () => {
         dist: {
           content: Buffer.alloc(0),
         },
-        tag: '',
+        tags: [ '' ],
         scope: '',
         name: 'foo',
         description: 'foo description new',
@@ -77,7 +77,7 @@ describe('test/core/service/PackageManagerService/publish.test.ts', () => {
         dist: {
           content: Buffer.alloc(0),
         },
-        tag: '',
+        tags: [ '' ],
         scope: '',
         name: 'foo',
         description: '~'.repeat(1100 * 100),
@@ -98,7 +98,7 @@ describe('test/core/service/PackageManagerService/publish.test.ts', () => {
         dist: {
           localFile: TestUtil.getFixtures('registry.npmjs.org/pedding/-/pedding-1.1.0.tgz'),
         },
-        tag: '',
+        tags: [ '' ],
         scope: '',
         name: 'pedding',
         description: 'pedding description',

--- a/test/port/controller/package/SavePackageVersionController.test.ts
+++ b/test/port/controller/package/SavePackageVersionController.test.ts
@@ -813,7 +813,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
         dist: {
           content: Buffer.from('', 'base64'),
         },
-        tag: 'latest',
+        tags: [ 'latest' ],
         isPrivate: true,
       }, user!);
 
@@ -1214,6 +1214,34 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
           .send(pkg);
 
         assert.equal(res.status, 201);
+      });
+
+      it('should 200 add default latest tag', async () => {
+        const name = '@cnpm/default_latest_tag';
+        token = await userService.createToken(user!.userId, {
+          name: 'new-token',
+          type: TokenType.granular,
+          allowedPackages: [ name ],
+          expires: 1,
+        });
+
+        const pkg = await TestUtil.getFullPackage({ name, version: '3.0.0' });
+        pkg['dist-tags'] = {
+          beta: '3.0.0',
+        };
+        const res = await app.httpRequest()
+          .put(`/${name}`)
+          .set('authorization', `Bearer ${token.token}`)
+          .set('user-agent', publisher.ua)
+          .send(pkg);
+
+        assert.equal(res.status, 201);
+
+        const queryRes = await app.httpRequest()
+          .get(`/${name}/latest`);
+
+        assert.equal(queryRes.body.version, '3.0.0');
+
       });
     });
   });

--- a/test/repository/PackageRepository.test.ts
+++ b/test/repository/PackageRepository.test.ts
@@ -29,7 +29,7 @@ describe('test/repository/PackageRepository.test.ts', () => {
         dist: {
           content: Buffer.alloc(0),
         },
-        tag: '',
+        tags: [ '' ],
         scope: '',
         name: 'foo',
         description: 'foo description',


### PR DESCRIPTION
> closes #574 Fixed the issue where custom tags in publishConfig prevented the default latest tag.
* 🧶 Modified the `savePackageVersion` API, automatically add latest tag if no latest tag.
* 🧶 The publish tag parameter has been changed to tags, triggering corresponding events in batches.
* ♻️ No changes to the package synchronization process.
------
> closes #574 修复 publishConfig 中自定义 tag，导致 latest tag 未设置的问题
* 🧶 修改 savePackageVersion 接口，如果当前包未配置 latest tag，则自动补全
* 🧶 publish tag 参数改为 tags，对应事件分批触发
* ♻️ 包同步流程不做修改

cc  @shinima @peachscript