### PR TITLE
fix: allow to disable sync unpkg files

### DIFF
--- a/app/core/event/SyncPackageVersionFile.ts
+++ b/app/core/event/SyncPackageVersionFile.ts
@@ -16,7 +16,9 @@ class SyncPackageVersionFileEvent {
   private readonly packageVersionFileService: PackageVersionFileService;
 
   protected async syncPackageVersionFile(fullname: string, version: string) {
+    // must set enableUnpkg and enableSyncUnpkgFiles = true both
     if (!this.config.cnpmcore.enableUnpkg) return;
+    if (!this.config.cnpmcore.enableSyncUnpkgFiles) return;
     // ignore sync on unittest
     if (this.config.env === 'unittest' && fullname !== '@cnpm/unittest-unpkg-demo') return;
     const [ scope, name ] = getScopeAndName(fullname);

--- a/app/port/config.ts
+++ b/app/port/config.ts
@@ -146,6 +146,10 @@ export type CnpmcoreConfig = {
    */
   enableUnpkg: boolean,
   /**
+   * enable sync unpkg files
+   */
+  enableSyncUnpkgFiles: boolean;
+  /**
    * enable this would make sync specific version task not append latest version into this task automatically,it would mark the local latest stable version as latest tag.
    * in most cases, you should set to false to keep the same behavior as source registry.
    */

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -53,6 +53,7 @@ export const cnpmcoreConfig: CnpmcoreConfig = {
   syncNotFound: false,
   redirectNotFound: true,
   enableUnpkg: true,
+  enableSyncUnpkgFiles: true,
   strictSyncSpecivicVersion: false,
   enableElasticsearch: !!process.env.CNPMCORE_CONFIG_ENABLE_ES,
   elasticsearchIndex: 'cnpmcore_packages',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new configuration option `enableSyncUnpkgFiles` for enhanced synchronization control.
  
- **Improvements**
  - Improved synchronization logic to check both `enableUnpkg` and `enableSyncUnpkgFiles` settings before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->