### PR TITLE
fix: should use NodeNext on module and moduleResolution tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "strict": true,
     "target": "ES2021",
-    "module": "Node16",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "declaration": false,
     "resolveJsonModule": true,
     "useUnknownInCatchVariables": false,


### PR DESCRIPTION
https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/#module-and-moduleresolution-must-match-under-recent-node-js-settings

> Option 'moduleResolution' must be set to 'NodeNext' (or left unspecified) when option 'module' is set to 'NodeNext'.
