### PR TITLE
fix: only set chrome-for-testing data timestamp after sync task finish

### DIFF
--- a/app/common/adapter/binary/AbstractBinary.ts
+++ b/app/common/adapter/binary/AbstractBinary.ts
@@ -31,6 +31,11 @@ export abstract class AbstractBinary {
   abstract initFetch(binaryName: BinaryName): Promise<void>;
   abstract fetch(dir: string, binaryName: BinaryName): Promise<FetchResult | undefined>;
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async finishFetch(_success: boolean, _binaryName: BinaryName): Promise<void> {
+    // do not thing by default
+  }
+
   protected async requestXml(url: string) {
     const { status, data, headers } = await this.httpclient.request(url, {
       timeout: 30000,

--- a/app/common/adapter/binary/ChromeForTestingBinary.ts
+++ b/app/common/adapter/binary/ChromeForTestingBinary.ts
@@ -32,7 +32,7 @@ export class ChromeForTestingBinary extends AbstractBinary {
       return;
     }
     const hasNewData = data.timestamp !== ChromeForTestingBinary.lastTimestamp;
-    this.logger.warn('[ChromeForTestingBinary] remote data timestamp: %j, last timestamp: %j, hasNewData: %s',
+    this.logger.info('[ChromeForTestingBinary] remote data timestamp: %j, last timestamp: %j, hasNewData: %s',
       data.timestamp, ChromeForTestingBinary.lastTimestamp, hasNewData);
     if (!hasNewData) {
       return;

--- a/app/core/service/BinarySyncerService.ts
+++ b/app/core/service/BinarySyncerService.ts
@@ -229,7 +229,7 @@ export class BinarySyncerService extends AbstractService {
       if (hasDownloadError) {
         logs.push(`[${isoNow()}][${dir}] ❌ Synced dir fail`);
       } else {
-        logs.push(`[${isoNow()}][${dir}] 🟢 Synced dir success`);
+        logs.push(`[${isoNow()}][${dir}] 🟢 Synced dir success, hasItems: ${hasItems}`);
       }
       await this.taskService.appendTaskLog(task, logs.join('\n'));
     }

--- a/app/core/service/BinarySyncerService.ts
+++ b/app/core/service/BinarySyncerService.ts
@@ -131,6 +131,7 @@ export class BinarySyncerService extends AbstractService {
       logs.push(`[${isoNow()}] 🟢 log: ${logUrl}`);
       logs.push(`[${isoNow()}] 🟢🟢🟢🟢🟢 "${binaryName}" 🟢🟢🟢🟢🟢`);
       await this.taskService.finishTask(task, TaskState.Success, logs.join('\n'));
+      await binaryAdapter.finishFetch(true, binaryName);
       this.logger.info('[BinarySyncerService.executeTask:success] taskId: %s, targetName: %s, log: %s',
         task.taskId, task.targetName, logUrl);
     } catch (err: any) {
@@ -148,6 +149,7 @@ export class BinarySyncerService extends AbstractService {
           task.taskId, task.targetName, task.error);
         this.logger.error(err);
       }
+      await binaryAdapter.finishFetch(false, binaryName);
       await this.taskService.finishTask(task, TaskState.Fail, logs.join('\n'));
     }
   }

--- a/test/common/adapter/binary/ChromeForTestingBinary.test.ts
+++ b/test/common/adapter/binary/ChromeForTestingBinary.test.ts
@@ -36,6 +36,7 @@ describe('test/common/adapter/binary/ChromeForTestingBinary.test.ts', () => {
         assert.match(versionRes?.items[1].name, /^chromedriver\-/);
         assert.match(versionRes?.items[2].name, /^chrome\-headless\-shell\-/);
       }
+      await binary.finishFetch(true);
       assert(ChromeForTestingBinary.lastTimestamp);
     });
 

--- a/test/common/adapter/binary/ChromeForTestingBinary.test.ts
+++ b/test/common/adapter/binary/ChromeForTestingBinary.test.ts
@@ -8,6 +8,7 @@ describe('test/common/adapter/binary/ChromeForTestingBinary.test.ts', () => {
   beforeEach(async () => {
     binary = await app.getEggObject(ChromeForTestingBinary);
   });
+
   describe('fetch()', () => {
     it('should work for chrome binary', async () => {
       assert.equal(ChromeForTestingBinary.lastTimestamp, '');


### PR DESCRIPTION
closes https://github.com/cnpm/cnpmcore/issues/652