### PR TITLE
fix: init release

### DIFF
--- a/app/common/adapter/binary/GithubBinary.ts
+++ b/app/common/adapter/binary/GithubBinary.ts
@@ -15,10 +15,10 @@ import {
 @BinaryAdapter(BinaryType.GitHub)
 export class GithubBinary extends AbstractBinary {
   // oxlint-disable-next-line typescript-eslint/no-explicit-any
-  private releases: Record<string, any[]> = {};
+  private releases: Record<string, any[] | undefined> = {};
 
   async initFetch(binaryName: BinaryName) {
-    this.releases[binaryName] = [];
+    this.releases[binaryName] = undefined;
   }
 
   protected async initReleases(


### PR DESCRIPTION
> close https://github.com/cnpm/cnpm/issues/459#issue-2998106947
1. Correct the initialization of initRelease to ensure the fetch process is triggered as expected.
------

> close https://github.com/cnpm/cnpm/issues/459#issue-2998106947
1. 🐛 修复 initRelease 时，被错误初始化为 [] 空数组，导致不会触发 fetch 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved handling of uninitialized or absent release data, ensuring clearer distinction between missing and empty release lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->