### PR TITLE
fix(search): author is `???` in result

### DIFF
--- a/app/core/service/PackageSearchService.ts
+++ b/app/core/service/PackageSearchService.ts
@@ -141,6 +141,16 @@ export class PackageSearchService extends AbstractService {
     const { hits, total } = res;
     return {
       objects: hits?.map(item => {
+        // 从 https://github.com/npm/cli/pull/7407 (npm cli v10.6.0) 开始，npm cli 使用 publisher 字段(以前使用 maintainers 字段)
+        // 从现有数据来看，_npmUser 字段和 publisher 字段是等价的
+        // 为了兼容老版本，不删除 _npmUser 字段
+        if (!item._source?.package.publisher && item._source?.package._npmUser) {
+          item._source.package.publisher = {
+            username: item._source.package._npmUser.name,
+            email: item._source.package._npmUser.email,
+          };
+        }
+
         return item._source;
       }),
       total: (total as estypes.SearchTotalHits).value,

--- a/app/repository/SearchRepository.ts
+++ b/app/repository/SearchRepository.ts
@@ -17,6 +17,10 @@ export type SearchMappingType = Pick<PackageManifestType, SearchJSONPickKey> & C
     name: string;
     email: string;
   }
+  publisher?: {
+    username: string;
+    email: string;
+  }
 };
 
 


### PR DESCRIPTION
### 改动原因

在今年 4 月份，npm cli 对 search 做了[一些改动]，在 4 月份以前(npm cli < `v10.6.0`)，采用的是 `maintainers` 字段，而在 https://github.com/npm/cli/pull/7407 后，改为使用: `publisher` 字段。

导致当 npm 版本大于等于 `v10.6.0` 后，search 结果中的 `author` 将变成 `???`，如图：

![CleanShot 2024-12-18 at 16 46 58@2x](https://github.com/user-attachments/assets/4b97bf63-78cb-4720-8c00-469eeff3e92f)

预期的结果应该为:

![CleanShot 2024-12-18 at 16 47 33@2x](https://github.com/user-attachments/assets/2d7fca89-4383-42bd-8b83-66257efe65e8)

### 技术细节说明

当前改动没有为 `es` 增加新的索引，原因是处于以下考虑:

1. es 的 `mapping` 一旦创建，就无法修改（虽然使用了 `dynamic: true` 但无法细粒度的进行控制）
2. 源数据中的 `_npmUser` 已经有相关信息了，没有必要为此浪费额外的磁盘空间
3. 如果想对以前的数据进行更新会比较麻烦，性价比较低

npm cli 老版本: https://github.com/npm/cli/pull/7407/files#diff-4bc15933c685fc9a9ce8be0c13a2f067f5e2b3334bacd6664bdfa7ddc46aedb6L58
npm cli 新版本: https://github.com/npm/cli/pull/7407/files#diff-4bc15933c685fc9a9ce8be0c13a2f067f5e2b3334bacd6664bdfa7ddc46aedb6R162

### 其他

相关 PR: https://github.com/cnpm/cnpmcore/pull/513

PTAL @Beace @fengmk2 @elrrrrrrr

[一些改动]: https://github.com/npm/cli/pull/7407