### PR TITLE
chore: disbale public registration by default

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -73,6 +73,9 @@ curl -v http://127.0.0.1:7001
 
 ### 登录和测试发包
 
+> cnpmcore 默认不开放注册，可以通过 `config.default.ts` 中的 `allowPublicRegistration` 配置开启，否则只有管理员可以登录
+
+
 注册 cnpmcore_admin 管理员
 
 ```bash

--- a/INTEGRATE.md
+++ b/INTEGRATE.md
@@ -92,6 +92,7 @@ export default () => {
     ...cnpmcoreConfig,
     enableChangesStream: false,
     syncMode: SyncMode.all,
+    allowPublicRegistration: true,
   };
   return config;
 }

--- a/INTEGRATE.md
+++ b/INTEGRATE.md
@@ -93,6 +93,7 @@ export default () => {
     enableChangesStream: false,
     syncMode: SyncMode.all,
     allowPublicRegistration: true,
+    // 放开注册配置
   };
   return config;
 }

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -42,7 +42,7 @@ export const cnpmcoreConfig: CnpmcoreConfig = {
     '@example',
   ],
   allowPublishNonScopePackage: false,
-  allowPublicRegistration: true,
+  allowPublicRegistration: false,
   admins: {
     cnpmcore_admin: 'admin@cnpmjs.org',
   },
@@ -221,4 +221,3 @@ export default (appInfo: EggAppConfig) => {
 
   return config;
 };
-

--- a/test/.setup.ts
+++ b/test/.setup.ts
@@ -5,6 +5,7 @@ beforeEach(async () => {
   // dont show console log on unittest by default
   TestUtil.app.loggers.disableConsole();
   await TestUtil.app.redis.flushdb('sync');
+  TestUtil.allowPublicRegistration();
 });
 
 afterEach(async () => {

--- a/test/TestUtil.ts
+++ b/test/TestUtil.ts
@@ -133,6 +133,10 @@ export class TestUtil {
     return this._app;
   }
 
+  static allowPublicRegistration() {
+    this.app.config.cnpmcore.allowPublicRegistration = true;
+  }
+
   static async rm(filepath: string) {
     try {
       await fs.unlink(filepath);


### PR DESCRIPTION
> The 'allowPublicRegistration' is enabled by default, which my cause unexpected users registering arbitrarily
1. ⚙  Modify the default configuration 'allowPublicRegistration' to 'false'`

-------------
> 目前默认开启了 `allowPublicRegistration` 配置，公网部署可能会导致预期外的用户任意注册

1. ⚙ 修改默认配置 `allowPublicRegistration` 为 `false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Public registration can now be enabled through a new configuration option, allowing for more flexible user onboarding.
  
- **Bug Fixes**
  - Updated the configuration to disallow public registration by default, ensuring only administrators can log in unless changed.

- **Documentation**
  - Added an informational note in the developer documentation regarding public registration settings. 

- **Tests**
  - Introduced a setup method to enable public registration before each test case runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->