### PR TITLE
fix: author info

### DIFF
--- a/app/core/service/PackageSearchService.ts
+++ b/app/core/service/PackageSearchService.ts
@@ -80,7 +80,15 @@ export class PackageSearchService extends AbstractService {
       _npmUser: latestManifest?._npmUser,
       // 最新版本发布信息
       publish_time: latestManifest?.publish_time,
+      // 最新版本的发布人，用于 npm cli 展示
     };
+
+    if (latestManifest?._npmUser) {
+      packageDoc.publisher = {
+        username: latestManifest._npmUser.name,
+        email: latestManifest._npmUser.email,
+      };
+    }
 
     const document: SearchManifestType = {
       package: packageDoc,

--- a/app/repository/SearchRepository.ts
+++ b/app/repository/SearchRepository.ts
@@ -12,6 +12,10 @@ export type SearchMappingType = Pick<PackageManifestType, SearchJSONPickKey> & C
   created: Date;
   modified: Date;
   author?: AuthorType | undefined;
+  publisher?: {
+    username: string;
+    email: string;
+  },
   _npmUser?: {
     name: string;
     email: string;

--- a/docs/elasticsearch-setup.md
+++ b/docs/elasticsearch-setup.md
@@ -796,6 +796,18 @@ PUT /cnpmcore_packages
             }
           }
         },
+        "publisher": {
+          "properties": {
+            "email": {
+              "normalizer": "raw",
+              "type": "keyword"
+            },
+            "username": {
+              "normalizer": "raw",
+              "type": "keyword"
+            }
+          }
+        },
         "created": {
           "type": "date"
         },
@@ -969,19 +981,20 @@ config: {
 }
 ```
 
-### 尝试写入或同步一条数据
-
-1. 手动写入
-
-```bash
-$ curl --location --request GET http://localhost:7001/-/v1/search/sync/colors
-```
-
-2. 开启同步
+### 尝试同步一条数据
 
 ```bash
 $ curl --location --request PUT 'http://localhost:7001/-/package/colors/syncs'
 ```
+
+### 尝试删除一条数据
+
+注意需要添加管理员 token，管理员在本地进行登录后，可通过查询 `~/.npmrc` 查看
+```bash
+$ curl --location --request DELETE -H 'Authorization: Bearer ${token}' 'http://localhost:7001/-/package/colors/syncs'
+```
+
+###
 
 ### 查询
 


### PR DESCRIPTION
> in npm@8 cli, empty author information after executing npm search

* 🐞 Fix: npm-cli author field is empty, need to add publisher-related fields
* 📚 Update API documentation
-----

> npm@8 命令行，执行 npm search 后，author 信息为空
* 🐞 修复 npm-cli author 字段为空，需添加 publisher 相关字段
* 📚 更新文档接口信息

![image](https://github.com/cnpm/cnpmcore/assets/5574625/f3a91d29-0bf4-498a-ae2f-c3dd4b47b22f)
