### PR TITLE
fix: fix breaking change about RSA_PKCS1_PADDING.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
     "url": "git@github.com:cnpm/cnpmcore.git"
   },
   "egg": {
+    "revert": [
+      "CVE-2023-46809"
+    ],
     "typescript": true
   },
   "keywords": [
@@ -90,7 +93,7 @@
     "egg-cors": "^3.0.0",
     "egg-errors": "^2.3.0",
     "egg-redis": "^2.4.0",
-    "egg-scripts": "^2.15.2",
+    "egg-scripts": "^3.0.0",
     "egg-status": "^1.0.0",
     "egg-tracer": "^1.1.0",
     "egg-typebox-validate": "^2.0.0",


### PR DESCRIPTION
**问题：**

Node.JS安全性修复导致RSA_PKCS1_PADDING不可用，会报出以下错误：

> RSA_PKCS1_PADDING is no longer supported for private decryption, this can be reverted with --security-revert=CVE-2023-46809。

该PR用于修复以上问题。

参考链接：[https://www.eggjs.org/zh-CN/core/security#revert-cve](https://www.eggjs.org/zh-CN/core/security#revert-cve)