### PR TITLE
fix: don't block tgz

### DIFF
--- a/test/port/controller/package/DownloadPackageVersionTarController.test.ts
+++ b/test/port/controller/package/DownloadPackageVersionTarController.test.ts
@@ -5,16 +5,13 @@ import { app, mock } from '@eggjs/mock/bootstrap';
 import { TestUtil } from '../../../../test/TestUtil.js';
 import { NFSClientAdapter } from '../../../../app/infra/NFSClientAdapter.js';
 import { SyncMode } from '../../../../app/common/constants.js';
-import { PackageManagerService } from '../../../../app/core/service/PackageManagerService.js';
 
 describe('test/port/controller/package/DownloadPackageVersionTarController.test.ts', () => {
   let publisher: any;
   let nfsClientAdapter: NFSClientAdapter;
-  let packageManagerService: PackageManagerService;
   beforeEach(async () => {
     publisher = await TestUtil.createUser();
     nfsClientAdapter = await app.getEggObject(NFSClientAdapter);
-    packageManagerService = await app.getEggObject(PackageManagerService);
   });
 
   const scope = '@cnpm';
@@ -42,7 +39,6 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
     assert(res.status === 201);
     assert(res.body.ok === true);
     assert.match(res.body.rev, /^\d+-\w{24}$/);
-    await packageManagerService.unblockPackageByFullname(scopedName);
   });
 
   describe('[GET /:fullname/-/:name-:version.tgz] download()', () => {
@@ -59,14 +55,6 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
         .get(`/${scopedName}/-/testmodule-download-version-tar-1.0.0.tgz`);
       assert(res.status === 302);
       assert(res.headers.location === `https://cdn.mock.com/packages/${scopedName}/1.0.0/${name}-1.0.0.tgz`);
-    });
-
-    it('should block tgz', async () => {
-      await packageManagerService.blockPackageByFullname(scopedName, 'test');
-      const res = await app.httpRequest()
-        .get(`/${scopedName}/-/testmodule-download-version-tar-1.0.0.tgz`)
-        .expect(451);
-      assert.equal(res.body.error, '[UNAVAILABLE_FOR_LEGAL_REASONS] @cnpm/testmodule-download-version-tar@1.0.0 was blocked, reason: test');
     });
 
     it('should support cors OPTIONS Request', async () => {
@@ -350,14 +338,6 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
       assert.equal(res.headers.location, `https://cdn.mock.com/packages/${scopedName}/1.0.0/${name}-1.0.0.tgz`);
     });
 
-    it('should block tgz', async () => {
-      await packageManagerService.blockPackageByFullname(scopedName, 'test');
-      const res = await app.httpRequest()
-        .get(`/${scopedName}/download/${scopedName}-1.0.0.tgz`)
-        .expect(451);
-      assert.equal(res.body.error, '[UNAVAILABLE_FOR_LEGAL_REASONS] @cnpm/testmodule-download-version-tar@1.0.0 was blocked, reason: test');
-    });
-
     it('should download a version tar with streaming success', async () => {
       mock(nfsClientAdapter, 'url', 'not-function');
       const res = await app.httpRequest()
@@ -405,15 +385,6 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
       assert(res.status === 302);
       assert(res.headers.location === `https://cdn.mock.com/packages/${scopedName}/1.0.0/${name}-1.0.0.tgz`);
     });
-
-    it('should block tgz', async () => {
-      await packageManagerService.blockPackageByFullname(scopedName, 'test');
-      const res = await app.httpRequest()
-        .get(`/${scopedName}/-/${scope}/${name}-1.0.0.tgz`)
-        .expect(451);
-      assert.equal(res.body.error, '[UNAVAILABLE_FOR_LEGAL_REASONS] @cnpm/testmodule-download-version-tar@1.0.0 was blocked, reason: test');
-    });
-
 
     it('should download a version tar with streaming success', async () => {
       mock(nfsClientAdapter, 'url', 'not-function');


### PR DESCRIPTION
revert https://github.com/cnpm/cnpmcore/pull/763

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the package download process by removing outdated package blocking checks, leading to a smoother and more direct download experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->