### PR TITLE
feat: set allowH2 to true and require Node.js >= 18

### DIFF
--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -186,6 +186,7 @@ export default (appInfo: EggAppConfig) => {
 
   config.httpclient = {
     useHttpClientNext: true,
+    allowH2: true,
   };
 
   config.view = {

--- a/package.json
+++ b/package.json
@@ -145,6 +145,6 @@
   },
   "homepage": "https://github.com/cnpm/npmcore#readme",
   "engines": {
-    "node": ">= 16.13.0"
+    "node": ">= 18.20.0"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option allowing the use of HTTP/2 in the HTTP client.
  
- **Updates**
	- Updated the minimum required Node.js version to 18.20.0 for improved performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->