### PR TITLE
fix: ignore hook when disable

### DIFF
--- a/app/port/schedule/TriggerHookWorker.ts
+++ b/app/port/schedule/TriggerHookWorker.ts
@@ -27,6 +27,7 @@ export class TriggerHookWorker {
   private readonly taskService: TaskService;
 
   async subscribe() {
+    if (!this.config.cnpmcore.hookEnable) return;
     if (executingCount >= this.config.cnpmcore.triggerHookWorkerMaxConcurrentTasks) return;
 
     executingCount++;


### PR DESCRIPTION
> Currently, `triggerHookWorkerMaxConcurrentTasks` is 10 by defualt, which can lead to some redis queries even hookEnable is not activated.
* ♻️ Follow `CreateTriggerHookWorker`, when hookEnable is not activated, do not query task queue.
-------

> 目前 triggerHookWorkerMaxConcurrentTasks  默认为 10，在未开启 hookEnable 时会带来一些冗余的 redis 查询
* ♻️ 参照 `CreateTriggerHookWorker` 逻辑，hookEnable 关闭时，不进行存量任务轮训

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added a check to ensure hooks are enabled before proceeding, improving reliability and preventing errors when hooks are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->