### PR TITLE
fix: should search default packages when text is empty

### DIFF
--- a/app/core/service/PackageSearchService.ts
+++ b/app/core/service/PackageSearchService.ts
@@ -152,6 +152,9 @@ export class PackageSearchService extends AbstractService {
 
   // https://github.com/npms-io/queries/blob/master/lib/search.js#L8C1-L78C2
   private _buildMatchQueries(text: string) {
+    if (!text) {
+      return [];
+    }
     return [
       // Standard match using cross_fields
       {

--- a/test/port/controller/package/SearchPackageController.test.ts
+++ b/test/port/controller/package/SearchPackageController.test.ts
@@ -54,6 +54,33 @@ describe('test/port/controller/package/SearchPackageController.test.ts', () => {
       assert.equal(res.body.total, 1);
     });
 
+    it('should get example package when search text is empty', async () => {
+      mockES.add({
+        method: 'POST',
+        path: `/${app.config.cnpmcore.elasticsearchIndex}/_search`,
+      }, () => {
+        return {
+          hits: {
+            total: { value: 1, relation: 'eq' },
+            hits: [{
+              _source: {
+                downloads: {
+                  all: 0,
+                },
+                package: {
+                  name: 'example',
+                  description: 'example package',
+                },
+              },
+            }],
+          },
+        };
+      });
+      const res = await app.httpRequest()
+        .get('/-/v1/search?from=0&size=1');
+      assert.equal(res.body.objects[0].package.name, 'example');
+      assert.equal(res.body.total, 1);
+    });
   });
 
   describe('[PUT /-/v1/search/sync/:fullname] sync()', async () => {


### PR DESCRIPTION
当搜索关键词为空时，不进行 ES 关键词搜索拼接，返回一个默认的全量数据排名。 close #622 