### PR TITLE
fix: 501 code

### DIFF
--- a/app/port/controller/package/SearchPackageController.ts
+++ b/app/port/controller/package/SearchPackageController.ts
@@ -10,7 +10,7 @@ import {
   EggContext,
 } from '@eggjs/tegg';
 import { Static } from 'egg-typebox-validate/typebox';
-import { E451 } from 'egg-errors';
+import { NotImplementedError } from 'egg-errors';
 
 import { AbstractController } from '../AbstractController';
 import { SearchQueryOptions } from '../../typebox';
@@ -35,7 +35,7 @@ export class SearchPackageController extends AbstractController {
     @HTTPQuery() size: Static<typeof SearchQueryOptions>['size'],
   ) {
     if (!this.config.cnpmcore.enableElasticsearch) {
-      throw new E451('search feature not enabled in `config.cnpmcore.enableElasticsearch`');
+      throw new NotImplementedError('search feature not enabled in `config.cnpmcore.enableElasticsearch`');
     }
     const data = await this.packageSearchService.searchPackage(text, from, size);
     this.setCDNHeaders(ctx);
@@ -48,7 +48,7 @@ export class SearchPackageController extends AbstractController {
   })
   async sync(@HTTPParam() fullname: string) {
     if (!this.config.cnpmcore.enableElasticsearch) {
-      throw new E451('search feature not enabled in `config.cnpmcore.enableElasticsearch`');
+      throw new NotImplementedError('search feature not enabled in `config.cnpmcore.enableElasticsearch`');
     }
     const name = await this.packageSearchService.syncPackage(fullname, true);
     return { package: name };
@@ -61,7 +61,7 @@ export class SearchPackageController extends AbstractController {
   @Middleware(AdminAccess)
   async delete(@HTTPParam() fullname: string) {
     if (!this.config.cnpmcore.enableElasticsearch) {
-      throw new E451('search feature not enabled in `config.cnpmcore.enableElasticsearch`');
+      throw new NotImplementedError('search feature not enabled in `config.cnpmcore.enableElasticsearch`');
     }
     const name = await this.packageSearchService.removePackage(fullname);
     return { package: name };

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "eslint": "^8.29.0",
     "eslint-config-egg": "^13.0.0",
     "git-contributor": "2",
-    "typescript": "^5.2.2"
+    "typescript": "5.2.2"
   },
   "author": "killagu",
   "license": "MIT",

--- a/test/port/controller/package/SearchPackageController.test.ts
+++ b/test/port/controller/package/SearchPackageController.test.ts
@@ -19,11 +19,11 @@ describe('test/port/controller/package/SearchPackageController.test.ts', () => {
   });
 
   describe('[GET /-/v1/search] search()', async () => {
-    it('should throw 451 when enableElasticsearch is false', async () => {
+    it('should throw 501 when enableElasticsearch is false', async () => {
       mock(app.config.cnpmcore, 'enableElasticsearch', false);
       await app.httpRequest()
         .get('/-/v1/search?text=example&from=0&size=1')
-        .expect(451);
+        .expect(501);
     });
 
     it('should get example package', async () => {
@@ -57,11 +57,11 @@ describe('test/port/controller/package/SearchPackageController.test.ts', () => {
   });
 
   describe('[PUT /-/v1/search/sync/:fullname] sync()', async () => {
-    it('should throw 451 when enableElasticsearch is false', async () => {
+    it('should throw 501 when enableElasticsearch is false', async () => {
       mock(app.config.cnpmcore, 'enableElasticsearch', false);
       await app.httpRequest()
         .put('/-/v1/search/sync/example')
-        .expect(451);
+        .expect(501);
     });
 
     it('should upsert a example package', async () => {
@@ -97,12 +97,12 @@ describe('test/port/controller/package/SearchPackageController.test.ts', () => {
     beforeEach(async () => {
       admin = await TestUtil.createAdmin();
     });
-    it('should throw 451 when enableElasticsearch is false', async () => {
+    it('should throw 501 when enableElasticsearch is false', async () => {
       mock(app.config.cnpmcore, 'enableElasticsearch', false);
       await app.httpRequest()
         .delete('/-/v1/search/sync/example')
         .set('authorization', admin.authorization)
-        .expect(451);
+        .expect(501);
     });
 
     it('should delete a example package', async () => {


### PR DESCRIPTION
> Adjust the error codes related to the 'unpublish' feature:
* ⚠️ Unpublishing all versions is currently not implemented on the server side, return the  501 code.
* 🚨 When the search functionality is disabled, return 501 instead of 451.
-------

> 调整 unpublish 相关错误码

* ⚠️ unpublish 所有版本目前服务端未实现，返回 501
* 🚨 未开启搜索功能时，也返回 501，替换原 451 错误码