### PR TITLE
fix: perf diff

### DIFF
--- a/app/core/service/BinarySyncerService.ts
+++ b/app/core/service/BinarySyncerService.ts
@@ -251,6 +251,7 @@ export class BinarySyncerService extends AbstractService {
       existsMap.set(item.name, item);
     }
     const diffItems: { item: Binary; reason: string }[] = [];
+    let latestItem: BinaryItem | undefined;
     for (const item of fetchItems) {
       const existsItem = existsMap.get(item.name);
       if (!existsItem) {
@@ -276,7 +277,10 @@ export class BinarySyncerService extends AbstractService {
         existsItem.ignoreDownloadStatuses = item.ignoreDownloadStatuses;
         existsItem.date = item.date;
       } else if (dir.endsWith(latestVersionParent)) {
-        const isLatestItem = sortBy(fetchItems, [ 'date' ]).pop()?.name === item.name;
+        if (!latestItem) {
+          latestItem = sortBy(fetchItems, [ 'date' ]).pop();
+        }
+        const isLatestItem = latestItem?.name === item.name;
         if (isLatestItem && existsItem.isDir) {
           diffItems.push({
             item: existsItem,


### PR DESCRIPTION
> optimize binary sync perf , closes #698 
* ♻️ calculate the latestItem only once for the same fetchItems.
--------
> binary 同步性能优化，close #698

* ♻️ binary 最新版本比对时，相同 fetchItems 仅计算一次。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logic for identifying the latest item in synchronization processes, ensuring more accurate date comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->