### PR TITLE
fix: hooks triggers

### DIFF
--- a/app/core/entity/Task.ts
+++ b/app/core/entity/Task.ts
@@ -231,6 +231,10 @@ export class Task<T extends TaskBaseData = TaskBaseData> extends Entity {
     return task;
   }
 
+  public static needMergeWhenWaiting(type: TaskType) {
+    return [ TaskType.SyncBinary, TaskType.SyncPackage ].includes(type);
+  }
+
   start(): TaskUpdateCondition {
     const condition = {
       taskId: this.taskId,

--- a/app/core/service/BinarySyncerService.ts
+++ b/app/core/service/BinarySyncerService.ts
@@ -19,7 +19,6 @@ import { Binary } from '../entity/Binary';
 import { TaskService } from './TaskService';
 import { AbstractBinary, BinaryItem } from '../../common/adapter/binary/AbstractBinary';
 import { AbstractService } from '../../common/AbstractService';
-import { TaskRepository } from '../../repository/TaskRepository';
 import { BinaryType } from '../../common/enum/Binary';
 import { sortBy } from 'lodash';
 
@@ -35,8 +34,6 @@ export class BinarySyncerService extends AbstractService {
   private readonly binaryRepository: BinaryRepository;
   @Inject()
   private readonly taskService: TaskService;
-  @Inject()
-  private readonly taskRepository: TaskRepository;
   @Inject()
   private readonly httpclient: EggHttpClient;
   @Inject()
@@ -89,13 +86,7 @@ export class BinarySyncerService extends AbstractService {
     return await this.nfsAdapter.getDownloadUrlOrStream(binary.storePath);
   }
 
-  // SyncBinary 由定时任务每台单机定时触发，手动去重
-  // 添加 bizId 在 db 防止重复，记录 id 错误
   public async createTask(binaryName: BinaryName, lastData?: any) {
-    const existsTask = await this.taskRepository.findTaskByTargetName(binaryName, TaskType.SyncBinary);
-    if (existsTask) {
-      return existsTask;
-    }
     try {
       return await this.taskService.createTask(Task.createSyncBinary(binaryName, lastData), false);
     } catch (e) {

--- a/app/core/service/TaskService.ts
+++ b/app/core/service/TaskService.ts
@@ -29,7 +29,7 @@ export class TaskService extends AbstractService {
     const existsTask = await this.taskRepository.findTaskByTargetName(task.targetName, task.type);
 
     // 只在包同步场景下做任务合并，其余场景通过 bizId 来进行任务幂等
-    if (existsTask && [ TaskType.SyncPackage, TaskType.SyncBinary ].includes(task.type)) {
+    if (existsTask && Task.needMergeWhenWaiting(task.type)) {
       // 在包同步场景，如果任务还未被触发，就不继续重复创建
       // 如果任务正在执行，可能任务状态已更新，这种情况需要继续创建
       if (existsTask.state === TaskState.Waiting) {

--- a/app/core/service/TaskService.ts
+++ b/app/core/service/TaskService.ts
@@ -27,8 +27,10 @@ export class TaskService extends AbstractService {
 
   public async createTask(task: Task, addTaskQueueOnExists: boolean) {
     const existsTask = await this.taskRepository.findTaskByTargetName(task.targetName, task.type);
-    if (existsTask) {
-      // 如果任务还未被触发，就不继续重复创建
+
+    // 只在包同步场景下做任务合并，其余场景通过 bizId 来进行任务幂等
+    if (existsTask && [ TaskType.SyncPackage, TaskType.SyncBinary ].includes(task.type)) {
+      // 在包同步场景，如果任务还未被触发，就不继续重复创建
       // 如果任务正在执行，可能任务状态已更新，这种情况需要继续创建
       if (existsTask.state === TaskState.Waiting) {
         if (task.type === TaskType.SyncPackage) {


### PR DESCRIPTION
> Since the eventBus#cork , version & tag events are triggered at same time, cause the abnormal triggers of different types of hooks.
* ~~🐞 Fix triggerHook type targetName to be `tagetName:changeId`~~
* 🤖 Only merge sync tasks (binary, package) which in waiting states
--------
> 由于 `eventBus#cork` 机制，版本事件同时触发，导致不同类型 hook 触发异常
* ~~🐞 修改 triggerHook 类型 targetName 为 `包名:changeId`~~
* 🤖 仅合并 waiting 状态下包同步任务
