### PR TITLE
fix: count

### DIFF
--- a/app/repository/PackageRepository.ts
+++ b/app/repository/PackageRepository.ts
@@ -19,7 +19,6 @@ import type { User as UserModel } from './model/User.js';
 import { User as UserEntity } from '../core/entity/User.js';
 import { AbstractRepository } from './AbstractRepository.js';
 import type { BugVersionPackages } from '../core/entity/BugVersion.js';
-import { DATABASE_TYPE } from '../../config/database.js';
 
 export type PackageManifestType = Pick<PackageJSONType, PackageJSONPickKey> & {
   _id: string;
@@ -592,20 +591,6 @@ export class PackageRepository extends AbstractRepository {
   }
 
   private async getTotalCountByModel(model: typeof Bone): Promise<number> {
-    if (this.config.cnpmcore.database.type === DATABASE_TYPE.MySQL) {
-      const { database } = this.config.orm as { database: string };
-      const sql = `
-        SELECT
-            TABLE_ROWS as table_rows
-          FROM
-            information_schema.tables
-          WHERE
-            table_schema = '${database}'
-            AND table_name = '${model.table}';
-      `;
-      const result = await this.orm.client.query(sql);
-      return result.rows?.[0].table_rows as number;
-    }
     const sql = `SELECT count(id) as total FROM ${model.table};`;
     const result = await this.orm.client.query(sql);
     const total = Number(result.rows?.[0].total);


### PR DESCRIPTION
> Fix potential performance issues caused by using `information_schema.tables` in distributed databases

1. 📊 `information_schema.tables` has no index, consumes large amounts of memory, and requires aggregation after being generated per instance.
2. 🚚 Execution plans involve multi-table joins, distributed operations, GROUP BY, and similar operations.
3. ♻️ Consistently use `SELECT COUNT` with index.
----------

> 修复在分布式 db 中，使用 `information_schema.tables` 可能导致的性能问题
1. 📊 `information_schema.tables` 内部无索引，占用大量内存，需要根据实例数生成后聚合
2. 🚚 执行计划涉及多表连接、分布式操作、GROUP BY 等操作
3. ♻️ 统一使用 `select count`，通过索引计算