### PR TITLE
fix: 🐛 oss config assert

### DIFF
--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -162,7 +162,7 @@ export default function startConfig(appInfo: EggAppConfig) {
         'Cache-Control': 'max-age=0, s-maxage=60',
       },
     };
-    assert(ossConfig.cdnBaseUrl, 'require env CNPMCORE_NFS_OSS_BUCKET');
+    assert(ossConfig.bucket, 'require env CNPMCORE_NFS_OSS_BUCKET');
     assert(ossConfig.endpoint, 'require env CNPMCORE_NFS_OSS_ENDPOINT');
     assert(ossConfig.accessKeyId, 'require env CNPMCORE_NFS_OSS_ID');
     assert(ossConfig.accessKeySecret, 'require env CNPMCORE_NFS_OSS_SECRET');


### PR DESCRIPTION
✅ Closes: #779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration validation to require the OSS bucket setting instead of a CDN URL, with no changes to public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->