### PR TITLE
fix: fix the issue where the license may be an object

### DIFF
--- a/app/core/service/PackageSearchService.ts
+++ b/app/core/service/PackageSearchService.ts
@@ -67,7 +67,7 @@ export class PackageSearchService extends AbstractService {
       keywords: manifest.keywords || [],
       versions: Object.keys(manifest.versions),
       description: manifest.description,
-      license: manifest.license,
+      license: typeof manifest.license === 'object' ? manifest.license?.type : manifest.license,
       maintainers: manifest.maintainers,
       author: formatAuthor(manifest.author),
       'dist-tags': manifest['dist-tags'],

--- a/app/repository/PackageRepository.ts
+++ b/app/repository/PackageRepository.ts
@@ -51,7 +51,7 @@ export type PackageJSONType = CnpmcorePatchInfo & {
     url?: string;
     email?: string;
   };
-  license?: string;
+  license?: LicenseType | string;
   author?: AuthorType | string;
   contributors?: ContributorType[] | string[];
   maintainers?: ContributorType[] | string[];
@@ -129,6 +129,11 @@ export type AuthorType = {
   username?: string;
   email?: string;
   url?: string;
+};
+
+type LicenseType = {
+  type: string;
+  url: string;
 };
 
 type ContributorType = {


### PR DESCRIPTION
有些 package 的 license 是个对象，会导致 es 写入失败 https://github.com/cnpm/cnpmcore/issues/585#issuecomment-1706009496

![image](https://github.com/cnpm/cnpmcore/assets/13284978/4343a1e8-1fa5-4aed-950d-d5038534dad8)
