### PR TITLE
Update elasticsearch-setup.md

### DIFF
--- a/docs/elasticsearch-setup.md
+++ b/docs/elasticsearch-setup.md
@@ -272,6 +272,8 @@ PUT cnpmcore_packages
 ```json
 {
   "index": {
+    "sort.field": "package.modified", 
+    "sort.order": "desc",
     "analysis": {
       "analyzer": {
         "package": {


### PR DESCRIPTION
setting应该以package的修改时间排序，不然私有package搜索列表就是固定排序的