### PR TITLE
fix: only set err.status on statusCode >= 200

### DIFF
--- a/app/port/middleware/ErrorHandler.ts
+++ b/app/port/middleware/ErrorHandler.ts
@@ -31,7 +31,7 @@ export async function ErrorHandler(ctx: EggContext, next: Next) {
     }
 
     // http status, default is DEFAULT_SERVER_ERROR_STATUS
-    ctx.status = err.status || DEFAULT_SERVER_ERROR_STATUS;
+    ctx.status = (typeof err.status === 'number' && err.status >= 200) ? err.status : DEFAULT_SERVER_ERROR_STATUS;
     // don't log NotImplementedError
     if (ctx.status >= DEFAULT_SERVER_ERROR_STATUS && err.name !== 'NotImplementedError') {
       ctx.logger.error(err);


### PR DESCRIPTION
> nodejs.AssertionError: invalid status code: -1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to ensure the HTTP status code is valid and within the correct range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->