### PR TITLE
feat: mirror astral-sh/python-build-standalone

### DIFF
--- a/config/binaries.ts
+++ b/config/binaries.ts
@@ -62,6 +62,13 @@ const binaries = {
       ignoreDownloadStatuses: [403] satisfies number[],
     },
   },
+  'python-build-standalone': {
+    category: 'python-build-standalone',
+    description: 'Produce redistributable builds of Python',
+    type: BinaryType.GitHub,
+    repo: 'astral-sh/python-build-standalone',
+    distUrl: 'https://github.com/astral-sh/python-build-standalone/releases',
+  },
   // CypressBinary
   cypress: {
     category: 'cypress',


### PR DESCRIPTION
closes https://github.com/cnpm/cnpmcore/issues/784

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new option for obtaining redistributable Python builds, making it easier for users to access pre-packaged releases via GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->