### PR TITLE
fix: block tgz

### DIFF
--- a/app/core/service/PackageVersionService.ts
+++ b/app/core/service/PackageVersionService.ts
@@ -5,9 +5,10 @@ import { PackageVersionRepository } from '../../repository/PackageVersionReposit
 import { getScopeAndName } from '../../common/PackageUtil';
 import { SqlRange } from '../entity/SqlRange';
 import { BugVersionService } from './BugVersionService';
-import type { PackageJSONType } from '../../repository/PackageRepository';
+import type { PackageJSONType, PackageRepository } from '../../repository/PackageRepository';
 import { DistRepository } from '../../repository/DistRepository';
 import { BugVersionAdvice } from '../entity/BugVersion';
+import { PackageVersionBlockRepository } from '../../repository/PackageVersionBlockRepository';
 
 @SingletonProto({
   accessLevel: AccessLevel.PUBLIC,
@@ -15,6 +16,12 @@ import { BugVersionAdvice } from '../entity/BugVersion';
 export class PackageVersionService {
   @Inject()
   private packageVersionRepository: PackageVersionRepository;
+
+  @Inject()
+  private packageRepository: PackageRepository;
+
+  @Inject()
+  private packageVersionBlockRepository: PackageVersionBlockRepository;
 
   @Inject()
   private readonly bugVersionService: BugVersionService;
@@ -114,5 +121,14 @@ export class PackageVersionService {
       }
     }
     return version;
+  }
+
+  async findBlockInfo(fullname: string) {
+    const [ scope, name ] = getScopeAndName(fullname);
+    const pkg = await this.packageRepository.findPackage(scope, name);
+    if (!pkg) {
+      return null;
+    }
+    return await this.packageVersionBlockRepository.findPackageBlock(pkg.packageId);
   }
 }

--- a/app/port/controller/package/DownloadPackageVersionTar.ts
+++ b/app/port/controller/package/DownloadPackageVersionTar.ts
@@ -80,6 +80,7 @@ export class DownloadPackageVersionTarController extends AbstractController {
     let pkg;
     let packageVersion;
     try {
+      pkg = await this.getPackageEntityByFullname(fullname, allowSync);
       packageVersion = await this.getPackageVersionEntity(pkg, version, allowSync);
     } catch (error) {
       if (this.config.cnpmcore.syncMode === SyncMode.proxy) {

--- a/app/port/controller/package/DownloadPackageVersionTar.ts
+++ b/app/port/controller/package/DownloadPackageVersionTar.ts
@@ -19,6 +19,7 @@ import { PackageManagerService } from '../../../core/service/PackageManagerServi
 import { ProxyCacheService } from '../../../core/service/ProxyCacheService';
 import { PackageSyncerService } from '../../../core/service/PackageSyncerService';
 import { RegistryManagerService } from '../../../core/service/RegistryManagerService';
+import { PackageVersionService } from '../../../core/service/PackageVersionService';
 
 @HTTPController()
 export class DownloadPackageVersionTarController extends AbstractController {
@@ -30,6 +31,8 @@ export class DownloadPackageVersionTarController extends AbstractController {
   private proxyCacheService: ProxyCacheService;
   @Inject()
   private packageSyncerService: PackageSyncerService;
+  @Inject()
+  private packageVersionService: PackageVersionService;
   @Inject()
   private nfsAdapter: NFSAdapter;
 
@@ -55,6 +58,16 @@ export class DownloadPackageVersionTarController extends AbstractController {
     const version = this.getAndCheckVersionFromFilename(ctx, fullname, filenameWithVersion);
     const storeKey = `/packages/${fullname}/${version}/${filenameWithVersion}.tgz`;
     const downloadUrl = await this.nfsAdapter.getDownloadUrl(storeKey);
+
+    // block tgz only all versions have been blocked
+    const blockInfo = await this.packageVersionService.findBlockInfo(fullname);
+    if (blockInfo?.reason) {
+      this.setCDNHeaders(ctx);
+      ctx.logger.info('[PackageController:downloadVersionTar] %s@%s, block for %s',
+        fullname, version, blockInfo.reason);
+      throw this.createPackageBlockError(blockInfo.reason, fullname, version);
+    }
+
     if (this.config.cnpmcore.syncMode === SyncMode.all && downloadUrl) {
       // try nfs url first, avoid db query
       this.packageManagerService.plusPackageVersionCounter(fullname, version);
@@ -67,7 +80,6 @@ export class DownloadPackageVersionTarController extends AbstractController {
     let pkg;
     let packageVersion;
     try {
-      pkg = await this.getPackageEntityByFullname(fullname, allowSync);
       packageVersion = await this.getPackageVersionEntity(pkg, version, allowSync);
     } catch (error) {
       if (this.config.cnpmcore.syncMode === SyncMode.proxy) {


### PR DESCRIPTION
> The tgz download interface does not check if the package is blocked, which may pose additional risks for parsing package-lock.json or other lock files. [exp](https://registry.npmmirror.com/joker-su/-/joker-su-1.0.0.tgz)
1. 🛡️ Add validation logic for DownloadPackageVersionTarController#download to check if the package is allowed to be downloaded.
2. 🧶 Add PackageVersionService#findBlockInfo to check if the corresponding package is blocked.
3. ♻️ When a single version is blocked, skip check as per the current manifest logic.

---------

> tgz 下载接口没有判断包是否被 block，对于 package-lock.json 或者其他依赖锁文件解析可能会有额外风险，[exp](https://registry.npmmirror.com/joker-su/-/joker-su-1.0.0.tgz)

1. 🛡️ `DownloadPackageVersionTarController#download` 接口新增校验逻辑，判断是否允许下载
2. 🧶 新增 PackageVersionService#findBlockInfo 判断对应包是否被全局拦截
3. ♻️ 单版本被 block 时，考虑到误封场景，按目前 manifest 逻辑，不在 tgz 下载时进行拦截操作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the package download process with an additional block check. Now, if a package is flagged, the download will be halted and a clear error response is returned to inform users of the block.
  - Introduced a method to retrieve block information related to package versions, improving the service's capabilities.

- **Tests**
  - Added new test cases to verify the blocking functionality for package downloads, ensuring the application correctly handles requests for blocked packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->