### PR TITLE
fix: sync cypress linux-arm64 binary

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 18, 20]
+        node-version: [16, 18, 20, 21]
         os: [ubuntu-latest]
 
     steps:

--- a/app/common/adapter/binary/CypressBinary.ts
+++ b/app/common/adapter/binary/CypressBinary.ts
@@ -42,8 +42,21 @@ export class CypressBinary extends AbstractBinary {
         // "https://cdn.cypress.io/desktop/9.2.0/darwin-arm64/cypress.zip"
         // "https://cdn.cypress.io/desktop/9.2.0/darwin-x64/cypress.zip"
         // "https://cdn.cypress.io/desktop/9.2.0/linux-x64/cypress.zip"
+        // "https://cdn.cypress.io/desktop/9.2.0/linux-arm64/cypress.zip"
         // "https://cdn.cypress.io/desktop/9.2.0/win32-x64/cypress.zip"
-        const platforms = [ 'darwin-x64', 'darwin-arm64', 'linux-x64', 'win32-x64' ];
+        // https://github.com/cypress-io/cypress/blob/develop/scripts/binary/index.js#L146
+        // const systems = [
+        //   { platform: 'linux', arch: 'x64' },
+        //   { platform: 'linux', arch: 'arm64' },
+        //   { platform: 'darwin', arch: 'x64' },
+        //   { platform: 'darwin', arch: 'arm64' },
+        //   { platform: 'win32', arch: 'x64' },
+        // ]
+        const platforms = [
+          'darwin-x64', 'darwin-arm64',
+          'linux-x64', 'linux-arm64',
+          'win32-x64',
+        ];
         for (const platform of platforms) {
           this.dirItems[subDir].push({
             name: `${platform}/`,

--- a/test/common/adapter/binary/CypressBinary.test.ts
+++ b/test/common/adapter/binary/CypressBinary.test.ts
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import assert from 'node:assert';
 import { app } from 'egg-mock/bootstrap';
 import { CypressBinary } from '../../../../app/common/adapter/binary/CypressBinary';
 import { TestUtil } from '../../../../test/TestUtil';
@@ -8,6 +8,7 @@ describe('test/common/adapter/binary/CypressBinary.test.ts', () => {
   beforeEach(async () => {
     binary = await app.getEggObject(CypressBinary);
   });
+
   describe('fetch()', () => {
     it('should fetch root: / work', async () => {
       app.mockHttpclient('https://registry.npmjs.com/cypress', 'GET', {
@@ -44,11 +45,12 @@ describe('test/common/adapter/binary/CypressBinary.test.ts', () => {
       });
       let result = await binary.fetch('/4.0.0/');
       assert(result);
-      assert(result.items.length === 4);
-      assert(result.items[0].name === 'darwin-x64/');
-      assert(result.items[1].name === 'darwin-arm64/');
-      assert(result.items[2].name === 'linux-x64/');
-      assert(result.items[3].name === 'win32-x64/');
+      assert.equal(result.items.length, 5);
+      assert.equal(result.items[0].name, 'darwin-x64/');
+      assert.equal(result.items[1].name, 'darwin-arm64/');
+      assert.equal(result.items[2].name, 'linux-x64/');
+      assert.equal(result.items[3].name, 'linux-arm64/');
+      assert.equal(result.items[4].name, 'win32-x64/');
       assert(result.items[0].isDir);
 
       result = await binary.fetch('/4.0.0/darwin-x64/');
@@ -70,6 +72,13 @@ describe('test/common/adapter/binary/CypressBinary.test.ts', () => {
       assert(result.items.length === 1);
       assert(result.items[0].name === 'cypress.zip');
       assert(result.items[0].url === 'https://cdn.cypress.io/desktop/4.0.0/linux-x64/cypress.zip');
+      assert(!result.items[0].isDir);
+
+      result = await binary.fetch('/4.0.0/linux-arm64/');
+      assert(result);
+      assert(result.items.length === 1);
+      assert(result.items[0].name === 'cypress.zip');
+      assert(result.items[0].url === 'https://cdn.cypress.io/desktop/4.0.0/linux-arm64/cypress.zip');
       assert(!result.items[0].isDir);
 
       result = await binary.fetch('/4.0.0/win32-x64/');


### PR DESCRIPTION
closes https://github.com/cnpm/cnpmjs.org/issues/1560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the `linux-arm64` platform in Cypress binary handling.
- **Tests**
	- Updated tests to include assertions for the newly supported `linux-arm64` platform.
- **Chores**
	- Updated Node.js version to 21 in workflow configuration for improved job execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->