### PR TITLE
test: run es tests on github action

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -87,6 +87,8 @@ jobs:
           POSTGRES_PASSWORD: postgres
           # The default PostgreSQL port
           POSTGRES_PORT: 5432
+          CNPMCORE_CONFIG_ENABLE_ES: true
+          CNPMCORE_CONFIG_ES_CLIENT_NODES: http://localhost:9200
 
       - name: Code Coverage
         uses: codecov/codecov-action@v5

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -161,7 +161,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [20, 22]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -68,11 +68,12 @@ jobs:
         uses: elastic/elastic-github-actions/elasticsearch@master
         with:
           stack-version: 8.18.0
+          elasticsearch_password: cnpmcore
 
       - name: Wait for Elasticsearch to be ready
         run: |
-          curl -v http://127.0.0.1:9200 -k -u elastic:changeme || echo "Elasticsearch is not ready"
-          while ! curl -v http://127.0.0.1:9200 -k -u elastic:changeme | grep -q "elasticsearch"; do
+          curl -v https://localhost:9200 -k -u elastic:cnpmcore || echo "Elasticsearch is not ready"
+          while ! curl -v https://localhost:9200 -k -u elastic:cnpmcore | grep -q "elasticsearch"; do
             echo "Waiting for Elasticsearch to be ready..."
             sleep 1
           done

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.18.0, 20, 22]
+        node-version: [20, 22, 24]
         os: [ubuntu-latest]
 
     steps:
@@ -117,7 +117,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.18.0, 20, 22]
+        node-version: [20, 22, 24]
         os: [ubuntu-latest]
 
     steps:
@@ -140,61 +140,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  # test-mysql57-oss-nfs:
-  #   runs-on: ${{ matrix.os }}
-  #   if: |
-  #     contains('
-  #       refs/heads/master-skip-oss
-  #       refs/heads/dev-skip-oss
-  #     ', github.ref)
-
-  #   services:
-  #     mysql:
-  #       image: mysql:5.7
-  #       env:
-  #         MYSQL_ALLOW_EMPTY_PASSWORD: true
-  #         MYSQL_DATABASE: cnpmcore_unittest
-  #       ports:
-  #         - 3306:3306
-  #       options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
-
-  #     redis:
-  #       image: redis
-  #       ports:
-  #         - 6379:6379
-
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       node-version: [20, 22]
-  #       os: [ubuntu-latest]
-
-  #   steps:
-  #   - name: Checkout Git Source
-  #     uses: actions/checkout@v4
-
-  #   - name: Use Node.js ${{ matrix.node-version }}
-  #     uses: actions/setup-node@v4
-  #     with:
-  #       node-version: ${{ matrix.node-version }}
-
-  #   - name: Install Dependencies
-  #     run: npm i
-
-  #   - name: Continuous Integration
-  #     run: npm run ci
-  #     env:
-  #       CNPMCORE_NFS_TYPE: oss
-  #       CNPMCORE_NFS_OSS_BUCKET: cnpmcore-unittest-github-nodejs-${{ matrix.node-version }}
-  #       CNPMCORE_NFS_OSS_ENDPOINT: https://oss-us-west-1.aliyuncs.com
-  #       CNPMCORE_NFS_OSS_ID: ${{ secrets.CNPMCORE_NFS_OSS_ID }}
-  #       CNPMCORE_NFS_OSS_SECRET: ${{ secrets.CNPMCORE_NFS_OSS_SECRET }}
-
-  #   - name: Code Coverage
-  #     uses: codecov/codecov-action@v5
-  #     with:
-  #       token: ${{ secrets.CODECOV_TOKEN }}
-
   test-mysql57-s3-nfs:
     runs-on: ${{ matrix.os }}
 
@@ -216,7 +161,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22]
+        node-version: [20, 22, 24]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -72,8 +72,7 @@ jobs:
 
       - name: Wait for Elasticsearch to be ready
         run: |
-          curl -v https://localhost:9200 -k -u elastic:cnpmcore || echo "Elasticsearch is not ready"
-          while ! curl -v https://localhost:9200 -k -u elastic:cnpmcore | grep -q "elasticsearch"; do
+          while ! curl -s https://localhost:9200 -k -u elastic:cnpmcore | grep -q "elasticsearch"; do
             echo "Waiting for Elasticsearch to be ready..."
             sleep 1
           done

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -72,6 +72,7 @@ jobs:
 
       - name: Wait for Elasticsearch to be ready
         run: |
