### PR TITLE
feat: mirror node-pty-prebuilt-multiarch

### DIFF
--- a/config/binaries.ts
+++ b/config/binaries.ts
@@ -937,6 +937,13 @@ const binaries = {
     repo: 'messense/homebrew-macos-cross-toolchains',
     distUrl: 'https://github.com/messense/homebrew-macos-cross-toolchains/releases',
   },
+  'node-pty-prebuilt-multiarch': {
+    category: 'node-pty-prebuilt-multiarch',
+    description: 'Prebuilt binaries for node-pty',
+    type: BinaryType.GitHub,
+    repo: 'homebridge/node-pty-prebuilt-multiarch',
+    distUrl: 'https://github.com/homebridge/node-pty-prebuilt-multiarch/releases',
+  },
 } as const;
 
 export type BinaryName = keyof typeof binaries;


### PR DESCRIPTION
closes https://github.com/cnpm/cnpmcore/issues/766

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded our binary support to include prebuilt binaries for the node-pty package, enhancing integration possibilities and deployment options for users relying on these binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->