### PR TITLE
fix: webauth no need to validate hostname on cli request

### DIFF
--- a/app/port/webauth/WebauthController.ts
+++ b/app/port/webauth/WebauthController.ts
@@ -35,8 +35,8 @@ import { genRSAKeys, decryptRSA } from '../../common/CryptoUtil';
 import { getBrowserTypeForWebauthn } from '../../common/UserUtil';
 
 const LoginRequestRule = Type.Object({
-  // cli 所在机器的 hostname
-  hostname: Type.String({ minLength: 1, maxLength: 100 }),
+  // cli 所在机器的 hostname，最新版本 npm cli 已经不会上报 hostname
+  hostname: Type.Optional(Type.String({ minLength: 1, maxLength: 100 })),
 });
 type LoginRequest = Static<typeof LoginRequestRule>;
 

--- a/test/port/webauth/webauthController.test.ts
+++ b/test/port/webauth/webauthController.test.ts
@@ -26,12 +26,11 @@ describe('test/port/webauth/webauthController.test.ts', () => {
       assert.equal(loginSessionId.length, 36);
     });
 
-    it('should check hostname', async () => {
+    it('should hostname is optional', async () => {
       const res = await app.httpRequest()
         .post('/-/v1/login');
 
-      assert.equal(res.status, 422);
-      assert.equal(res.body.error, "[INVALID_PARAM] must have required property 'hostname'");
+      assert.equal(res.status, 200);
     });
   });
 


### PR DESCRIPTION
closes https://github.com/cnpm/cnpmcore/issues/718

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated login processing to allow for optional hostname information, aligning with the latest CLI behavior.
  
- **Tests**
  - Modified test case for the login endpoint to reflect the change in hostname requirement, now asserting a successful response without a hostname.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->