### PR TITLE
docs(elk): add missing version field

### DIFF
--- a/docs/elasticsearch-setup.md
+++ b/docs/elasticsearch-setup.md
@@ -600,6 +600,10 @@ PUT cnpmcore_packages
           "normalizer": "raw",
           "type": "keyword"
         },
+        "version": {
+          "normalizer": "raw",
+          "type": "keyword"
+        },
         "versions": {
           "index": false,
           "type": "text"


### PR DESCRIPTION
此字段在刚开始接入 es 时就已经存在(PR: #513). 因为 es 中设置了 `dynamic: true` 故一直没有报错, 但为了更好的健壮性, 对其进行补全.

不影响现有索引, 无需 `reindex`, 但如果企业是刚开始接入 cnpm, 那设置下会更好.

PTAL @Beace @fengmk2 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced package management by adding version information to improve filtering and search capabilities. This update expands data handling without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->