+          curl -v https://localhost:9200 -u elastic:cnpmcore
           while ! curl -s https://localhost:9200 -k -u elastic:cnpmcore | grep -q "elasticsearch"; do
             echo "Waiting for Elasticsearch to be ready..."
             sleep 1

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -71,8 +71,8 @@ jobs:
 
       - name: Wait for Elasticsearch to be ready
         run: |
-          curl -v http://localhost:9200 -k -u elastic:changeme
-          while ! curl -s http://localhost:9200 -k -u elastic:changeme | grep -q "elasticsearch"; do
+          curl -v http://127.0.0.1:9200 -k -u elastic:changeme || echo "Elasticsearch is not ready"
+          while ! curl -v http://127.0.0.1:9200 -k -u elastic:changeme | grep -q "elasticsearch"; do
             echo "Waiting for Elasticsearch to be ready..."
             sleep 1
           done

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -71,7 +71,8 @@ jobs:
 
       - name: Wait for Elasticsearch to be ready
         run: |
-          while ! curl -s http://localhost:9200 -u elastic:changeme | grep -q "elasticsearch"; do
+          curl -v http://localhost:9200 -k -u elastic:changeme
+          while ! curl -s http://localhost:9200 -k -u elastic:changeme | grep -q "elasticsearch"; do
             echo "Waiting for Elasticsearch to be ready..."
             sleep 1
           done

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -68,12 +68,12 @@ jobs:
         uses: elastic/elastic-github-actions/elasticsearch@master
         with:
           stack-version: 8.18.0
-          elasticsearch_password: cnpmcore
+          security-enabled: false
 
       - name: Wait for Elasticsearch to be ready
         run: |
-          curl -v https://localhost:9200 -u elastic:cnpmcore
-          while ! curl -s https://localhost:9200 -k -u elastic:cnpmcore | grep -q "elasticsearch"; do
+          curl -v http://localhost:9200
+          while ! curl -s http://localhost:9200 | grep -q "elasticsearch"; do
             echo "Waiting for Elasticsearch to be ready..."
             sleep 1
           done

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -56,6 +56,26 @@ jobs:
       - name: Install Dependencies
         run: npm i -g npminstall && npminstall
 
+      # https://github.com/elastic/elastic-github-actions/blob/master/elasticsearch/README.md
+      - name: Configure sysctl limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
+      - name: Runs Elasticsearch
+        uses: elastic/elastic-github-actions/elasticsearch@master
+        with:
+          stack-version: 8.18.0
+
+      - name: Wait for Elasticsearch to be ready
+        run: |
+          while ! curl -s http://localhost:9200 -u elastic:changeme | grep -q "elasticsearch"; do
+            echo "Waiting for Elasticsearch to be ready..."
+            sleep 1
+          done
+
       - name: Continuous Integration
         run: npm run ci:postgresql
         env:

--- a/test/cli/npm/install.test.ts
+++ b/test/cli/npm/install.test.ts
@@ -204,8 +204,8 @@ describe('test/cli/npm/install.test.ts', () => {
         dataType: 'json',
       });
       assert.equal(res.status, 200);
-      assert.ok(res.data.time.unpublished);
-      assert.equal(res.data.versions, undefined);
+      assert.ok(res.data.time.unpublished, JSON.stringify(res.data));
+      assert.equal(res.data.versions, undefined, JSON.stringify(res.data));
     });
   });
 });


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Adds Elasticsearch setup to GitHub Actions workflow to enable running Elasticsearch-dependent tests in CI.

- Added system configuration steps for Elasticsearch in the GitHub Actions workflow, including swap and sysctl settings.
- Integrated the official Elastic GitHub Action to run Elasticsearch 8.18.0 during CI tests.
- Implemented a wait mechanism to ensure Elasticsearch is fully ready before proceeding with tests.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced CI workflow to configure system limits and start an Elasticsearch service before running tests. The workflow now waits for Elasticsearch to be fully ready before proceeding.
	- Improved test diagnostics by adding detailed response data to assertion messages for better debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->