### PR TITLE
feat: mirror homebrew-macos-cross-toolchains

### DIFF
--- a/config/binaries.ts
+++ b/config/binaries.ts
@@ -918,6 +918,13 @@ const binaries = {
     repo: 'webdriverio-community/node-edgedriver',
     distUrl: 'https://developer.microsoft.com/zh-cn/microsoft-edge/tools/webdriver/',
   },
+  'homebrew-macos-cross-toolchains': {
+    category: 'homebrew-macos-cross-toolchains',
+    description: 'macOS cross compiler toolchains',
+    type: BinaryType.GitHub,
+    repo: 'messense/homebrew-macos-cross-toolchains',
+    distUrl: 'https://github.com/messense/homebrew-macos-cross-toolchains/releases',
+  },
 } as const;
 
 export type BinaryName = keyof typeof binaries;


### PR DESCRIPTION
https://github.com/messense/homebrew-macos-cross-toolchains/releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `homebrew-macos-cross-toolchains` in the binaries list, enhancing cross-toolchain capabilities for macOS users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->