### PR TITLE
fix: rc version should match `*` version

### DIFF
--- a/app/core/service/PackageVersionFileService.ts
+++ b/app/core/service/PackageVersionFileService.ts
@@ -113,10 +113,10 @@ export class PackageVersionFileService extends AbstractService {
     // check allow packages
     const fullname = getFullname(pkgScope, pkgName);
     const pkgConfig = this.#unpkgWhiteListAllowPackages[fullname];
-    if (!pkgConfig) {
+    if (!pkgConfig?.version) {
       throw new ForbiddenError(`"${fullname}" is not allow to unpkg files, see ${unpkgWhiteListUrl}`);
     }
-    if (!pkgConfig.version || !semver.satisfies(pkgVersion, pkgConfig.version)) {
+    if (pkgConfig.version !== '*' && !semver.satisfies(pkgVersion, pkgConfig.version)) {
       throw new ForbiddenError(`"${fullname}@${pkgVersion}" not satisfies "${pkgConfig.version}" to unpkg files, see ${unpkgWhiteListUrl}`);
     }
   }


### PR DESCRIPTION
closes https://github.com/cnpm/unpkg-white-list/issues/63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package version checking to support wildcard (`*`) versions, ensuring better compatibility and flexibility.
  - Fixed issues in handling release candidate (rc) versions in package version checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->