### PR TITLE
fix: add logs fro aggregate errors

### DIFF
--- a/app/common/adapter/NPMRegistry.ts
+++ b/app/common/adapter/NPMRegistry.ts
@@ -98,6 +98,7 @@ export class NPMRegistry {
       data: params,
       dataType: 'json',
       timing: true,
+      retry: 3,
       timeout: this.timeout,
       followRedirect: true,
       gzip: true,

--- a/app/core/service/PackageSyncerService.ts
+++ b/app/core/service/PackageSyncerService.ts
@@ -173,7 +173,9 @@ export class PackageSyncerService extends AbstractService {
       logId = data.logId;
     } catch (err: any) {
       const status = err.status || 'unknow';
-      logs.push(`[${isoNow()}][UP] ❌ Sync ${fullname} fail, create sync task error: ${err}, status: ${status}`);
+      // 可能会抛出 AggregateError 异常
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError
+      logs.push(`[${isoNow()}][UP] ❌ Sync ${fullname} fail, create sync task error: ${err}, status: ${status} ${err instanceof AggregateError ? err.errors : ''}`);
       logs.push(`[${isoNow()}][UP] ${failEnd}`);
       await this.taskService.appendTaskLog(task, logs.join('\n'));
       return;


### PR DESCRIPTION
> add logs for sync tasks with the upstream registry errors  [ref](https://cdn.npmmirror.com/packages/%40eggjs/tegg-schedule-plugin/syncs/2024/04/171901-661fac1a613c4b7bd1e015e3.log)
* 📒 Log the corresponding errors for AggregateError

--------------

> 对 upstream registry 创建同步任务失败时，添加日志信息 [ref](https://cdn.npmmirror.com/packages/%40eggjs/tegg-schedule-plugin/syncs/2024/04/171901-661fac1a613c4b7bd1e015e3.log)
* 📒 针对 AggregateError 打印对应 errors



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated comments in the package synchronization service to include information about handling `AggregateError` exceptions.
- **New Features**
	- Added a retry mechanism with a limit of 3 attempts in the HTTP requests for the NPMRegistry class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->