### PR TITLE
fix: should set OPTIONS on access-control-allow-methods

### DIFF
--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -100,6 +100,8 @@ export default (appInfo: EggAppConfig) => {
       return ctx.get('Origin');
     },
     credentials: true,
+    // https://github.com/koajs/cors/blob/master/index.js#L10C57-L10C64
+    allowMethods: 'GET,HEAD,PUT,POST,DELETE,PATCH,OPTIONS',
   };
 
   config.nfs = {

--- a/test/port/controller/HomeController/cors.test.ts
+++ b/test/port/controller/HomeController/cors.test.ts
@@ -7,11 +7,12 @@ describe('test/port/controller/HomeController/cors.test.ts', () => {
       const res = await app.httpRequest()
         .get('/-/ping')
         .set('origin', 'https://www.test-cors.org');
-      assert(res.status === 200);
-      assert(res.body.pong === true);
-      assert(res.headers.vary === 'Origin');
-      assert(res.headers['access-control-allow-origin'] === 'https://www.test-cors.org');
-      assert(res.headers['access-control-allow-credentials'] === 'true');
+      assert.equal(res.status, 200);
+      assert.equal(res.body.pong, true);
+      assert.equal(res.headers.vary, 'Origin');
+      assert.equal(res.headers['access-control-allow-origin'], 'https://www.test-cors.org');
+      assert.equal(res.headers['access-control-allow-credentials'], 'true');
+      assert(!res.headers['access-control-allow-methods']);
     });
 
     it('should OPTIONS work', async () => {
@@ -20,11 +21,12 @@ describe('test/port/controller/HomeController/cors.test.ts', () => {
         .set('origin', 'https://www.test-cors.org/foo')
         .set('Access-Control-Request-Method', 'OPTIONS')
         .set('Access-Control-Request-Headers', 'authorization');
-      assert(res.status === 204);
-      assert(res.headers.vary === 'Origin');
-      assert(res.headers['access-control-allow-origin'] === 'https://www.test-cors.org/foo');
-      assert(res.headers['access-control-allow-credentials'] === 'true');
-      assert(res.headers['access-control-allow-headers'] === 'authorization');
+      assert.equal(res.status, 204);
+      assert.equal(res.headers.vary, 'Origin');
+      assert.equal(res.headers['access-control-allow-origin'], 'https://www.test-cors.org/foo');
+      assert.equal(res.headers['access-control-allow-credentials'], 'true');
+      assert.equal(res.headers['access-control-allow-headers'], 'authorization');
+      assert.equal(res.headers['access-control-allow-methods'], 'GET,HEAD,PUT,POST,DELETE,PATCH,OPTIONS');
     });
   });
 });


### PR DESCRIPTION
Access to fetch at 'https://registry.npmmirror.com/isstream/-/isstream-0.1.0.tgz' from origin 'https://foo.com' has been blocked by CORS policy: Method OPTIONS is not allowed by Access-Control-Allow-Methods in preflight response.