### PR TITLE
Update PackageVersionFileController.ts

### DIFF
--- a/app/port/controller/PackageVersionFileController.ts
+++ b/app/port/controller/PackageVersionFileController.ts
@@ -172,10 +172,10 @@ export class PackageVersionFileController extends AbstractController {
   }
   
   @HTTPMethod({
-    path: `/:fullname@:versionSpec/:path(.+)`,
+    path: `/npm/:fullname@:versionSpec/:path(.+)`,
     method: HTTPMethodEnum.GET,
   })
-  async rawNpm(@Context() ctx: EggContext,
+  async rawNpmVer(@Context() ctx: EggContext,
       @HTTPParam() fullname: string,
       @HTTPParam() versionSpec: string,
       @HTTPParam() path: string,
@@ -183,6 +183,17 @@ export class PackageVersionFileController extends AbstractController {
     return await this.raw(ctx, fullname, versionSpec, path, meta);
   }
 
+  @HTTPMethod({
+    path: `/npm/:fullname/:path(.+)`,
+    method: HTTPMethodEnum.GET,
+  })
+  async rawNpm(@Context() ctx: EggContext,
+      @HTTPParam() fullname: string,
+      @HTTPParam() path: string,
+      @HTTPQuery() meta: string) {
+    return await this.raw(ctx, fullname, "latest", path, meta);
+  }
+  
   /**
    * compatibility with unpkg
    * 1. try to match alias entry. e.g. accessing `index.js` or `index.json` using /index

--- a/app/port/controller/PackageVersionFileController.ts
+++ b/app/port/controller/PackageVersionFileController.ts
@@ -180,7 +180,7 @@ export class PackageVersionFileController extends AbstractController {
       @HTTPParam() versionSpec: string,
       @HTTPParam() path: string,
       @HTTPQuery() meta: string) {
-    return await this.raw(ctx, fullname, versionSpec, filepath, meta);
+    return await this.raw(ctx, fullname, versionSpec, path, meta);
   }
 
   /**

--- a/app/port/controller/PackageVersionFileController.ts
+++ b/app/port/controller/PackageVersionFileController.ts
@@ -172,28 +172,22 @@ export class PackageVersionFileController extends AbstractController {
   }
   
   @HTTPMethod({
-    path: `/npm/:fullname@:versionSpec/:path(.+)`,
+    path: `/npm/:fullname(${FULLNAME_REG_STRING})/:path(.+)`,
     method: HTTPMethodEnum.GET,
   })
   async rawNpmVer(@Context() ctx: EggContext,
       @HTTPParam() fullname: string,
-      @HTTPParam() versionSpec: string,
       @HTTPParam() path: string,
       @HTTPQuery() meta: string) {
-    return await this.raw(ctx, fullname, versionSpec, path, meta);
+    let ver = fullname.slice(1).split('@')[1];
+    if(ver){
+      fullname = fullname.slice(0,-1-ver.length)
+    }else{
+      ver = 'latest'
+    }
+    return await this.raw(ctx, fullname, ver, path, meta);
   }
 
-  @HTTPMethod({
-    path: `/npm/:fullname/:path(.+)`,
-    method: HTTPMethodEnum.GET,
-  })
-  async rawNpm(@Context() ctx: EggContext,
-      @HTTPParam() fullname: string,
-      @HTTPParam() path: string,
-      @HTTPQuery() meta: string) {
-    return await this.raw(ctx, fullname, "latest", path, meta);
-  }
-  
   /**
    * compatibility with unpkg
    * 1. try to match alias entry. e.g. accessing `index.js` or `index.json` using /index

--- a/app/port/controller/PackageVersionFileController.ts
+++ b/app/port/controller/PackageVersionFileController.ts
@@ -170,6 +170,18 @@ export class PackageVersionFileController extends AbstractController {
     }
     return await this.distRepository.getDistStream(file.dist);
   }
+  
+  @HTTPMethod({
+    path: `/:fullname@versionSpec/:path(.+)`,
+    method: HTTPMethodEnum.GET,
+  })
+  async rawNpm(@Context() ctx: EggContext,
+      @HTTPParam() fullname: string,
+      @HTTPParam() versionSpec: string,
+      @HTTPParam() path: string,
+      @HTTPQuery() meta: string) {
+    return await this.raw(ctx, fullname, versionSpec, filepath, meta);
+  }
 
   /**
    * compatibility with unpkg

--- a/app/port/controller/PackageVersionFileController.ts
+++ b/app/port/controller/PackageVersionFileController.ts
@@ -172,7 +172,7 @@ export class PackageVersionFileController extends AbstractController {
   }
   
   @HTTPMethod({
-    path: `/:fullname@versionSpec/:path(.+)`,
+    path: `/:fullname@:versionSpec/:path(.+)`,
     method: HTTPMethodEnum.GET,
   })
   async rawNpm(@Context() ctx: EggContext,


### PR DESCRIPTION
fix https://github.com/cnpm/cnpmcore/issues/696
支持https://unpkg.com/  & https://www.jsdelivr.com/  风格的路径

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new HTTP method `rawNpmVer` for handling GET requests with specific version specifications in the URL, allowing for more precise access to package files.
	- Added a new HTTP method `rawNpm` for simplified access to the latest version of package files, enhancing user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->