### PR TITLE
Revert "feat: set allowH2 to true and require Node.js >= 18 (#705)"

### DIFF
--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -186,7 +186,6 @@ export default (appInfo: EggAppConfig) => {
 
   config.httpclient = {
     useHttpClientNext: true,
-    allowH2: true,
   };
 
   config.view = {

--- a/package.json
+++ b/package.json
@@ -145,6 +145,6 @@
   },
   "homepage": "https://github.com/cnpm/npmcore#readme",
   "engines": {
-    "node": ">= 18.20.0"
+    "node": ">= 16.13.0"
   }
 }


### PR DESCRIPTION
This reverts commit 9a7994090b18df0847eb7552ceff273eab80dea9.

![image](https://github.com/user-attachments/assets/eeb9ea95-60ec-4bcf-a695-60be303e2f5f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated HTTP client configuration to enhance compatibility.
	- Adjusted minimum Node.js version requirement for broader support.

- **Bug Fixes**
	- Removed HTTP/2 support from the HTTP client configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->