### PR TITLE
fix: remove unuse mysql2 deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "lodash": "^4.17.21",
     "mime-types": "^2.1.35",
     "mysql": "^2.18.1",
-    "mysql2": "^3.9.4",
     "npm-package-arg": "^10.1.0",
     "oss-cnpm": "^5.0.1",
     "p-map": "^4.0.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the `mysql2` dependency from the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->