### PR TITLE
fix: support + wildcast

### DIFF
--- a/app/core/service/PackageVersionFileService.ts
+++ b/app/core/service/PackageVersionFileService.ts
@@ -116,7 +116,11 @@ export class PackageVersionFileService extends AbstractService {
     if (!pkgConfig?.version) {
       throw new ForbiddenError(`"${fullname}" is not allow to unpkg files, see ${unpkgWhiteListUrl}`);
     }
-    if (pkgConfig.version !== '*' && !semver.satisfies(pkgVersion, pkgConfig.version)) {
+
+    // satisfies 默认不会包含 prerelease 版本
+    // https://docs.npmjs.com/about-semantic-versioning#using-semantic-versioning-to-specify-update-types-your-package-can-accept
+    // [x, *] 代表任意版本，这里统一通过 semver 来判断
+    if (!semver.satisfies(pkgVersion, pkgConfig.version, { includePrerelease: true })) {
       throw new ForbiddenError(`"${fullname}@${pkgVersion}" not satisfies "${pkgConfig.version}" to unpkg files, see ${unpkgWhiteListUrl}`);
     }
   }

--- a/test/port/controller/PackageVersionFileController/listFiles.test.ts
+++ b/test/port/controller/PackageVersionFileController/listFiles.test.ts
@@ -940,6 +940,9 @@ describe('test/port/controller/PackageVersionFileController/listFiles.test.ts', 
               bar: {
                 version: '1.0.0',
               },
+              baz: {
+                version: '*',
+              },
             },
           },
         });
@@ -984,6 +987,25 @@ describe('test/port/controller/PackageVersionFileController/listFiles.test.ts', 
           .expect(201);
         res = await app.httpRequest()
           .get('/foo/0.3.0-rc15/files/package.json')
+          .expect('content-type', 'application/json; charset=utf-8');
+        assert.equal(res.status, 200);
+        assert(res.body.name);
+
+        pkg = await TestUtil.getFullPackage({
+          name: 'baz',
+          version: '0.3.0-rc15',
+          versionObject: {
+            description: 'work with utf8mb4 💩, 𝌆 utf8_unicode_ci, foo𝌆bar 🍻',
+          },
+        });
+        await app.httpRequest()
+          .put(`/${pkg.name}`)
+          .set('authorization', publisher.authorization)
+          .set('user-agent', publisher.ua)
+          .send(pkg)
+          .expect(201);
+        res = await app.httpRequest()
+          .get('/baz/0.3.0-rc15/files/package.json')
           .expect('content-type', 'application/json; charset=utf-8');
         assert.equal(res.status, 200);
         assert(res.body.name);


### PR DESCRIPTION
> Update #692, Declare compatibility using + notation

1. 🤖 Ensure version matching by `semver`
---------

> 更新 #692 , 兼容版本声明为 `+` 的场景
1. 🤖 统一通过 `semver` 进行版本匹配判断

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for prerelease versions when checking package version compatibility.

- **Tests**
  - Updated test cases to include operations related to a new object `baz` with version `*`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->