### PR TITLE
fix: use new changestream endpoint

### DIFF
--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -1387,7 +1387,7 @@ export class PackageManagerService extends AbstractService {
           const pkgVersion = await this.packageVersionService.getVersion(
             npa(`${fullname}@${spec}`)
           );
-          assert(pkgVersion);
+          assert.ok(pkgVersion);
         } catch {
           throw new BadRequestError(`deps ${fullname}@${spec} not found`);
         }

--- a/app/repository/TaskRepository.ts
+++ b/app/repository/TaskRepository.ts
@@ -56,7 +56,7 @@ export class TaskRepository extends AbstractRepository {
     task: TaskEntity,
     condition: TaskUpdateCondition
   ): Promise<boolean> {
-    assert(task.id, 'task have no save');
+    assert.ok(task.id, 'task have no save');
     const changes = ModelConvertor.convertEntityToChanges(task, this.Task);
     const updateRows = await this.Task.update(
       {

--- a/app/repository/util/EntityProperty.ts
+++ b/app/repository/util/EntityProperty.ts
@@ -7,7 +7,7 @@ export function EntityProperty(entityProperty: string) {
   // oxlint-disable-next-line typescript-eslint/no-explicit-any
   return (target: any, modelProperty: PropertyKey) => {
     const clazz = target.constructor as EggProtoImplClass;
-    assert(
+    assert.ok(
       typeof modelProperty === 'string',
       `[model/${clazz.name}] expect method name be typeof string, but now is ${String(modelProperty)}`
     );

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -47,7 +47,7 @@ export const cnpmcoreConfig: CnpmcoreConfig = {
   syncDownloadDataMaxDate: '',
   enableChangesStream: false,
   checkChangesStreamInterval: 500,
-  changesStreamRegistry: 'https://replicate.npmjs.com',
+  changesStreamRegistry: 'https://replicate.npmjs.com/registry',
   changesStreamRegistryMode: ChangesStreamMode.streaming,
   registry: env('CNPMCORE_CONFIG_REGISTRY', 'string', 'http://localhost:7001'),
   alwaysAuth: false,

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -162,10 +162,10 @@ export default function startConfig(appInfo: EggAppConfig) {
         'Cache-Control': 'max-age=0, s-maxage=60',
       },
     };
-    assert(ossConfig.bucket, 'require env CNPMCORE_NFS_OSS_BUCKET');
-    assert(ossConfig.endpoint, 'require env CNPMCORE_NFS_OSS_ENDPOINT');
-    assert(ossConfig.accessKeyId, 'require env CNPMCORE_NFS_OSS_ID');
-    assert(ossConfig.accessKeySecret, 'require env CNPMCORE_NFS_OSS_SECRET');
+    assert.ok(ossConfig.bucket, 'require env CNPMCORE_NFS_OSS_BUCKET');
+    assert.ok(ossConfig.endpoint, 'require env CNPMCORE_NFS_OSS_ENDPOINT');
+    assert.ok(ossConfig.accessKeyId, 'require env CNPMCORE_NFS_OSS_ID');
+    assert.ok(ossConfig.accessKeySecret, 'require env CNPMCORE_NFS_OSS_SECRET');
     config.nfs.client = new OSSClient(ossConfig);
   } else if (nfsType === 's3') {
     const s3Config = {
@@ -183,16 +183,16 @@ export default function startConfig(appInfo: EggAppConfig) {
       ),
       disableURL: env('CNPMCORE_NFS_S3_CLIENT_DISABLE_URL', 'boolean', false),
     };
-    assert(s3Config.endpoint, 'require env CNPMCORE_NFS_S3_CLIENT_ENDPOINT');
-    assert(
+    assert.ok(s3Config.endpoint, 'require env CNPMCORE_NFS_S3_CLIENT_ENDPOINT');
+    assert.ok(
       s3Config.credentials.accessKeyId,
       'require env CNPMCORE_NFS_S3_CLIENT_ID'
     );
-    assert(
+    assert.ok(
       s3Config.credentials.secretAccessKey,
       'require env CNPMCORE_NFS_S3_CLIENT_SECRET'
     );
-    assert(s3Config.bucket, 'require env CNPMCORE_NFS_S3_CLIENT_BUCKET');
+    assert.ok(s3Config.bucket, 'require env CNPMCORE_NFS_S3_CLIENT_BUCKET');
     // @ts-expect-error has no construct signatures
     config.nfs.client = new S3Client(s3Config);
   }

--- a/test/TestUtil.ts
+++ b/test/TestUtil.ts
@@ -7,7 +7,7 @@ import { mkdtempSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import type { Readable } from 'node:stream';
 import mysql from 'mysql2/promise';
-import pg from 'pg';
+import { Client } from 'pg';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import semver from 'semver';
@@ -106,7 +106,7 @@ export class TestUtil {
       if (config.type === DATABASE_TYPE.MySQL) {
         this.connection = await mysql.createConnection(config as any);
       } else if (config.type === DATABASE_TYPE.PostgreSQL) {
-        this.connection = new pg.Client(config as any);
+        this.connection = new Client(config as any);
       }
       await this.connection.connect();
     }

--- a/test/cli/npm/install.test.ts
+++ b/test/cli/npm/install.test.ts
@@ -204,7 +204,7 @@ describe('test/cli/npm/install.test.ts', () => {
         dataType: 'json',
       });
       assert.equal(res.status, 200);
-      assert(res.data.time.unpublished);
+      assert.ok(res.data.time.unpublished);
       assert.equal(res.data.versions, undefined);
     });
   });

--- a/test/common/CryptoUtil.test.ts
+++ b/test/common/CryptoUtil.test.ts
@@ -10,8 +10,8 @@ describe('test/common/CryptoUtil.test.ts', () => {
   describe('genRSAKeys()', () => {
     it('should work', () => {
       const keys = genRSAKeys();
-      assert(keys.publicKey);
-      assert(keys.privateKey);
+      assert.ok(keys.publicKey);
+      assert.ok(keys.privateKey);
     });
   });
 

--- a/test/common/UserUtil.test.ts
+++ b/test/common/UserUtil.test.ts
@@ -8,21 +8,21 @@ describe('test/common/UserUtil.test.ts', () => {
       for (let i = 0; i < 2000; i++) {
         const token = randomToken('cnpm');
         assert.match(token, /cnpm_\w{31,33}_\w{4,6}/);
-        assert(checkToken(token, 'cnpm'));
-        assert(!checkToken(token, 'npm'));
-        assert(!checkToken(token + 'a', 'cnpm'));
+        assert.ok(checkToken(token, 'cnpm'));
+        assert.ok(!checkToken(token, 'npm'));
+        assert.ok(!checkToken(token + 'a', 'cnpm'));
       }
     });
   });
 
   describe('checkToken()', () => {
     it('should work', () => {
-      assert(checkToken(randomToken('cnpm'), 'cnpm'));
-      assert(!checkToken('', 'cnpm'));
-      assert(!checkToken('cnpm__', 'cnpm'));
-      assert(!checkToken('cnpm_1_2', 'npm'));
-      assert(!checkToken('cnpm_1_2', 'cnpm'));
-      assert(!checkToken(String.raw`cnpm_1?!@#_2\dd`, 'cnpm'));
+      assert.ok(checkToken(randomToken('cnpm'), 'cnpm'));
+      assert.ok(!checkToken('', 'cnpm'));
+      assert.ok(!checkToken('cnpm__', 'cnpm'));
+      assert.ok(!checkToken('cnpm_1_2', 'npm'));
+      assert.ok(!checkToken('cnpm_1_2', 'cnpm'));
+      assert.ok(!checkToken(String.raw`cnpm_1?!@#_2\dd`, 'cnpm'));
     });
   });
 });

--- a/test/common/adapter/BugVersionStore.test.ts
+++ b/test/common/adapter/BugVersionStore.test.ts
@@ -19,14 +19,14 @@ describe('test/common/adapter/BugVersionStore.test.ts', () => {
     describe('version hit', () => {
       it('should return bug version', () => {
         const cache = bugVersionStore.getBugVersion(version);
-        assert(cache === bugVersion);
+        assert.ok(cache === bugVersion);
       });
     });
 
     describe('version miss', () => {
       it('should return undefined', () => {
         const cache = bugVersionStore.getBugVersion('1.0.1');
-        assert(!cache);
+        assert.ok(!cache);
       });
     });
   });

--- a/test/common/adapter/CacheAdapter.test.ts
+++ b/test/common/adapter/CacheAdapter.test.ts
@@ -15,30 +15,30 @@ describe('test/common/adapter/CacheAdapter.test.ts', () => {
   describe('lock(), unlock()', () => {
     it('should work', async () => {
       const lockId = await cache.lock('unittest', 1);
-      assert(lockId);
+      assert.ok(lockId);
       assert.equal(typeof lockId, 'string');
       const lockId2 = await cache.lock('unittest', 1);
-      assert(!lockId2);
+      assert.ok(!lockId2);
       const lockId3 = await cache.lock('unittest', 1);
-      assert(!lockId3);
+      assert.ok(!lockId3);
       await setTimeout(1100);
       // lock timeout
       const lockId4 = await cache.lock('unittest', 1);
-      assert(lockId4);
+      assert.ok(lockId4);
       assert.equal(typeof lockId4, 'string');
       assert.notEqual(lockId4, lockId);
       // unlock wrong
       await cache.unlock('unittest', lockId);
       const lockId5 = await cache.lock('unittest', 1);
-      assert(!lockId5);
+      assert.ok(!lockId5);
       // unlock success
       await cache.unlock('unittest', lockId4);
       const lockId6 = await cache.lock('unittest', 1);
-      assert(lockId6);
+      assert.ok(lockId6);
       // unlock not exists key
       await cache.unlock('unittest-not-exists', lockId6);
       const lockId7 = await cache.lock('unittest', 1);
-      assert(!lockId7);
+      assert.ok(!lockId7);
     });
 
     it('should work on concurrency', async () => {
@@ -55,19 +55,19 @@ describe('test/common/adapter/CacheAdapter.test.ts', () => {
         cache.lock('unittest-concurrency', 1),
         cache.lock('unittest-concurrency', 1),
       ]);
-      assert(locks.filter(lockId => !!lockId).length === 1);
+      assert.ok(locks.filter(lockId => !!lockId).length === 1);
     });
 
     it('should mock lock timeout', async () => {
       const lockId = await cache.lock('CNPMCORE_L_unittest', 10);
-      assert(lockId);
+      assert.ok(lockId);
       const lockId2 = await cache.lock('CNPMCORE_L_unittest', 10);
-      assert(!lockId2);
+      assert.ok(!lockId2);
       // mock get return existsTimestamp > now
       mock.data(app.redis, 'get', `${Date.now() - 123 * 1000}`);
       // lock timeout, use new lock
       const lockId3 = await cache.lock('CNPMCORE_L_unittest', 10);
-      assert(lockId3);
+      assert.ok(lockId3);
       assert.notEqual(lockId3, lockId);
     });
   });

--- a/test/common/adapter/NpmRegistry.test.ts
+++ b/test/common/adapter/NpmRegistry.test.ts
@@ -14,13 +14,13 @@ describe('test/common/adapter/CacheAdapter.test.ts', () => {
 
   describe('setRegistryHost()', () => {
     it('default registry', async () => {
-      assert(npmRegistry.registry === 'https://registry.npmjs.org');
+      assert.ok(npmRegistry.registry === 'https://registry.npmjs.org');
     });
     it('should work', async () => {
-      assert(npmRegistry.registry);
+      assert.ok(npmRegistry.registry);
       const host = 'https://registry.npmmirror.com';
       npmRegistry.setRegistryHost(host);
-      assert(npmRegistry.registry === 'https://registry.npmmirror.com');
+      assert.ok(npmRegistry.registry === 'https://registry.npmmirror.com');
     });
   });
 });

--- a/test/common/adapter/binary/ApiBinary.test.ts
+++ b/test/common/adapter/binary/ApiBinary.test.ts
@@ -24,34 +24,34 @@ describe('test/common/adapter/binary/ApiBinary.test.ts', () => {
         persist: false,
       });
       const result = await binary.fetch('/', 'node');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchDir = false;
       let matchFile = false;
       for (const item of result.items) {
         if (item.name === 'v0.10.40/') {
-          assert(item.date === '09-Jul-2015 21:57');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '09-Jul-2015 21:57');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir = true;
         }
         if (item.name === 'node-v0.1.100.tar.gz') {
-          assert(item.date === '26-Aug-2011 16:21');
-          assert(item.isDir === false);
-          assert(item.size === 3_813_493);
-          assert(
+          assert.ok(item.date === '26-Aug-2011 16:21');
+          assert.ok(item.isDir === false);
+          assert.ok(item.size === 3_813_493);
+          assert.ok(
             item.url ===
               'https://r.cnpmjs.org/-/binary/node/node-v0.1.100.tar.gz'
           );
           matchFile = true;
         }
         if (!item.isDir) {
-          assert(typeof item.size === 'number');
-          assert(item.size > 0);
+          assert.ok(typeof item.size === 'number');
+          assert.ok(item.size > 0);
         }
       }
-      assert(matchDir);
-      assert(matchFile);
+      assert.ok(matchDir);
+      assert.ok(matchFile);
     });
 
     it('should fetch subdir: /v16.13.1/ work', async () => {
@@ -68,34 +68,34 @@ describe('test/common/adapter/binary/ApiBinary.test.ts', () => {
         }
       );
       const result = await binary.fetch('/v16.13.1/', 'node');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchDir = false;
       let matchFile = false;
       for (const item of result.items) {
         if (item.name === 'docs/') {
-          assert(item.date === '30-Nov-2021 19:33');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '30-Nov-2021 19:33');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir = true;
         }
         if (item.name === 'SHASUMS256.txt') {
-          assert(item.date === '01-Dec-2021 16:13');
-          assert(item.isDir === false);
-          assert(item.size === 3153);
-          assert(
+          assert.ok(item.date === '01-Dec-2021 16:13');
+          assert.ok(item.isDir === false);
+          assert.ok(item.size === 3153);
+          assert.ok(
             item.url ===
               'https://r.cnpmjs.org/-/binary/node/v16.13.1/SHASUMS256.txt'
           );
           matchFile = true;
         }
         if (!item.isDir) {
-          assert(typeof item.size === 'number');
-          assert(item.size > 0);
+          assert.ok(typeof item.size === 'number');
+          assert.ok(item.size > 0);
         }
       }
-      assert(matchDir);
-      assert(matchFile);
+      assert.ok(matchDir);
+      assert.ok(matchFile);
     });
   });
 });

--- a/test/common/adapter/binary/BucketBinary.test.ts
+++ b/test/common/adapter/binary/BucketBinary.test.ts
@@ -23,29 +23,29 @@ describe('test/common/adapter/binary/BucketBinary.test.ts', () => {
         }
       );
       const result = await binary.fetch('/', 'chromedriver');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchDir = false;
       let matchFile = false;
       for (const item of result.items) {
         if (item.name === '97.0.4692.71/') {
-          assert(/^\d{4}-\d{2}-\d{2}T\d{2}:00:00Z$/.test(item.date));
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(/^\d{4}-\d{2}-\d{2}T\d{2}:00:00Z$/.test(item.date));
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir = true;
         }
         if (item.name === 'LATEST_RELEASE_70.0.3538') {
-          assert(item.date === '2018-11-06T07:19:08.413Z');
-          assert(item.size === 12);
-          assert(
+          assert.ok(item.date === '2018-11-06T07:19:08.413Z');
+          assert.ok(item.size === 12);
+          assert.ok(
             item.url ===
               'https://chromedriver.storage.googleapis.com/LATEST_RELEASE_70.0.3538'
           );
           matchFile = true;
         }
       }
-      assert(matchDir);
-      assert(matchFile);
+      assert.ok(matchDir);
+      assert.ok(matchFile);
     });
 
     it('should fetch subdir: /97.0.4692.71/ work', async () => {
@@ -60,25 +60,25 @@ describe('test/common/adapter/binary/BucketBinary.test.ts', () => {
         }
       );
       const result = await binary.fetch('/97.0.4692.71/', 'chromedriver');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchFile = false;
       for (const item of result.items) {
-        assert(item.isDir === false);
-        assert(typeof item.size === 'number');
-        assert(item.size > 2);
+        assert.ok(item.isDir === false);
+        assert.ok(typeof item.size === 'number');
+        assert.ok(item.size > 2);
         // console.log(item);
         if (item.name === 'chromedriver_mac64_m1.zip') {
-          assert(item.date === '2022-01-05T05:45:15.397Z');
-          assert(item.size === 7_846_919);
-          assert(
+          assert.ok(item.date === '2022-01-05T05:45:15.397Z');
+          assert.ok(item.size === 7_846_919);
+          assert.ok(
             item.url ===
               'https://chromedriver.storage.googleapis.com/97.0.4692.71/chromedriver_mac64_m1.zip'
           );
           matchFile = true;
         }
       }
-      assert(matchFile);
+      assert.ok(matchFile);
     });
 
     it('should ignore dir with size = 0', async () => {
@@ -94,10 +94,10 @@ describe('test/common/adapter/binary/BucketBinary.test.ts', () => {
       );
       // https://selenium-release.storage.googleapis.com/?delimiter=/&prefix=2.43/
       const result = await binary.fetch('/2.43/', 'selenium');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       for (const item of result.items) {
-        assert(item.name !== '2.43');
+        assert.ok(item.name !== '2.43');
       }
     });
 
@@ -109,10 +109,10 @@ describe('test/common/adapter/binary/BucketBinary.test.ts', () => {
         persist: false,
       });
       const result = await binary.fetch('/', 'node-inspector');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       for (const item of result.items) {
-        assert(item.name !== 'AWSLogs/');
+        assert.ok(item.name !== 'AWSLogs/');
       }
     });
   });

--- a/test/common/adapter/binary/ChromeForTestingBinary.test.ts
+++ b/test/common/adapter/binary/ChromeForTestingBinary.test.ts
@@ -41,12 +41,12 @@ describe('test/common/adapter/binary/ChromeForTestingBinary.test.ts', () => {
       assert.equal(result?.items[2].date, '2023-09-16T00:21:21.964Z');
       assert.equal(result?.items[2].isDir, false);
       const latestVersion = result.items[result.items.length - 1].name;
-      assert(latestVersion);
+      assert.ok(latestVersion);
       assert.equal(latestVersion, '119.0.6008.0/');
 
       const platformRes = await binary.fetch(`/${latestVersion}`);
       const platforms = platformRes?.items.map(item => item.name);
-      assert(platforms);
+      assert.ok(platforms);
       assert.deepEqual(platforms, [
         'linux64/',
         'mac-arm64/',
@@ -59,18 +59,18 @@ describe('test/common/adapter/binary/ChromeForTestingBinary.test.ts', () => {
         const versionRes = await binary.fetch(`/${latestVersion}${platform}`);
         const versions = versionRes?.items.map(item => item.name);
         assert.equal(versions?.length, 3);
-        assert(versionRes?.items[0].name);
+        assert.ok(versionRes?.items[0].name);
         assert.equal(versionRes?.items[0].isDir, false);
         assert.match(versionRes?.items[0].name, /^chrome-/);
         assert.match(versionRes?.items[1].name, /^chromedriver-/);
         assert.match(versionRes?.items[2].name, /^chrome-headless-shell-/);
       }
       await binary.finishFetch(true);
-      assert(ChromeForTestingBinary.lastTimestamp);
+      assert.ok(ChromeForTestingBinary.lastTimestamp);
     });
 
     it('should return empty when timestamp is not changed', async () => {
-      assert(ChromeForTestingBinary.lastTimestamp);
+      assert.ok(ChromeForTestingBinary.lastTimestamp);
       await binary.initFetch();
       app.mockHttpclient(
         'https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json',

--- a/test/common/adapter/binary/CypressBinary.test.ts
+++ b/test/common/adapter/binary/CypressBinary.test.ts
@@ -13,81 +13,100 @@ describe('test/common/adapter/binary/CypressBinary.test.ts', () => {
   describe('fetch()', () => {
     it('should fetch root: / work', async () => {
       app.mockHttpclient('https://registry.npmjs.com/cypress', 'GET', {
-        data: await TestUtil.readFixturesFile('registry.npmjs.com/cypress.json'),
+        data: await TestUtil.readFixturesFile(
+          'registry.npmjs.com/cypress.json'
+        ),
         persist: false,
       });
       const result = await binary.fetch('/');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchDir1 = false;
       let matchDir2 = false;
       for (const item of result.items) {
         if (item.name === '4.0.0/') {
-          assert(item.date === '2020-02-06T19:40:50.366Z');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '2020-02-06T19:40:50.366Z');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir1 = true;
         }
         if (item.name === '9.2.0/') {
-          assert(item.date === '2021-12-21T16:13:41.383Z');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '2021-12-21T16:13:41.383Z');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir2 = true;
         }
       }
-      assert(matchDir1);
-      assert(matchDir2);
+      assert.ok(matchDir1);
+      assert.ok(matchDir2);
     });
 
     it('should fetch subdir: /4.0.0/, /4.0.0/linux-x64/ work', async () => {
       app.mockHttpclient('https://registry.npmjs.com/cypress', 'GET', {
-        data: await TestUtil.readFixturesFile('registry.npmjs.com/cypress.json'),
+        data: await TestUtil.readFixturesFile(
+          'registry.npmjs.com/cypress.json'
+        ),
         persist: false,
       });
       let result = await binary.fetch('/4.0.0/');
-      assert(result);
+      assert.ok(result);
       assert.equal(result.items.length, 5);
       assert.equal(result.items[0].name, 'darwin-x64/');
       assert.equal(result.items[1].name, 'darwin-arm64/');
       assert.equal(result.items[2].name, 'linux-x64/');
       assert.equal(result.items[3].name, 'linux-arm64/');
       assert.equal(result.items[4].name, 'win32-x64/');
-      assert(result.items[0].isDir);
+      assert.ok(result.items[0].isDir);
 
       result = await binary.fetch('/4.0.0/darwin-x64/');
-      assert(result);
-      assert(result.items.length === 1);
-      assert(result.items[0].name === 'cypress.zip');
-      assert(result.items[0].url === 'https://cdn.cypress.io/desktop/4.0.0/darwin-x64/cypress.zip');
-      assert(!result.items[0].isDir);
+      assert.ok(result);
+      assert.ok(result.items.length === 1);
+      assert.ok(result.items[0].name === 'cypress.zip');
+      assert.ok(
+        result.items[0].url ===
+          'https://cdn.cypress.io/desktop/4.0.0/darwin-x64/cypress.zip'
+      );
+      assert.ok(!result.items[0].isDir);
 
       result = await binary.fetch('/4.0.0/darwin-arm64/');
-      assert(result);
-      assert(result.items.length === 1);
-      assert(result.items[0].name === 'cypress.zip');
-      assert(result.items[0].url === 'https://cdn.cypress.io/desktop/4.0.0/darwin-arm64/cypress.zip');
-      assert(!result.items[0].isDir);
+      assert.ok(result);
+      assert.ok(result.items.length === 1);
+      assert.ok(result.items[0].name === 'cypress.zip');
+      assert.ok(
+        result.items[0].url ===
+          'https://cdn.cypress.io/desktop/4.0.0/darwin-arm64/cypress.zip'
+      );
+      assert.ok(!result.items[0].isDir);
 
       result = await binary.fetch('/4.0.0/linux-x64/');
-      assert(result);
-      assert(result.items.length === 1);
-      assert(result.items[0].name === 'cypress.zip');
-      assert(result.items[0].url === 'https://cdn.cypress.io/desktop/4.0.0/linux-x64/cypress.zip');
-      assert(!result.items[0].isDir);
+      assert.ok(result);
+      assert.ok(result.items.length === 1);
+      assert.ok(result.items[0].name === 'cypress.zip');
+      assert.ok(
+        result.items[0].url ===
+          'https://cdn.cypress.io/desktop/4.0.0/linux-x64/cypress.zip'
+      );
+      assert.ok(!result.items[0].isDir);
 
       result = await binary.fetch('/4.0.0/linux-arm64/');
-      assert(result);
-      assert(result.items.length === 1);
-      assert(result.items[0].name === 'cypress.zip');
-      assert(result.items[0].url === 'https://cdn.cypress.io/desktop/4.0.0/linux-arm64/cypress.zip');
-      assert(!result.items[0].isDir);
+      assert.ok(result);
+      assert.ok(result.items.length === 1);
+      assert.ok(result.items[0].name === 'cypress.zip');
+      assert.ok(
+        result.items[0].url ===
+          'https://cdn.cypress.io/desktop/4.0.0/linux-arm64/cypress.zip'
+      );
+      assert.ok(!result.items[0].isDir);
 
       result = await binary.fetch('/4.0.0/win32-x64/');
-      assert(result);
-      assert(result.items.length === 1);
-      assert(result.items[0].name === 'cypress.zip');
-      assert(result.items[0].url === 'https://cdn.cypress.io/desktop/4.0.0/win32-x64/cypress.zip');
-      assert(!result.items[0].isDir);
+      assert.ok(result);
+      assert.ok(result.items.length === 1);
+      assert.ok(result.items[0].name === 'cypress.zip');
+      assert.ok(
+        result.items[0].url ===
+          'https://cdn.cypress.io/desktop/4.0.0/win32-x64/cypress.zip'
+      );
+      assert.ok(!result.items[0].isDir);
     });
   });
 });

--- a/test/common/adapter/binary/EdgedriverBinary.test.ts
+++ b/test/common/adapter/binary/EdgedriverBinary.test.ts
@@ -57,12 +57,12 @@ describe('test/common/adapter/binary/EdgedriverBinary.test.ts', () => {
       });
 
       const latestVersion = result.items[result.items.length - 1].name;
-      assert(latestVersion);
+      assert.ok(latestVersion);
       assert.equal(latestVersion, '126.0.2578.0/');
       result = await binary.fetch(`/${latestVersion}`);
-      assert(result);
+      assert.ok(result);
       const items = result.items;
-      assert(items.length >= 3);
+      assert.ok(items.length >= 3);
       for (const item of items) {
         // {
         //   name: 'edgedriver_win64.zip',
@@ -74,9 +74,9 @@ describe('test/common/adapter/binary/EdgedriverBinary.test.ts', () => {
         assert.equal(item.isDir, false);
         assert.match(item.name, /^edgedriver_\w+.zip$/);
         assert.match(item.url, /^https:\/\//);
-        assert(typeof item.size === 'number');
-        assert(item.size > 0);
-        assert(item.date);
+        assert.ok(typeof item.size === 'number');
+        assert.ok(item.size > 0);
+        assert.ok(item.date);
       }
     });
   });

--- a/test/common/adapter/binary/ElectronBinary.test.ts
+++ b/test/common/adapter/binary/ElectronBinary.test.ts
@@ -24,34 +24,34 @@ describe('test/common/adapter/binary/ElectronBinary.test.ts', () => {
         }
       );
       let result = await binary.fetch('/');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       // console.log(result.items);
       for (const item of result.items) {
-        assert(item.name.endsWith('/'));
-        assert(item.isDir);
-        assert(item.size === '-');
+        assert.ok(item.name.endsWith('/'));
+        assert.ok(item.isDir);
+        assert.ok(item.size === '-');
       }
 
       const firstDir = result.items[0].name;
       const secondDir = result.items[1].name;
-      assert(firstDir === `v${secondDir}`);
+      assert.ok(firstDir === `v${secondDir}`);
       result = await binary.fetch(`/${firstDir}`);
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       for (const item of result.items) {
-        assert(!item.name.endsWith('/'));
-        assert(!item.isDir);
+        assert.ok(!item.name.endsWith('/'));
+        assert.ok(!item.isDir);
       }
       const firstItemsLength = result.items.length;
       // console.log(result.items);
 
       result = await binary.fetch(`/${secondDir}`);
-      assert(result);
-      assert(result.items.length === firstItemsLength);
+      assert.ok(result);
+      assert.ok(result.items.length === firstItemsLength);
       for (const item of result.items) {
-        assert(!item.name.endsWith('/'));
-        assert(!item.isDir);
+        assert.ok(!item.name.endsWith('/'));
+        assert.ok(!item.isDir);
       }
       // console.log(result.items);
     });

--- a/test/common/adapter/binary/GithubBinary.test.ts
+++ b/test/common/adapter/binary/GithubBinary.test.ts
@@ -25,21 +25,21 @@ describe('test/common/adapter/binary/GithubBinary.test.ts', () => {
         }
       );
       let result = await binary.fetch('/', 'electron');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       for (const item of result.items) {
-        assert(item.name.endsWith('/'));
-        assert(item.isDir);
-        assert(item.size === '-');
+        assert.ok(item.name.endsWith('/'));
+        assert.ok(item.isDir);
+        assert.ok(item.size === '-');
       }
 
       const firstDir = `/${result.items[0].name}`;
       result = await binary.fetch(firstDir, 'electron');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       for (const item of result.items) {
-        assert(!item.name.endsWith('/'));
-        assert(!item.isDir);
+        assert.ok(!item.name.endsWith('/'));
+        assert.ok(!item.isDir);
       }
       // console.log(result.items);
     });
@@ -57,33 +57,33 @@ describe('test/common/adapter/binary/GithubBinary.test.ts', () => {
         }
       );
       let result = await binary.fetch('/', 'skia-canvas');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       // console.log(JSON.stringify(result.items, null, 2));
       let matchDir = false;
       for (const item of result.items) {
-        assert(item.isDir === true);
+        assert.ok(item.isDir === true);
         if (item.name === 'v0.9.30/') {
           matchDir = true;
         }
       }
-      assert(matchDir);
+      assert.ok(matchDir);
 
       result = await binary.fetch('/v0.9.24/', 'skia-canvas');
-      assert(result?.items.every(item => !/{.*}/.test(item.url)));
+      assert.ok(result?.items.every(item => !/{.*}/.test(item.url)));
 
       result = await binary.fetch('/v0.9.30/', 'skia-canvas');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       // console.log(JSON.stringify(result.items, null, 2));
       let matchFile1 = false;
       let matchFile2 = false;
       let matchFile3 = false;
       for (const item of result.items) {
-        assert(item.isDir === false);
+        assert.ok(item.isDir === false);
         if (item.name === 'skia-canvas-v0.9.30-darwin-arm64.tar.gz') {
-          assert(item.date === '2024-08-26T18:04:13Z');
-          assert(item.size === 7_547_563);
+          assert.ok(item.date === '2024-08-26T18:04:13Z');
+          assert.ok(item.size === 7_547_563);
           assert.equal(
             item.url,
             'https://github.com/samizdatco/skia-canvas/releases/download/v0.9.30/skia-canvas-v0.9.30-darwin-arm64.tar.gz'
@@ -91,8 +91,8 @@ describe('test/common/adapter/binary/GithubBinary.test.ts', () => {
           matchFile1 = true;
         }
         if (item.name === 'skia-canvas-v0.9.30-linux-arm-glibc.tar.gz') {
-          assert(item.date === '2024-08-26T18:04:17Z');
-          assert(item.size === 8_836_353);
+          assert.ok(item.date === '2024-08-26T18:04:17Z');
+          assert.ok(item.size === 8_836_353);
           assert.equal(
             item.url,
             'https://github.com/samizdatco/skia-canvas/releases/download/v0.9.30/skia-canvas-v0.9.30-linux-arm-glibc.tar.gz'
@@ -100,8 +100,8 @@ describe('test/common/adapter/binary/GithubBinary.test.ts', () => {
           matchFile2 = true;
         }
         if (item.name === 'skia-canvas-v0.9.30-win32-x64.tar.gz') {
-          assert(item.date === '2024-08-26T18:04:29Z');
-          assert(item.size === 7_497_076);
+          assert.ok(item.date === '2024-08-26T18:04:29Z');
+          assert.ok(item.size === 7_497_076);
           assert.equal(
             item.url,
             'https://github.com/samizdatco/skia-canvas/releases/download/v0.9.30/skia-canvas-v0.9.30-win32-x64.tar.gz'
@@ -109,9 +109,9 @@ describe('test/common/adapter/binary/GithubBinary.test.ts', () => {
           matchFile3 = true;
         }
       }
-      assert(matchFile1);
-      assert(matchFile2);
-      assert(matchFile3);
+      assert.ok(matchFile1);
+      assert.ok(matchFile2);
+      assert.ok(matchFile3);
     });
 
     it('should fetch protobuf', async () => {
@@ -127,30 +127,30 @@ describe('test/common/adapter/binary/GithubBinary.test.ts', () => {
         }
       );
       let result = await binary.fetch('/', 'protobuf');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchDir = false;
       for (const item of result.items) {
-        assert(item.isDir === true);
+        assert.ok(item.isDir === true);
         if (item.name === 'v28.2/') {
           matchDir = true;
         }
       }
-      assert(matchDir);
+      assert.ok(matchDir);
 
       result = await binary.fetch('/v28.2/', 'protobuf');
-      assert(result?.items.every(item => !/{.*}/.test(item.url)));
+      assert.ok(result?.items.every(item => !/{.*}/.test(item.url)));
 
       result = await binary.fetch('/v28.2/', 'protobuf');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       // console.log(JSON.stringify(result.items, null, 2));
       let matchFile1 = false;
       for (const item of result.items) {
-        assert(item.isDir === false);
+        assert.ok(item.isDir === false);
         if (item.name === 'protoc-28.2-linux-aarch_64.zip') {
-          assert(item.date === '2024-09-18T21:02:40Z');
-          assert(item.size === 3_218_760);
+          assert.ok(item.date === '2024-09-18T21:02:40Z');
+          assert.ok(item.size === 3_218_760);
           assert.equal(
             item.url,
             'https://github.com/protocolbuffers/protobuf/releases/download/v28.2/protoc-28.2-linux-aarch_64.zip'
@@ -158,7 +158,7 @@ describe('test/common/adapter/binary/GithubBinary.test.ts', () => {
           matchFile1 = true;
         }
       }
-      assert(matchFile1);
+      assert.ok(matchFile1);
     });
   });
 });

--- a/test/common/adapter/binary/ImageminBinary.test.ts
+++ b/test/common/adapter/binary/ImageminBinary.test.ts
@@ -17,69 +17,69 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
       ),
     });
     let result = await binary.fetch('/', 'jpegtran-bin');
-    assert(result);
-    assert(result.items.length > 0);
+    assert.ok(result);
+    assert.ok(result.items.length > 0);
     let matchDir1 = false;
     let matchDir2 = false;
     for (const item of result.items) {
       if (item.name === 'v4.0.0/') {
-        assert(item.date);
-        assert(item.isDir === true);
-        assert(item.size === '-');
+        assert.ok(item.date);
+        assert.ok(item.isDir === true);
+        assert.ok(item.size === '-');
         matchDir1 = true;
       }
       if (item.name === 'v6.0.1/') {
-        assert(item.date);
-        assert(item.isDir === true);
-        assert(item.size === '-');
+        assert.ok(item.date);
+        assert.ok(item.isDir === true);
+        assert.ok(item.size === '-');
         matchDir2 = true;
       }
     }
-    assert(matchDir1);
-    assert(matchDir2);
+    assert.ok(matchDir1);
+    assert.ok(matchDir2);
 
     // https://github.com/imagemin/jpegtran-bin/blob/v4.0.0/lib/index.js
     result = await binary.fetch('/v4.0.0/', 'jpegtran-bin');
-    assert(result);
-    assert(result.items.length === 1);
-    assert(result.items[0].name === 'vendor/');
-    assert(result.items[0].isDir === true);
+    assert.ok(result);
+    assert.ok(result.items.length === 1);
+    assert.ok(result.items[0].name === 'vendor/');
+    assert.ok(result.items[0].isDir === true);
 
     result = await binary.fetch('/v4.0.0/vendor/', 'jpegtran-bin');
-    assert(result);
-    assert(result.items.length === 5);
-    assert(result.items[0].name === 'macos/');
-    assert(result.items[0].isDir === true);
-    assert(result.items[1].name === 'linux/');
-    assert(result.items[1].isDir === true);
-    assert(result.items[2].name === 'freebsd/');
-    assert(result.items[2].isDir === true);
-    assert(result.items[3].name === 'sunos/');
-    assert(result.items[3].isDir === true);
-    assert(result.items[4].name === 'win/');
-    assert(result.items[4].isDir === true);
+    assert.ok(result);
+    assert.ok(result.items.length === 5);
+    assert.ok(result.items[0].name === 'macos/');
+    assert.ok(result.items[0].isDir === true);
+    assert.ok(result.items[1].name === 'linux/');
+    assert.ok(result.items[1].isDir === true);
+    assert.ok(result.items[2].name === 'freebsd/');
+    assert.ok(result.items[2].isDir === true);
+    assert.ok(result.items[3].name === 'sunos/');
+    assert.ok(result.items[3].isDir === true);
+    assert.ok(result.items[4].name === 'win/');
+    assert.ok(result.items[4].isDir === true);
 
     result = await binary.fetch('/v4.0.0/vendor/win/', 'jpegtran-bin');
-    assert(result);
-    assert(result.items.length === 2);
-    assert(result.items[0].name === 'x86/');
-    assert(result.items[0].isDir === true);
-    assert(result.items[1].name === 'x64/');
-    assert(result.items[1].isDir === true);
+    assert.ok(result);
+    assert.ok(result.items.length === 2);
+    assert.ok(result.items[0].name === 'x86/');
+    assert.ok(result.items[0].isDir === true);
+    assert.ok(result.items[1].name === 'x64/');
+    assert.ok(result.items[1].isDir === true);
 
     result = await binary.fetch('/v4.0.0/vendor/win/x86/', 'jpegtran-bin');
-    assert(result);
+    assert.ok(result);
     // console.log(result.items);
-    assert(result.items.length === 2);
-    assert(result.items[0].name === 'jpegtran.exe');
-    assert(
+    assert.ok(result.items.length === 2);
+    assert.ok(result.items[0].name === 'jpegtran.exe');
+    assert.ok(
       result.items[0].url ===
         'https://raw.githubusercontent.com/imagemin/jpegtran-bin/v4.0.0/vendor/win/x86/jpegtran.exe'
     );
-    assert(result.items[0].isDir === false);
-    assert(result.items[1].name === 'libjpeg-62.dll');
-    assert(result.items[1].isDir === false);
-    assert(
+    assert.ok(result.items[0].isDir === false);
+    assert.ok(result.items[1].name === 'libjpeg-62.dll');
+    assert.ok(result.items[1].isDir === false);
+    assert.ok(
       result.items[1].url ===
         'https://raw.githubusercontent.com/imagemin/jpegtran-bin/v4.0.0/vendor/win/x86/libjpeg-62.dll'
     );
@@ -93,54 +93,54 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
     });
     let result = await binary.fetch('/', 'advpng-bin');
     // console.log(result?.items.map(_ => _.name));
-    assert(result);
-    assert(result.items.length > 0);
+    assert.ok(result);
+    assert.ok(result.items.length > 0);
     let matchDir1 = false;
     let matchDir2 = false;
     for (const item of result.items) {
       if (item.name === 'v4.0.0/') {
-        assert(item.date);
-        assert(item.isDir === true);
-        assert(item.size === '-');
+        assert.ok(item.date);
+        assert.ok(item.isDir === true);
+        assert.ok(item.size === '-');
         matchDir1 = true;
       }
       if (item.name === 'v6.0.1/') {
-        assert(item.date);
-        assert(item.isDir === true);
-        assert(item.size === '-');
+        assert.ok(item.date);
+        assert.ok(item.isDir === true);
+        assert.ok(item.size === '-');
         matchDir2 = true;
       }
     }
-    assert(matchDir1);
-    assert(matchDir2);
+    assert.ok(matchDir1);
+    assert.ok(matchDir2);
 
     // https://github.com/imagemin/advpng-bin/blob/v4.0.0/lib/index.js
     result = await binary.fetch('/v4.0.0/', 'advpng-bin');
-    assert(result);
-    assert(result.items.length === 1);
-    assert(result.items[0].name === 'vendor/');
-    assert(result.items[0].isDir === true);
+    assert.ok(result);
+    assert.ok(result.items.length === 1);
+    assert.ok(result.items[0].name === 'vendor/');
+    assert.ok(result.items[0].isDir === true);
 
     result = await binary.fetch('/v4.0.0/vendor/', 'advpng-bin');
-    assert(result);
-    assert(result.items.length === 3);
-    assert(result.items[0].name === 'osx/');
-    assert(result.items[0].isDir === true);
-    assert(result.items[1].name === 'linux/');
-    assert(result.items[1].isDir === true);
-    assert(result.items[2].name === 'win32/');
-    assert(result.items[2].isDir === true);
+    assert.ok(result);
+    assert.ok(result.items.length === 3);
+    assert.ok(result.items[0].name === 'osx/');
+    assert.ok(result.items[0].isDir === true);
+    assert.ok(result.items[1].name === 'linux/');
+    assert.ok(result.items[1].isDir === true);
+    assert.ok(result.items[2].name === 'win32/');
+    assert.ok(result.items[2].isDir === true);
 
     result = await binary.fetch('/v4.0.0/vendor/osx/', 'advpng-bin');
-    assert(result);
+    assert.ok(result);
     // console.log(result.items);
-    assert(result.items.length === 1);
-    assert(result.items[0].name === 'advpng');
-    assert(
+    assert.ok(result.items.length === 1);
+    assert.ok(result.items[0].name === 'advpng');
+    assert.ok(
       result.items[0].url ===
         'https://raw.githubusercontent.com/imagemin/advpng-bin/v4.0.0/vendor/osx/advpng'
     );
-    assert(result.items[0].isDir === false);
+    assert.ok(result.items[0].isDir === false);
   });
 
   it('should fetch mozjpeg-bin', async () => {
@@ -148,68 +148,68 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
       data: await TestUtil.readFixturesFile('registry.npmjs.com/mozjpeg.json'),
     });
     let result = await binary.fetch('/', 'mozjpeg-bin');
-    assert(result);
+    assert.ok(result);
     // console.log(result.items);
-    assert(result.items.length > 0);
+    assert.ok(result.items.length > 0);
     let matchDir1 = false;
     let matchDir2 = false;
     for (const item of result.items) {
       if (item.name === 'v4.0.0/') {
-        assert(item.date);
-        assert(item.isDir === true);
-        assert(item.size === '-');
+        assert.ok(item.date);
+        assert.ok(item.isDir === true);
+        assert.ok(item.size === '-');
         matchDir1 = true;
       }
       if (item.name === 'v6.0.1/') {
-        assert(item.date);
-        assert(item.isDir === true);
-        assert(item.size === '-');
+        assert.ok(item.date);
+        assert.ok(item.isDir === true);
+        assert.ok(item.size === '-');
         matchDir2 = true;
       }
     }
-    assert(matchDir1);
-    assert(matchDir2);
+    assert.ok(matchDir1);
+    assert.ok(matchDir2);
 
     // https://github.com/imagemin/mozjpeg-bin/blob/v4.0.0/lib/index.js
     result = await binary.fetch('/v4.0.0/', 'mozjpeg-bin');
-    assert(result);
-    assert(result.items.length === 1);
-    assert(result.items[0].name === 'vendor/');
-    assert(result.items[0].isDir === true);
+    assert.ok(result);
+    assert.ok(result.items.length === 1);
+    assert.ok(result.items[0].name === 'vendor/');
+    assert.ok(result.items[0].isDir === true);
 
     result = await binary.fetch('/v4.0.0/vendor/', 'mozjpeg-bin');
-    assert(result);
-    assert(result.items.length === 4);
-    assert(result.items[0].name === 'osx/');
-    assert(result.items[0].isDir === true);
-    assert(result.items[1].name === 'macos/');
-    assert(result.items[1].isDir === true);
-    assert(result.items[2].name === 'linux/');
-    assert(result.items[2].isDir === true);
-    assert(result.items[3].name === 'win/');
-    assert(result.items[3].isDir === true);
+    assert.ok(result);
+    assert.ok(result.items.length === 4);
+    assert.ok(result.items[0].name === 'osx/');
+    assert.ok(result.items[0].isDir === true);
+    assert.ok(result.items[1].name === 'macos/');
+    assert.ok(result.items[1].isDir === true);
+    assert.ok(result.items[2].name === 'linux/');
+    assert.ok(result.items[2].isDir === true);
+    assert.ok(result.items[3].name === 'win/');
+    assert.ok(result.items[3].isDir === true);
 
     result = await binary.fetch('/v4.0.0/vendor/osx/', 'mozjpeg-bin');
-    assert(result);
+    assert.ok(result);
     // console.log(result.items);
-    assert(result.items.length === 1);
-    assert(result.items[0].name === 'cjpeg');
-    assert(
+    assert.ok(result.items.length === 1);
+    assert.ok(result.items[0].name === 'cjpeg');
+    assert.ok(
       result.items[0].url ===
         'https://raw.githubusercontent.com/imagemin/mozjpeg-bin/v4.0.0/vendor/osx/cjpeg'
     );
-    assert(result.items[0].isDir === false);
+    assert.ok(result.items[0].isDir === false);
 
     result = await binary.fetch('/v8.0.0/vendor/macos/', 'mozjpeg-bin');
-    assert(result);
+    assert.ok(result);
     // console.log(result.items);
-    assert(result.items.length === 1);
-    assert(result.items[0].name === 'cjpeg');
-    assert(
+    assert.ok(result.items.length === 1);
+    assert.ok(result.items[0].name === 'cjpeg');
+    assert.ok(
       result.items[0].url ===
         'https://raw.githubusercontent.com/imagemin/mozjpeg-bin/v8.0.0/vendor/macos/cjpeg'
     );
-    assert(result.items[0].isDir === false);
+    assert.ok(result.items[0].isDir === false);
   });
 
   it('should fetch gifsicle-bin', async () => {
@@ -217,27 +217,27 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
       data: await TestUtil.readFixturesFile('registry.npmjs.com/gifsicle.json'),
     });
     const result = await binary.fetch('/', 'gifsicle-bin');
-    assert(result);
+    assert.ok(result);
     // console.log(result.items);
-    assert(result.items.length > 0);
+    assert.ok(result.items.length > 0);
     let matchDir1 = false;
     let matchDir2 = false;
     for (const item of result.items) {
       if (item.name === 'v4.0.0/') {
-        assert(item.date);
-        assert(item.isDir === true);
-        assert(item.size === '-');
+        assert.ok(item.date);
+        assert.ok(item.isDir === true);
+        assert.ok(item.size === '-');
         matchDir1 = true;
       }
       if (item.name === 'v6.0.1/') {
-        assert(item.date);
-        assert(item.isDir === true);
-        assert(item.size === '-');
+        assert.ok(item.date);
+        assert.ok(item.isDir === true);
+        assert.ok(item.size === '-');
         matchDir2 = true;
       }
     }
-    assert(matchDir1);
-    assert(matchDir2);
+    assert.ok(matchDir1);
+    assert.ok(matchDir2);
   });
 
   it('should fetch optipng-bin', async () => {
@@ -247,27 +247,27 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
       ),
     });
     const result = await binary.fetch('/', 'optipng-bin');
-    assert(result);
+    assert.ok(result);
     // console.log(result.items);
-    assert(result.items.length > 0);
+    assert.ok(result.items.length > 0);
     let matchDir1 = false;
     let matchDir2 = false;
     for (const item of result.items) {
       if (item.name === 'v4.0.0/') {
-        assert(item.date);
-        assert(item.isDir === true);
-        assert(item.size === '-');
+        assert.ok(item.date);
+        assert.ok(item.isDir === true);
+        assert.ok(item.size === '-');
         matchDir1 = true;
       }
       if (item.name === 'v6.0.0/') {
-        assert(item.date);
-        assert(item.isDir === true);
-        assert(item.size === '-');
+        assert.ok(item.date);
+        assert.ok(item.isDir === true);
+        assert.ok(item.size === '-');
         matchDir2 = true;
       }
     }
-    assert(matchDir1);
-    assert(matchDir2);
+    assert.ok(matchDir1);
+    assert.ok(matchDir2);
   });
 
   it('should fetch zopflipng-bin', async () => {
@@ -277,27 +277,27 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
       ),
     });
     const result = await binary.fetch('/', 'zopflipng-bin');
-    assert(result);
+    assert.ok(result);
     // console.log(result.items);
-    assert(result.items.length > 0);
+    assert.ok(result.items.length > 0);
     let matchDir1 = false;
     let matchDir2 = false;
     for (const item of result.items) {
       if (item.name === 'v4.0.0/') {
-        assert(item.date);
-        assert(item.isDir === true);
-        assert(item.size === '-');
+        assert.ok(item.date);
+        assert.ok(item.isDir === true);
+        assert.ok(item.size === '-');
         matchDir1 = true;
       }
       if (item.name === 'v6.0.1/') {
-        assert(item.date);
-        assert(item.isDir === true);
-        assert(item.size === '-');
+        assert.ok(item.date);
+        assert.ok(item.isDir === true);
+        assert.ok(item.size === '-');
         matchDir2 = true;
       }
     }
-    assert(matchDir1);
-    assert(matchDir2);
+    assert.ok(matchDir1);
+    assert.ok(matchDir2);
   });
 
   it('should fetch jpegoptim-bin', async () => {
@@ -307,27 +307,27 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
       ),
     });
     const result = await binary.fetch('/', 'jpegoptim-bin');
-    assert(result);
+    assert.ok(result);
     // console.log(result.items);
-    assert(result.items.length > 0);
+    assert.ok(result.items.length > 0);
     let matchDir1 = false;
     let matchDir2 = false;
     for (const item of result.items) {
       if (item.name === 'v4.0.0/') {
-        assert(item.date);
-        assert(item.isDir === true);
-        assert(item.size === '-');
+        assert.ok(item.date);
+        assert.ok(item.isDir === true);
+        assert.ok(item.size === '-');
         matchDir1 = true;
       }
       if (item.name === 'v6.0.1/') {
-        assert(item.date);
-        assert(item.isDir === true);
-        assert(item.size === '-');
+        assert.ok(item.date);
+        assert.ok(item.isDir === true);
+        assert.ok(item.size === '-');
         matchDir2 = true;
       }
     }
-    assert(matchDir1);
-    assert(matchDir2);
+    assert.ok(matchDir1);
+    assert.ok(matchDir2);
   });
 
   it('should fetch guetzli-bin', async () => {
@@ -336,26 +336,26 @@ describe('test/common/adapter/binary/ImageminBinary.test.ts', () => {
     });
     const result = await binary.fetch('/', 'guetzli-bin');
     // console.log(result);
-    assert(result);
+    assert.ok(result);
     // console.log(result.items);
-    assert(result.items.length > 0);
+    assert.ok(result.items.length > 0);
     let matchDir1 = false;
     let matchDir2 = false;
     for (const item of result.items) {
       if (item.name === 'v4.0.0/') {
-        assert(item.date);
-        assert(item.isDir === true);
-        assert(item.size === '-');
+        assert.ok(item.date);
+        assert.ok(item.isDir === true);
+        assert.ok(item.size === '-');
         matchDir1 = true;
       }
       if (item.name === 'v4.0.2/') {
-        assert(item.date);
-        assert(item.isDir === true);
-        assert(item.size === '-');
+        assert.ok(item.date);
+        assert.ok(item.isDir === true);
+        assert.ok(item.size === '-');
         matchDir2 = true;
       }
     }
-    assert(matchDir1);
-    assert(matchDir2);
+    assert.ok(matchDir1);
+    assert.ok(matchDir2);
   });
 });

--- a/test/common/adapter/binary/NodeBinary.test.ts
+++ b/test/common/adapter/binary/NodeBinary.test.ts
@@ -16,31 +16,33 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('nodejs.org/site/index.html'),
       });
       const result = await binary.fetch('/', 'node');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchDir = false;
       let matchFile = false;
       for (const item of result.items) {
         if (item.name === 'v0.10.40/') {
-          assert(item.date === '09-Jul-2015 21:57');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '09-Jul-2015 21:57');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir = true;
         }
         if (item.name === 'node-v0.1.100.tar.gz') {
-          assert(item.date === '26-Aug-2011 16:21');
-          assert(item.isDir === false);
-          assert(item.size === '3813493');
-          assert(item.url === 'https://nodejs.org/dist/node-v0.1.100.tar.gz');
+          assert.ok(item.date === '26-Aug-2011 16:21');
+          assert.ok(item.isDir === false);
+          assert.ok(item.size === '3813493');
+          assert.ok(
+            item.url === 'https://nodejs.org/dist/node-v0.1.100.tar.gz'
+          );
           matchFile = true;
         }
         if (!item.isDir) {
-          assert(typeof item.size === 'string');
-          assert(item.size.length > 2);
+          assert.ok(typeof item.size === 'string');
+          assert.ok(item.size.length > 2);
         }
       }
-      assert(matchDir);
-      assert(matchFile);
+      assert.ok(matchDir);
+      assert.ok(matchFile);
     });
 
     it('should fetch subdir: /v16.13.1/ work', async () => {
@@ -50,33 +52,33 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
         ),
       });
       const result = await binary.fetch('/v16.13.1/', 'node');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchDir = false;
       let matchFile = false;
       for (const item of result.items) {
         if (item.name === 'docs/') {
-          assert(item.date === '30-Nov-2021 19:33');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '30-Nov-2021 19:33');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir = true;
         }
         if (item.name === 'SHASUMS256.txt') {
-          assert(item.date === '01-Dec-2021 16:13');
-          assert(item.isDir === false);
-          assert(item.size === '3153');
-          assert(
+          assert.ok(item.date === '01-Dec-2021 16:13');
+          assert.ok(item.isDir === false);
+          assert.ok(item.size === '3153');
+          assert.ok(
             item.url === 'https://nodejs.org/dist/v16.13.1/SHASUMS256.txt'
           );
           matchFile = true;
         }
         if (!item.isDir) {
-          assert(typeof item.size === 'string');
-          assert(item.size.length > 2);
+          assert.ok(typeof item.size === 'string');
+          assert.ok(item.size.length > 2);
         }
       }
-      assert(matchDir);
-      assert(matchFile);
+      assert.ok(matchDir);
+      assert.ok(matchFile);
     });
 
     it('should fetch subdir: /v18.15.0/ work', async () => {
@@ -86,8 +88,8 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
         ),
       });
       const result = await binary.fetch('/v18.15.0/', 'node');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchDir = false;
       let matchFile = false;
       for (const item of result.items) {
@@ -118,12 +120,12 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
           matchFile = true;
         }
         if (!item.isDir) {
-          assert(typeof item.size === 'string');
-          assert(item.size.length > 2);
+          assert.ok(typeof item.size === 'string');
+          assert.ok(item.size.length > 2);
         }
       }
-      assert(matchDir);
-      assert(matchFile);
+      assert.ok(matchDir);
+      assert.ok(matchFile);
     });
 
     it('should fetch subdir: /v14.0.0-nightly20200119b318926634/ work', async () => {
@@ -140,23 +142,23 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
         '/v14.0.0-nightly20200119b318926634/',
         'node-nightly'
       );
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchDir = false;
       let matchFile1 = false;
       let matchFile2 = false;
       for (const item of result.items) {
         if (item.name === 'docs/') {
-          assert(item.date === '19-Jan-2020 06:34');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '19-Jan-2020 06:34');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir = true;
         }
         if (item.name === 'SHASUMS256.txt') {
-          assert(item.date === '19-Jan-2020 07:35');
-          assert(item.isDir === false);
-          assert(item.size === '3797');
-          assert(
+          assert.ok(item.date === '19-Jan-2020 07:35');
+          assert.ok(item.isDir === false);
+          assert.ok(item.size === '3797');
+          assert.ok(
             item.url ===
               'https://nodejs.org/download/nightly/v14.0.0-nightly20200119b318926634/SHASUMS256.txt'
           );
@@ -166,23 +168,23 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
           item.name ===
           'node-v14.0.0-nightly20200119b318926634-linux-s390x.tar.xz'
         ) {
-          assert(item.date === '19-Jan-2020 06:03');
-          assert(item.isDir === false);
-          assert(item.size === '20416228');
-          assert(
+          assert.ok(item.date === '19-Jan-2020 06:03');
+          assert.ok(item.isDir === false);
+          assert.ok(item.size === '20416228');
+          assert.ok(
             item.url ===
               'https://nodejs.org/download/nightly/v14.0.0-nightly20200119b318926634/node-v14.0.0-nightly20200119b318926634-linux-s390x.tar.xz'
           );
           matchFile2 = true;
         }
         if (!item.isDir) {
-          assert(typeof item.size === 'string');
-          assert(item.size.length > 2);
+          assert.ok(typeof item.size === 'string');
+          assert.ok(item.size.length > 2);
         }
       }
-      assert(matchDir);
-      assert(matchFile1);
-      assert(matchFile2);
+      assert.ok(matchDir);
+      assert.ok(matchFile1);
+      assert.ok(matchFile2);
     });
 
     it('should skip zero size file', async () => {
@@ -199,8 +201,8 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
         '/v14.0.0-nightly20200204ee9e689df2/',
         'node-nightly'
       );
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchDir = false;
       let matchFile1 = false;
       let matchFile2 = false;
@@ -210,10 +212,10 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
           matchDir = true;
         }
         if (item.name === 'SHASUMS256.txt') {
-          assert(item.date === '04-Feb-2020 06:15');
-          assert(item.isDir === false);
-          assert(item.size === '1364');
-          assert(
+          assert.ok(item.date === '04-Feb-2020 06:15');
+          assert.ok(item.isDir === false);
+          assert.ok(item.size === '1364');
+          assert.ok(
             item.url ===
               'https://nodejs.org/download/nightly/v14.0.0-nightly20200204ee9e689df2/SHASUMS256.txt'
           );
@@ -223,10 +225,10 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
           item.name ===
           'node-v14.0.0-nightly20200204ee9e689df2-linux-arm64.tar.gz'
         ) {
-          assert(item.date === '04-Feb-2020 06:02');
-          assert(item.isDir === false);
-          assert(item.size === '33496011');
-          assert(
+          assert.ok(item.date === '04-Feb-2020 06:02');
+          assert.ok(item.isDir === false);
+          assert.ok(item.size === '33496011');
+          assert.ok(
             item.url ===
               'https://nodejs.org/download/nightly/v14.0.0-nightly20200204ee9e689df2/node-v14.0.0-nightly20200204ee9e689df2-linux-arm64.tar.gz'
           );
@@ -237,14 +239,14 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
           matchFile3 = true;
         }
         if (!item.isDir) {
-          assert(typeof item.size === 'string');
-          assert(item.size.length > 2);
+          assert.ok(typeof item.size === 'string');
+          assert.ok(item.size.length > 2);
         }
       }
-      assert(!matchDir);
-      assert(matchFile1);
-      assert(matchFile2);
-      assert(!matchFile3);
+      assert.ok(!matchDir);
+      assert.ok(matchFile1);
+      assert.ok(matchFile2);
+      assert.ok(!matchFile3);
     });
 
     it('should on python', async () => {
@@ -268,83 +270,85 @@ describe('test/common/adapter/binary/NodeBinary.test.ts', () => {
       });
 
       let result = await binary.fetch('/', 'python');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchDir1 = false;
       let matchDir2 = false;
       let matchFile = false;
       for (const item of result.items) {
         if (item.name === '2.7.18/') {
-          assert(item.date === '20-Apr-2020 13:48');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '20-Apr-2020 13:48');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir1 = true;
         }
         if (item.name === '3.7.3/') {
-          assert(item.date === '25-Mar-2019 23:04');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '25-Mar-2019 23:04');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir2 = true;
         }
         if (item.name === 'README.html') {
-          assert(item.date);
-          assert(item.isDir === false);
-          assert(item.size);
-          assert(item.url === 'https://www.python.org/ftp/python/README.html');
+          assert.ok(item.date);
+          assert.ok(item.isDir === false);
+          assert.ok(item.size);
+          assert.ok(
+            item.url === 'https://www.python.org/ftp/python/README.html'
+          );
           matchFile = true;
         }
         if (!item.isDir) {
-          assert(typeof item.size === 'string');
-          assert(item.size.length > 2);
+          assert.ok(typeof item.size === 'string');
+          assert.ok(item.size.length > 2);
         }
       }
-      assert(matchDir1);
-      assert(matchDir2);
-      assert(matchFile);
+      assert.ok(matchDir1);
+      assert.ok(matchDir2);
+      assert.ok(matchFile);
 
       result = await binary.fetch('/3.7.3/', 'python');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
 
       matchDir1 = false;
       matchDir2 = false;
       matchFile = false;
       for (const item of result.items) {
         if (item.name === 'win32/') {
-          assert(item.date === '25-Mar-2019 23:04');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '25-Mar-2019 23:04');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir1 = true;
         }
         if (item.name === 'amd64/') {
-          assert(item.date === '25-Mar-2019 23:03');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '25-Mar-2019 23:03');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir2 = true;
         }
         if (item.name === 'python-3.7.3.exe') {
-          assert(item.date === '25-Mar-2019 23:04');
-          assert(item.isDir === false);
-          assert(item.size === '25424128');
-          assert(
+          assert.ok(item.date === '25-Mar-2019 23:04');
+          assert.ok(item.isDir === false);
+          assert.ok(item.size === '25424128');
+          assert.ok(
             item.url ===
               'https://www.python.org/ftp/python/3.7.3/python-3.7.3.exe'
           );
           matchFile = true;
         }
         if (!item.isDir) {
-          assert(typeof item.size === 'string');
-          assert(item.size.length > 2);
+          assert.ok(typeof item.size === 'string');
+          assert.ok(item.size.length > 2);
         }
       }
-      assert(matchDir1);
-      assert(matchDir2);
-      assert(matchFile);
+      assert.ok(matchDir1);
+      assert.ok(matchDir2);
+      assert.ok(matchFile);
 
       result = await binary.fetch('/src/', 'python');
-      assert(result);
-      assert(result.items.length > 0);
-      assert(!result.items.some(item => item.name === 'Python-1.6.tar.gz'));
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
+      assert.ok(!result.items.some(item => item.name === 'Python-1.6.tar.gz'));
     });
   });
 });

--- a/test/common/adapter/binary/NodePreGypBinary.test.ts
+++ b/test/common/adapter/binary/NodePreGypBinary.test.ts
@@ -19,36 +19,36 @@ describe('test/common/adapter/binary/NodePreGypBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('nodejs.org/site/index.json'),
       });
       let result = await binary.fetch('/', 'grpc');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchDir1 = false;
       let matchDir2 = false;
       for (const item of result.items) {
         if (item.name === 'v1.24.11/') {
-          assert(item.date === '2021-07-23T18:07:10.297Z');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '2021-07-23T18:07:10.297Z');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir1 = true;
         }
         if (item.name === 'v1.14.0/') {
-          assert(item.date === '2018-08-10T16:59:52.551Z');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '2018-08-10T16:59:52.551Z');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir2 = true;
         }
       }
-      assert(matchDir1);
-      assert(matchDir2);
+      assert.ok(matchDir1);
+      assert.ok(matchDir2);
 
       result = await binary.fetch('/v1.24.11/', 'grpc');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       // console.log(JSON.stringify(result.items, null, 2));
       for (const item of result.items) {
-        assert(item.isDir === false);
-        assert(item.name);
-        assert(item.date);
-        assert(item.url.includes('/v1.24.11/'));
+        assert.ok(item.isDir === false);
+        assert.ok(item.name);
+        assert.ok(item.date);
+        assert.ok(item.url.includes('/v1.24.11/'));
         assert.deepEqual(item.ignoreDownloadStatuses, [404]);
       }
     });
@@ -63,37 +63,37 @@ describe('test/common/adapter/binary/NodePreGypBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('nodejs.org/site/index.json'),
       });
       let result = await binary.fetch('/', 'grpc-tools');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       // console.log(JSON.stringify(result.items, null, 2));
       let matchDir1 = false;
       let matchDir2 = false;
       for (const item of result.items) {
         if (item.name === 'v1.11.2/') {
-          assert(item.date === '2021-06-18T17:01:49.917Z');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '2021-06-18T17:01:49.917Z');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir1 = true;
         }
         if (item.name === 'v0.14.1/') {
-          assert(item.date === '2016-05-11T22:54:25.492Z');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '2016-05-11T22:54:25.492Z');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir2 = true;
         }
       }
-      assert(matchDir1);
-      assert(matchDir2);
+      assert.ok(matchDir1);
+      assert.ok(matchDir2);
 
       result = await binary.fetch('/v1.11.2/', 'grpc-tools');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       // console.log(JSON.stringify(result.items, null, 2));
       for (const item of result.items) {
-        assert(item.isDir === false);
-        assert(item.name);
-        assert(item.date);
-        assert(item.url.includes('/v1.11.2/'));
+        assert.ok(item.isDir === false);
+        assert.ok(item.name);
+        assert.ok(item.date);
+        assert.ok(item.url.includes('/v1.11.2/'));
         assert.deepEqual(item.ignoreDownloadStatuses, [404]);
       }
     });
@@ -108,36 +108,36 @@ describe('test/common/adapter/binary/NodePreGypBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('nodejs.org/site/index.json'),
       });
       const result = await binary.fetch('/', 'nodegit');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       // console.log(JSON.stringify(result.items, null, 2));
       let matchFile1 = false;
       let matchFile2 = false;
       let matchFile3 = false;
       for (const item of result.items) {
-        assert(item.isDir === false);
+        assert.ok(item.isDir === false);
         if (item.name === 'nodegit-v0.27.0-node-v64-linux-x64.tar.gz') {
-          assert(item.date === '2020-07-28T19:27:28.363Z');
-          assert(item.size === '-');
-          assert(
+          assert.ok(item.date === '2020-07-28T19:27:28.363Z');
+          assert.ok(item.size === '-');
+          assert.ok(
             item.url ===
               'https://axonodegit.s3.amazonaws.com/nodegit/nodegit/nodegit-v0.27.0-node-v64-linux-x64.tar.gz'
           );
           matchFile1 = true;
         }
         if (item.name === 'nodegit-v0.25.0-node-v64-darwin-x64.tar.gz') {
-          assert(item.date === '2019-08-09T16:46:10.709Z');
-          assert(item.size === '-');
-          assert(
+          assert.ok(item.date === '2019-08-09T16:46:10.709Z');
+          assert.ok(item.size === '-');
+          assert.ok(
             item.url ===
               'https://axonodegit.s3.amazonaws.com/nodegit/nodegit/nodegit-v0.25.0-node-v64-darwin-x64.tar.gz'
           );
           matchFile2 = true;
         }
         if (item.name === 'nodegit-v0.26.0-node-v57-win32-x64.tar.gz') {
-          assert(item.date === '2019-09-11T15:47:20.192Z');
-          assert(item.size === '-');
-          assert(
+          assert.ok(item.date === '2019-09-11T15:47:20.192Z');
+          assert.ok(item.size === '-');
+          assert.ok(
             item.url ===
               'https://axonodegit.s3.amazonaws.com/nodegit/nodegit/nodegit-v0.26.0-node-v57-win32-x64.tar.gz'
           );
@@ -147,9 +147,9 @@ describe('test/common/adapter/binary/NodePreGypBinary.test.ts', () => {
           throw new Error('should not run this');
         }
       }
-      assert(matchFile1);
-      assert(matchFile2);
-      assert(matchFile3);
+      assert.ok(matchFile1);
+      assert.ok(matchFile2);
+      assert.ok(matchFile3);
     });
 
     it('should fetch wrtc', async () => {
@@ -160,59 +160,59 @@ describe('test/common/adapter/binary/NodePreGypBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('nodejs.org/site/index.json'),
       });
       let result = await binary.fetch('/', 'wrtc');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       // console.log(JSON.stringify(result.items, null, 2));
       let matchDir = false;
       for (const item of result.items) {
-        assert(item.isDir === true);
+        assert.ok(item.isDir === true);
         if (item.name === 'v0.4.7/') {
           matchDir = true;
         }
       }
-      assert(matchDir);
+      assert.ok(matchDir);
 
       result = await binary.fetch('/v0.4.7/', 'wrtc');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       // console.log(JSON.stringify(result.items, null, 2));
       let matchFile1 = false;
       let matchFile2 = false;
       let matchFile3 = false;
       for (const item of result.items) {
-        assert(item.isDir === false);
+        assert.ok(item.isDir === false);
         assert.deepEqual(item.ignoreDownloadStatuses, [404]);
         if (item.name === 'linux-arm64.tar.gz') {
-          assert(item.date === '2021-01-10T15:43:35.384Z');
-          assert(item.size === '-');
-          assert(
+          assert.ok(item.date === '2021-01-10T15:43:35.384Z');
+          assert.ok(item.size === '-');
+          assert.ok(
             item.url ===
               'https://node-webrtc.s3.amazonaws.com/wrtc/v0.4.7/Release/linux-arm64.tar.gz'
           );
           matchFile1 = true;
         }
         if (item.name === 'linux-x64.tar.gz') {
-          assert(item.date === '2021-01-10T15:43:35.384Z');
-          assert(item.size === '-');
-          assert(
+          assert.ok(item.date === '2021-01-10T15:43:35.384Z');
+          assert.ok(item.size === '-');
+          assert.ok(
             item.url ===
               'https://node-webrtc.s3.amazonaws.com/wrtc/v0.4.7/Release/linux-x64.tar.gz'
           );
           matchFile2 = true;
         }
         if (item.name === 'darwin-x64.tar.gz') {
-          assert(item.date === '2021-01-10T15:43:35.384Z');
-          assert(item.size === '-');
-          assert(
+          assert.ok(item.date === '2021-01-10T15:43:35.384Z');
+          assert.ok(item.size === '-');
+          assert.ok(
             item.url ===
               'https://node-webrtc.s3.amazonaws.com/wrtc/v0.4.7/Release/darwin-x64.tar.gz'
           );
           matchFile3 = true;
         }
       }
-      assert(matchFile1);
-      assert(matchFile2);
-      assert(matchFile3);
+      assert.ok(matchFile1);
+      assert.ok(matchFile2);
+      assert.ok(matchFile3);
     });
 
     it('should fetch libpg-query', async () => {
@@ -225,19 +225,19 @@ describe('test/common/adapter/binary/NodePreGypBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('nodejs.org/site/index.json'),
       });
       const result = await binary.fetch('/', 'libpg-query-node');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchFile1 = false;
       let matchFile2 = false;
       let matchFile3 = false;
       let matchFile4 = false;
       let matchFile5 = false;
       for (const item of result.items) {
-        assert(item.isDir === false);
+        assert.ok(item.isDir === false);
         assert.deepEqual(item.ignoreDownloadStatuses, [404]);
         if (item.name === 'queryparser-v13.2.1-node-v108-darwin-arm64.tar.gz') {
-          assert(item.date === '2022-03-11T00:49:54.060Z');
-          assert(item.size === '-');
+          assert.ok(item.date === '2022-03-11T00:49:54.060Z');
+          assert.ok(item.size === '-');
           assert.equal(
             item.url,
             'https://supabase-public-artifacts-bucket.s3.amazonaws.com/libpg-query-node/queryparser-v13.2.1-node-v108-darwin-arm64.tar.gz'
@@ -245,8 +245,8 @@ describe('test/common/adapter/binary/NodePreGypBinary.test.ts', () => {
           matchFile1 = true;
         }
         if (item.name === 'queryparser-v13.2.1-node-v108-darwin-x64.tar.gz') {
-          assert(item.date === '2022-03-11T00:49:54.060Z');
-          assert(item.size === '-');
+          assert.ok(item.date === '2022-03-11T00:49:54.060Z');
+          assert.ok(item.size === '-');
           assert.equal(
             item.url,
             'https://supabase-public-artifacts-bucket.s3.amazonaws.com/libpg-query-node/queryparser-v13.2.1-node-v108-darwin-x64.tar.gz'
@@ -254,8 +254,8 @@ describe('test/common/adapter/binary/NodePreGypBinary.test.ts', () => {
           matchFile2 = true;
         }
         if (item.name === 'queryparser-v13.2.1-node-v108-linux-arm.tar.gz') {
-          assert(item.date === '2022-03-11T00:49:54.060Z');
-          assert(item.size === '-');
+          assert.ok(item.date === '2022-03-11T00:49:54.060Z');
+          assert.ok(item.size === '-');
           assert.equal(
             item.url,
             'https://supabase-public-artifacts-bucket.s3.amazonaws.com/libpg-query-node/queryparser-v13.2.1-node-v108-linux-arm.tar.gz'
@@ -263,8 +263,8 @@ describe('test/common/adapter/binary/NodePreGypBinary.test.ts', () => {
           matchFile3 = true;
         }
         if (item.name === 'queryparser-v13.2.1-node-v108-linux-x64.tar.gz') {
-          assert(item.date === '2022-03-11T00:49:54.060Z');
-          assert(item.size === '-');
+          assert.ok(item.date === '2022-03-11T00:49:54.060Z');
+          assert.ok(item.size === '-');
           assert.equal(
             item.url,
             'https://supabase-public-artifacts-bucket.s3.amazonaws.com/libpg-query-node/queryparser-v13.2.1-node-v108-linux-x64.tar.gz'
@@ -281,11 +281,11 @@ describe('test/common/adapter/binary/NodePreGypBinary.test.ts', () => {
           matchFile5 = true;
         }
       }
-      assert(matchFile1);
-      assert(matchFile2);
-      assert(matchFile3);
-      assert(matchFile4);
-      assert(matchFile5);
+      assert.ok(matchFile1);
+      assert.ok(matchFile2);
+      assert.ok(matchFile3);
+      assert.ok(matchFile4);
+      assert.ok(matchFile5);
     });
   });
 });

--- a/test/common/adapter/binary/NwjsBinary.test.ts
+++ b/test/common/adapter/binary/NwjsBinary.test.ts
@@ -17,19 +17,19 @@ describe('test/common/adapter/binary/NwjsBinary.test.ts', () => {
         persist: false,
       });
       const result = await binary.fetch('/');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchDir = false;
       for (const item of result.items) {
-        assert(item.isDir);
+        assert.ok(item.isDir);
         if (item.name === 'v0.59.0/') {
-          assert(item.date === '02-Dec-2021 16:40');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '02-Dec-2021 16:40');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir = true;
         }
       }
-      assert(matchDir);
+      assert.ok(matchDir);
     });
 
     it('should fetch subdir: /v0.59.0/, /v0.59.1/x64/ work', async () => {
@@ -40,34 +40,34 @@ describe('test/common/adapter/binary/NwjsBinary.test.ts', () => {
         persist: false,
       });
       let result = await binary.fetch('/v0.59.0/');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchDir = false;
       let matchFile = false;
       for (const item of result.items) {
         // console.log(item);
         if (item.name === 'x64/') {
-          assert(item.date === '-');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '-');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir = true;
         }
         if (item.name === 'nwjs-v0.59.0-win-x64.zip') {
-          assert(item.date === '2021-12-02T23:35:59.000Z');
-          assert(item.isDir === false);
-          assert(item.size === 110_828_221);
-          assert(
+          assert.ok(item.date === '2021-12-02T23:35:59.000Z');
+          assert.ok(item.isDir === false);
+          assert.ok(item.size === 110_828_221);
+          assert.ok(
             item.url === 'https://dl.nwjs.io/v0.59.0/nwjs-v0.59.0-win-x64.zip'
           );
           matchFile = true;
         }
         if (!item.isDir) {
-          assert(typeof item.size === 'number');
-          assert(item.size > 2);
+          assert.ok(typeof item.size === 'number');
+          assert.ok(item.size > 2);
         }
       }
-      assert(matchDir);
-      assert(matchFile);
+      assert.ok(matchDir);
+      assert.ok(matchFile);
 
       // https://nwjs2.s3.amazonaws.com/?delimiter=/&prefix=v0.59.1%2Fx64%2F
       app.mockHttpclient('https://nwjs2.s3.amazonaws.com/', 'GET', {
@@ -77,29 +77,29 @@ describe('test/common/adapter/binary/NwjsBinary.test.ts', () => {
         persist: false,
       });
       result = await binary.fetch('/v0.59.1/x64/');
-      assert(result);
-      assert(result.items.length === 2);
+      assert.ok(result);
+      assert.ok(result.items.length === 2);
       let matchFile1 = false;
       let matchFile2 = false;
       for (const item of result.items) {
         // console.log(item);
         if (item.name === 'node.lib') {
-          assert(item.date === '2021-12-21T22:41:19.000Z');
-          assert(item.isDir === false);
-          assert(item.size === 871_984);
-          assert(item.url === 'https://dl.nwjs.io/v0.59.1/x64/node.lib');
+          assert.ok(item.date === '2021-12-21T22:41:19.000Z');
+          assert.ok(item.isDir === false);
+          assert.ok(item.size === 871_984);
+          assert.ok(item.url === 'https://dl.nwjs.io/v0.59.1/x64/node.lib');
           matchFile1 = true;
         }
         if (item.name === 'nw.lib') {
-          assert(item.date === '2021-12-21T22:41:19.000Z');
-          assert(item.isDir === false);
-          assert(item.size === 6_213_840);
-          assert(item.url === 'https://dl.nwjs.io/v0.59.1/x64/nw.lib');
+          assert.ok(item.date === '2021-12-21T22:41:19.000Z');
+          assert.ok(item.isDir === false);
+          assert.ok(item.size === 6_213_840);
+          assert.ok(item.url === 'https://dl.nwjs.io/v0.59.1/x64/nw.lib');
           matchFile2 = true;
         }
       }
-      assert(matchFile1);
-      assert(matchFile2);
+      assert.ok(matchFile1);
+      assert.ok(matchFile2);
     });
   });
 });

--- a/test/common/adapter/binary/PlaywrightBinary.test.ts
+++ b/test/common/adapter/binary/PlaywrightBinary.test.ts
@@ -34,18 +34,18 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
         )
         .persist();
       const result = await binary.fetch('/');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchDir1 = false;
       for (const item of result.items) {
         if (item.name === 'builds/') {
-          assert(item.date);
+          assert.ok(item.date);
           assert.equal(item.isDir, true);
-          assert(item.size === '-');
+          assert.ok(item.size === '-');
           matchDir1 = true;
         }
       }
-      assert(matchDir1);
+      assert.ok(matchDir1);
     });
 
     it('should fetch subdir: /builds/, /builds/chromium/ work', async () => {
@@ -70,7 +70,7 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
         )
         .persist();
       let result = await binary.fetch('/builds/');
-      assert(result);
+      assert.ok(result);
       assert.equal(result.items.length, 8, JSON.stringify(result, null, 2));
       assert.equal(result.items[0].name, 'chromium/');
       assert.equal(result.items[1].name, 'chromium-tip-of-tree/');
@@ -94,18 +94,18 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
       ];
       for (const dirname of names) {
         result = await binary.fetch(`/builds/${dirname}/`);
-        assert(result);
+        assert.ok(result);
         // console.log(dirname, result.items);
-        assert(result.items.length > 0, JSON.stringify(result, null, 2));
+        assert.ok(result.items.length > 0, JSON.stringify(result, null, 2));
         for (const item of result.items) {
-          assert(item.isDir);
+          assert.ok(item.isDir);
         }
         result = await binary.fetch(
           `/builds/${dirname}/${result.items[0].name}`
         );
-        assert(result);
+        assert.ok(result);
         // console.log(result.items);
-        assert(result.items.length > 0);
+        assert.ok(result.items.length > 0);
         let shouldIncludeChromiumHeadlessShell = false;
         // chromium-tip-of-tree-headless-shell
         let shouldIncludeChromiumTipOfTreeHeadlessShell = false;
@@ -117,11 +117,11 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
           //   size: '-',
           //   date: '2022-04-18T20:51:53.788Z'
           // },
-          assert(item.isDir === false);
-          assert(item.name);
-          assert(item.size === '-');
-          assert(item.url);
-          assert(item.date);
+          assert.ok(item.isDir === false);
+          assert.ok(item.name);
+          assert.ok(item.size === '-');
+          assert.ok(item.url);
+          assert.ok(item.date);
           if (
             dirname === 'chromium' &&
             item.name.startsWith('chromium-headless-shell')
@@ -145,11 +145,11 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
           }
         }
         if (dirname === 'chromium') {
-          assert(shouldIncludeChromiumHeadlessShell);
+          assert.ok(shouldIncludeChromiumHeadlessShell);
           // console.log(result);
         }
         if (dirname === 'chromium-tip-of-tree') {
-          assert(shouldIncludeChromiumTipOfTreeHeadlessShell);
+          assert.ok(shouldIncludeChromiumTipOfTreeHeadlessShell);
         }
         // if (dirname === 'winldd') {
         //   console.log(result);

--- a/test/common/adapter/binary/PrismaBinary.test.ts
+++ b/test/common/adapter/binary/PrismaBinary.test.ts
@@ -21,8 +21,8 @@ describe('test/common/adapter/binary/PrismaBinary.test.ts', () => {
       await binary.initFetch();
       const result = await binary.fetch('/all_commits/', 'prisma');
       // console.log(result);
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchDir1 = false;
       let matchDir2 = false;
       let matchDir3 = false;
@@ -46,9 +46,9 @@ describe('test/common/adapter/binary/PrismaBinary.test.ts', () => {
           matchDir3 = true;
         }
       }
-      assert(matchDir1);
-      assert(matchDir2);
-      assert(matchDir3);
+      assert.ok(matchDir1);
+      assert.ok(matchDir2);
+      assert.ok(matchDir3);
     });
 
     it('should fetch subdir: /61023c35d2c8762f66f09bc4183d2f630b541d08/ work', async () => {
@@ -66,7 +66,7 @@ describe('test/common/adapter/binary/PrismaBinary.test.ts', () => {
         '/61023c35d2c8762f66f09bc4183d2f630b541d08/',
         'prisma'
       );
-      assert(result);
+      assert.ok(result);
       assert.equal(result.items.length, 16);
       assert.equal(result.items[0].name, 'darwin-arm64/');
       assert.equal(result.items[1].name, 'darwin/');
@@ -88,7 +88,7 @@ describe('test/common/adapter/binary/PrismaBinary.test.ts', () => {
         '/61023c35d2c8762f66f09bc4183d2f630b541d08/darwin-arm64/',
         'prisma'
       );
-      assert(result);
+      assert.ok(result);
       assert.equal(result.items.length, 20);
       assert.equal(
         result.items[0].name,

--- a/test/common/adapter/binary/PuppeteerBinary.test.ts
+++ b/test/common/adapter/binary/PuppeteerBinary.test.ts
@@ -37,154 +37,154 @@ describe('test/common/adapter/binary/PuppeteerBinary.test.ts', () => {
         Win: '1441468',
         Win_x64: '1441468',
       });
-      assert(result);
-      assert(result.items.length === 5);
+      assert.ok(result);
+      assert.ok(result.items.length === 5);
       // 'Linux_x64', 'Mac', 'Mac_Arm', 'Win', 'Win_x64'
-      assert(result.items[0].name === 'Linux_x64/');
-      assert(result.items[0].isDir === true);
-      assert(result.items[0].date);
-      assert(result.items[1].name === 'Mac/');
-      assert(result.items[1].isDir === true);
-      assert(result.items[1].date);
-      assert(result.items[2].name === 'Mac_Arm/');
-      assert(result.items[2].isDir === true);
-      assert(result.items[2].date);
-      assert(result.items[3].name === 'Win/');
-      assert(result.items[3].isDir === true);
-      assert(result.items[3].date);
-      assert(result.items[4].name === 'Win_x64/');
-      assert(result.items[4].isDir === true);
-      assert(result.items[4].date);
+      assert.ok(result.items[0].name === 'Linux_x64/');
+      assert.ok(result.items[0].isDir === true);
+      assert.ok(result.items[0].date);
+      assert.ok(result.items[1].name === 'Mac/');
+      assert.ok(result.items[1].isDir === true);
+      assert.ok(result.items[1].date);
+      assert.ok(result.items[2].name === 'Mac_Arm/');
+      assert.ok(result.items[2].isDir === true);
+      assert.ok(result.items[2].date);
+      assert.ok(result.items[3].name === 'Win/');
+      assert.ok(result.items[3].isDir === true);
+      assert.ok(result.items[3].date);
+      assert.ok(result.items[4].name === 'Win_x64/');
+      assert.ok(result.items[4].isDir === true);
+      assert.ok(result.items[4].date);
 
       result = await binary.fetch('/Linux_x64/', 'chromium-browser-snapshots');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       // console.log(result.items);
       let matchDir = false;
       for (const item of result.items) {
-        assert(item.isDir === true);
-        assert(item.date);
+        assert.ok(item.isDir === true);
+        assert.ok(item.date);
         if (item.name === '1000015/') {
           matchDir = true;
         }
       }
-      assert(matchDir);
+      assert.ok(matchDir);
 
       result = await binary.fetch(
         '/Linux_x64/1000015/',
         'chromium-browser-snapshots'
       );
-      assert(result);
-      assert(result.items.length === 1);
+      assert.ok(result);
+      assert.ok(result.items.length === 1);
       // console.log(result.items);
-      assert(result.items[0].name === 'chrome-linux.zip');
-      assert(result.items[0].isDir === false);
-      assert(result.items[0].date);
-      assert(result.items[0].url);
+      assert.ok(result.items[0].name === 'chrome-linux.zip');
+      assert.ok(result.items[0].isDir === false);
+      assert.ok(result.items[0].date);
+      assert.ok(result.items[0].url);
       result = await binary.fetch(
         '/Mac/1000015/',
         'chromium-browser-snapshots'
       );
-      assert(result);
-      assert(result.items.length === 1);
+      assert.ok(result);
+      assert.ok(result.items.length === 1);
       // console.log(result.items);
-      assert(result.items[0].name === 'chrome-mac.zip');
-      assert(result.items[0].isDir === false);
-      assert(result.items[0].date);
-      assert(result.items[0].url);
+      assert.ok(result.items[0].name === 'chrome-mac.zip');
+      assert.ok(result.items[0].isDir === false);
+      assert.ok(result.items[0].date);
+      assert.ok(result.items[0].url);
       result = await binary.fetch(
         '/Mac_Arm/1000015/',
         'chromium-browser-snapshots'
       );
-      assert(result);
-      assert(result.items.length === 1);
+      assert.ok(result);
+      assert.ok(result.items.length === 1);
       // console.log(result.items);
-      assert(result.items[0].name === 'chrome-mac.zip');
-      assert(result.items[0].isDir === false);
-      assert(result.items[0].date);
-      assert(result.items[0].url);
+      assert.ok(result.items[0].name === 'chrome-mac.zip');
+      assert.ok(result.items[0].isDir === false);
+      assert.ok(result.items[0].date);
+      assert.ok(result.items[0].url);
       result = await binary.fetch(
         '/Win/1000015/',
         'chromium-browser-snapshots'
       );
-      assert(result);
-      assert(result.items.length === 1);
+      assert.ok(result);
+      assert.ok(result.items.length === 1);
       // console.log(result.items);
-      assert(result.items[0].name === 'chrome-win.zip');
-      assert(result.items[0].isDir === false);
-      assert(result.items[0].date);
-      assert(result.items[0].url);
+      assert.ok(result.items[0].name === 'chrome-win.zip');
+      assert.ok(result.items[0].isDir === false);
+      assert.ok(result.items[0].date);
+      assert.ok(result.items[0].url);
       result = await binary.fetch(
         '/Win_x64/1000015/',
         'chromium-browser-snapshots'
       );
-      assert(result);
-      assert(result.items.length === 1);
+      assert.ok(result);
+      assert.ok(result.items.length === 1);
       // console.log(result.items);
-      assert(result.items[0].name === 'chrome-win.zip');
-      assert(result.items[0].isDir === false);
-      assert(result.items[0].date);
-      assert(result.items[0].url);
+      assert.ok(result.items[0].name === 'chrome-win.zip');
+      assert.ok(result.items[0].isDir === false);
+      assert.ok(result.items[0].date);
+      assert.ok(result.items[0].url);
 
       result = await binary.fetch(
         '/Linux_x64/100057/',
         'chromium-browser-snapshots'
       );
-      assert(result);
-      assert(result.items.length === 1);
+      assert.ok(result);
+      assert.ok(result.items.length === 1);
       // console.log(result.items);
-      assert(result.items[0].name === 'chrome-linux.zip');
-      assert(result.items[0].isDir === false);
-      assert(result.items[0].date);
-      assert(result.items[0].url);
+      assert.ok(result.items[0].name === 'chrome-linux.zip');
+      assert.ok(result.items[0].isDir === false);
+      assert.ok(result.items[0].date);
+      assert.ok(result.items[0].url);
 
       result = await binary.fetch(
         '/Linux_x64/1000569/',
         'chromium-browser-snapshots'
       );
-      assert(result);
-      assert(result.items?.length === 1);
+      assert.ok(result);
+      assert.ok(result.items?.length === 1);
       // console.log(result.items);
-      assert(result.items[0].name === 'chrome-linux.zip');
-      assert(result.items[0].isDir === false);
-      assert(result.items[0].date);
-      assert(result.items[0].url);
+      assert.ok(result.items[0].name === 'chrome-linux.zip');
+      assert.ok(result.items[0].isDir === false);
+      assert.ok(result.items[0].date);
+      assert.ok(result.items[0].url);
 
       result = await binary.fetch(
         '/Linux_x64/100056/',
         'chromium-browser-snapshots'
       );
-      assert(result);
-      assert(result.items?.length === 1);
+      assert.ok(result);
+      assert.ok(result.items?.length === 1);
       // console.log(result.items);
-      assert(result.items[0].name === 'chrome-linux.zip');
-      assert(result.items[0].isDir === false);
-      assert(result.items[0].date);
-      assert(result.items[0].url);
+      assert.ok(result.items[0].name === 'chrome-linux.zip');
+      assert.ok(result.items[0].isDir === false);
+      assert.ok(result.items[0].date);
+      assert.ok(result.items[0].url);
 
       result = await binary.fetch(
         '/Linux_x64/1000557/',
         'chromium-browser-snapshots'
       );
-      assert(result);
-      assert(result.items?.length === 1);
+      assert.ok(result);
+      assert.ok(result.items?.length === 1);
       // console.log(result.items);
-      assert(result.items[0].name === 'chrome-linux.zip');
-      assert(result.items[0].isDir === false);
-      assert(result.items[0].date);
-      assert(result.items[0].url);
+      assert.ok(result.items[0].name === 'chrome-linux.zip');
+      assert.ok(result.items[0].isDir === false);
+      assert.ok(result.items[0].date);
+      assert.ok(result.items[0].url);
 
       result = await binary.fetch(
         '/Linux_x64/100055/',
         'chromium-browser-snapshots'
       );
-      assert(result);
-      assert(result.items?.length === 1);
+      assert.ok(result);
+      assert.ok(result.items?.length === 1);
       // console.log(result.items);
-      assert(result.items[0].name === 'chrome-linux.zip');
-      assert(result.items[0].isDir === false);
-      assert(result.items[0].date);
-      assert(result.items[0].url);
+      assert.ok(result.items[0].name === 'chrome-linux.zip');
+      assert.ok(result.items[0].isDir === false);
+      assert.ok(result.items[0].date);
+      assert.ok(result.items[0].url);
     });
   });
 });

--- a/test/common/adapter/binary/SqlcipherBinary.test.ts
+++ b/test/common/adapter/binary/SqlcipherBinary.test.ts
@@ -23,26 +23,26 @@ describe('test/common/adapter/binary/SqlcipherBinary.test.ts', () => {
         }
       );
       const result = await binary.fetch('/');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       let matchDir1 = false;
       let matchDir2 = false;
       for (const item of result.items) {
         if (item.name === 'v5.3.1/') {
-          assert(item.date === '2021-12-14T13:12:31.587Z');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '2021-12-14T13:12:31.587Z');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir1 = true;
         }
         if (item.name === 'v5.0.0/') {
-          assert(item.date === '2020-09-25T13:05:17.722Z');
-          assert(item.isDir === true);
-          assert(item.size === '-');
+          assert.ok(item.date === '2020-09-25T13:05:17.722Z');
+          assert.ok(item.isDir === true);
+          assert.ok(item.size === '-');
           matchDir2 = true;
         }
       }
-      assert(matchDir1);
-      assert(matchDir2);
+      assert.ok(matchDir1);
+      assert.ok(matchDir2);
       app.mockAgent().assertNoPendingInterceptors();
     });
 
@@ -58,11 +58,11 @@ describe('test/common/adapter/binary/SqlcipherBinary.test.ts', () => {
         }
       );
       const result = await binary.fetch('/v5.3.1/');
-      assert(result);
-      assert(result.items.length > 0);
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
       for (const item of result.items) {
-        assert(item.isDir === false);
-        assert(item.name.endsWith('.tar.gz'));
+        assert.ok(item.isDir === false);
+        assert.ok(item.name.endsWith('.tar.gz'));
         assert.deepEqual(item.ignoreDownloadStatuses, [404, 403]);
       }
       app.mockAgent().assertNoPendingInterceptors();

--- a/test/common/adapter/changesStream/CnpmcoreChangesStream.test.ts
+++ b/test/common/adapter/changesStream/CnpmcoreChangesStream.test.ts
@@ -33,7 +33,7 @@ describe('test/common/adapter/changesStream/CnpmcoreChangesStream.test.ts', () =
         },
       });
       const since = await cnpmcoreChangesStream.getInitialSince(registry);
-      assert(since === '9517');
+      assert.ok(since === '9517');
     });
 
     it('should throw error', async () => {
@@ -85,7 +85,7 @@ describe('test/common/adapter/changesStream/CnpmcoreChangesStream.test.ts', () =
         res.push(change as ChangesStreamChange);
       }
 
-      assert(res.length === 1);
+      assert.ok(res.length === 1);
     });
   });
 });

--- a/test/common/adapter/changesStream/CnpmjsorgChangesStream.test.ts
+++ b/test/common/adapter/changesStream/CnpmjsorgChangesStream.test.ts
@@ -28,7 +28,7 @@ describe('test/common/adapter/changesStream/CnpmjsorgChangesStream.test.ts', () 
     it('should work', async () => {
       const since = await cnpmjsorgChangesStream.getInitialSince(registry);
       const now = Date.now();
-      assert(now - Number(since) < 10_000);
+      assert.ok(now - Number(since) < 10_000);
     });
   });
 
@@ -58,7 +58,7 @@ describe('test/common/adapter/changesStream/CnpmjsorgChangesStream.test.ts', () 
       for await (const change of stream) {
         res.push(change as ChangesStreamChange);
       }
-      assert(res.length === 2);
+      assert.ok(res.length === 2);
     });
 
     it('should work when fetch latest changes', async () => {
@@ -86,7 +86,7 @@ describe('test/common/adapter/changesStream/CnpmjsorgChangesStream.test.ts', () 
       for await (const change of stream) {
         changes.push(change);
       }
-      assert(changes.length === 2);
+      assert.ok(changes.length === 2);
     });
 
     it('should reject max limit', async () => {

--- a/test/common/adapter/changesStream/NpmChangesStream.test.ts
+++ b/test/common/adapter/changesStream/NpmChangesStream.test.ts
@@ -90,7 +90,7 @@ describe('test/common/adapter/changesStream/NpmChangesStream.test.ts', () => {
         // 62080870
         // 36904024
         const stream = npmChangesStream.fetchChanges(registry, lastSeq);
-        assert(stream);
+        assert.ok(stream);
         let hasMore = false;
         try {
           for await (const change of stream) {

--- a/test/core/entity/BugVersion.test.ts
+++ b/test/core/entity/BugVersion.test.ts
@@ -61,7 +61,7 @@ describe('test/core/entity/BugVersion.test.ts', () => {
 
     it('should return undefined if not a bug version', () => {
       const advice = bugVersion.fixVersion('colors', '1.4.3');
-      assert(!advice);
+      assert.ok(!advice);
     });
   });
 
@@ -179,7 +179,7 @@ describe('test/core/entity/BugVersion.test.ts', () => {
           node: '>=0.1.90',
         },
       });
-      assert(!fixedManifest);
+      assert.ok(!fixedManifest);
     });
 
     it('should not mofidy manifest if not a bug version', () => {
@@ -225,7 +225,7 @@ describe('test/core/entity/BugVersion.test.ts', () => {
           node: '>=0.1.90',
         },
       });
-      assert(!fixedManifest);
+      assert.ok(!fixedManifest);
     });
   });
 });

--- a/test/core/entity/SqlRange.test.ts
+++ b/test/core/entity/SqlRange.test.ts
@@ -63,7 +63,7 @@ describe('test/npm/core/entity/SqlRange.test.ts', () => {
   });
   it('should support =', () => {
     const res = new SqlRange('1.0.0 || 2.0.0');
-    assert(res.containPreRelease === false);
+    assert.ok(res.containPreRelease === false);
     assert.deepEqual(res.condition, {
       $or: [
         {

--- a/test/core/event/StoreManifest.test.ts
+++ b/test/core/event/StoreManifest.test.ts
@@ -17,17 +17,17 @@ describe('test/core/event/StoreManifest.test.ts', () => {
       const { pkg } = await TestUtil.createPackage({ version: '1.0.0' });
       const [scope, name] = getScopeAndName(pkg.name);
       const packageId = await packageRepository.findPackageId(scope, name);
-      assert(packageId);
+      assert.ok(packageId);
       const packageVersion = await packageRepository.findPackageVersion(
         packageId,
         '1.0.0'
       );
-      assert(packageVersion);
+      assert.ok(packageVersion);
       const packageVersionManifest =
         await packageRepository.findPackageVersionManifest(
           packageVersion.packageVersionId
         );
-      assert(!packageVersionManifest);
+      assert.ok(!packageVersionManifest);
       app.notExpectLog(
         '[PackageRepository:savePackageVersionManifest:new] id: '
       );
@@ -47,21 +47,23 @@ describe('test/core/event/StoreManifest.test.ts', () => {
       await eventWaiter.await('PACKAGE_VERSION_ADDED');
       const [scope, name] = getScopeAndName(pkg.name);
       const packageId = await packageRepository.findPackageId(scope, name);
-      assert(packageId);
+      assert.ok(packageId);
       const packageVersion = await packageRepository.findPackageVersion(
         packageId,
         '1.0.0'
       );
-      assert(packageVersion);
+      assert.ok(packageVersion);
       const packageVersionManifest =
         await packageRepository.findPackageVersionManifest(
           packageVersion.packageVersionId
         );
-      assert(packageVersionManifest);
+      assert.ok(packageVersionManifest);
       app.expectLog('[PackageRepository:savePackageVersionManifest:new] id: ');
-      assert(packageVersionManifest.manifest.readme === 'test store manifest');
-      assert(packageVersionManifest.manifest.description);
-      assert(packageVersionManifest.manifest.version === '1.0.0');
+      assert.ok(
+        packageVersionManifest.manifest.readme === 'test store manifest'
+      );
+      assert.ok(packageVersionManifest.manifest.description);
+      assert.ok(packageVersionManifest.manifest.version === '1.0.0');
       // console.log(packageVersionManifest.manifest);
 
       await TestUtil.createPackage(
@@ -74,13 +76,13 @@ describe('test/core/event/StoreManifest.test.ts', () => {
         packageId,
         '2.0.0'
       );
-      assert(packageVersion2);
+      assert.ok(packageVersion2);
       const packageVersionManifest2 =
         await packageRepository.findPackageVersionManifest(
           packageVersion2.packageVersionId
         );
-      assert(packageVersionManifest2);
-      assert(packageVersionManifest2.manifest.version === '2.0.0');
+      assert.ok(packageVersionManifest2);
+      assert.ok(packageVersionManifest2.manifest.version === '2.0.0');
       // console.log(packageVersionManifest2.manifest);
 
       // should work same version

--- a/test/core/service/BinarySyncerService/createTask.test.ts
+++ b/test/core/service/BinarySyncerService/createTask.test.ts
@@ -21,8 +21,8 @@ describe('test/core/service/BinarySyncerService/createTask.test.ts', () => {
         'banana' as BinaryName,
         {}
       );
-      assert(task?.taskId === newTask?.taskId);
-      assert(task?.bizId === 'SyncBinary:banana');
+      assert.ok(task?.taskId === newTask?.taskId);
+      assert.ok(task?.bizId === 'SyncBinary:banana');
     });
   });
 });

--- a/test/core/service/BinarySyncerService/executeTask.test.ts
+++ b/test/core/service/BinarySyncerService/executeTask.test.ts
@@ -35,7 +35,7 @@ describe('test/core/service/BinarySyncerService/executeTask.test.ts', () => {
       );
       await binarySyncerService.createTask('node', {});
       let task = await binarySyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       mock(NodeBinary.prototype, 'fetch', async (dir: string) => {
         if (dir === '/') {
           return {
@@ -87,29 +87,29 @@ describe('test/core/service/BinarySyncerService/executeTask.test.ts', () => {
       });
       await binarySyncerService.executeTask(task);
       app.mockAgent().assertNoPendingInterceptors();
-      assert(!(await TaskModel.findOne({ taskId: task.taskId })));
-      assert(await HistoryTaskModel.findOne({ taskId: task.taskId }));
+      assert.ok(!(await TaskModel.findOne({ taskId: task.taskId })));
+      assert.ok(await HistoryTaskModel.findOne({ taskId: task.taskId }));
       let stream = await binarySyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       let log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('Syncing diff: 2 => 2'));
-      assert(log.includes('[/] 🟢 Synced dir success'));
-      assert(log.includes('[/latest/] 🟢 Synced dir success'));
-      assert(log.includes('[/latest/docs/] 🟢 Synced dir success'));
+      assert.ok(log.includes('Syncing diff: 2 => 2'));
+      assert.ok(log.includes('[/] 🟢 Synced dir success'));
+      assert.ok(log.includes('[/latest/] 🟢 Synced dir success'));
+      assert.ok(log.includes('[/latest/docs/] 🟢 Synced dir success'));
 
       // sync again
       await binarySyncerService.createTask('node', {});
       task = await binarySyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await binarySyncerService.executeTask(task);
       stream = await binarySyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('reason: revalidate latest version'));
-      assert(log.includes('Syncing diff: 2 => 1'));
-      assert(log.includes('[/] 🟢 Synced dir success'));
+      assert.ok(log.includes('reason: revalidate latest version'));
+      assert.ok(log.includes('Syncing diff: 2 => 1'));
+      assert.ok(log.includes('[/] 🟢 Synced dir success'));
 
       // mock date change
       app.mockHttpclient('https://nodejs.org/dist/index.json', 'GET', {
@@ -142,21 +142,21 @@ describe('test/core/service/BinarySyncerService/executeTask.test.ts', () => {
       });
       await binarySyncerService.createTask('node', {});
       task = await binarySyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await binarySyncerService.executeTask(task);
       stream = await binarySyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('Syncing diff: 2 => 1'));
-      assert(log.includes('[/] 🟢 Synced dir success'));
+      assert.ok(log.includes('Syncing diff: 2 => 1'));
+      assert.ok(log.includes('[/] 🟢 Synced dir success'));
       app.mockAgent().assertNoPendingInterceptors();
     });
 
     it('should mock download file error', async () => {
       await binarySyncerService.createTask('node', {});
       const task = await binarySyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       mock(NodeBinary.prototype, 'fetch', async (dir: string) => {
         if (dir === '/') {
           return {
@@ -223,32 +223,32 @@ describe('test/core/service/BinarySyncerService/executeTask.test.ts', () => {
         }
       );
       await binarySyncerService.executeTask(task);
-      assert(!(await TaskModel.findOne({ taskId: task.taskId })));
-      assert(await HistoryTaskModel.findOne({ taskId: task.taskId }));
+      assert.ok(!(await TaskModel.findOne({ taskId: task.taskId })));
+      assert.ok(await HistoryTaskModel.findOne({ taskId: task.taskId }));
       const stream = await binarySyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('Syncing diff: 2 => 2'));
-      assert(
+      assert.ok(log.includes('Syncing diff: 2 => 2'));
+      assert.ok(
         log.includes(
           '❌ [0.0.0] Download https://nodejs.org/dist/latest/docs/apilinks-not-exists.json'
         )
       );
-      assert(
+      assert.ok(
         log.includes(
           '❌ [1] Download https://nodejs.org/dist/index-not-exists.json'
         )
       );
-      assert(log.includes('[/] ❌ Synced dir fail'));
-      assert(log.includes('[/latest/] ❌ Synced dir fail'));
-      assert(log.includes('[/latest/docs/] ❌ Synced dir fail'));
+      assert.ok(log.includes('[/] ❌ Synced dir fail'));
+      assert.ok(log.includes('[/latest/] ❌ Synced dir fail'));
+      assert.ok(log.includes('[/latest/docs/] ❌ Synced dir fail'));
     });
 
     it('should mock download file not found', async () => {
       await binarySyncerService.createTask('node', {});
       const task = await binarySyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       mock(NodeBinary.prototype, 'fetch', async (dir: string) => {
         if (dir === '/') {
           return {
@@ -315,26 +315,26 @@ describe('test/core/service/BinarySyncerService/executeTask.test.ts', () => {
         }
       );
       await binarySyncerService.executeTask(task);
-      assert(!(await TaskModel.findOne({ taskId: task.taskId })));
-      assert(await HistoryTaskModel.findOne({ taskId: task.taskId }));
+      assert.ok(!(await TaskModel.findOne({ taskId: task.taskId })));
+      assert.ok(await HistoryTaskModel.findOne({ taskId: task.taskId }));
       const stream = await binarySyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('Syncing diff: 2 => 2'));
-      assert(
+      assert.ok(log.includes('Syncing diff: 2 => 2'));
+      assert.ok(
         log.includes(
           '🧪️ [0.0.0] Download https://nodejs.org/dist/latest/docs/apilinks-not-exists.json not found, skip it'
         )
       );
-      assert(
+      assert.ok(
         log.includes(
           '🧪️ [1] Download https://nodejs.org/dist/index-not-exists.json not found, skip it'
         )
       );
-      assert(log.includes('[/] 🟢 Synced dir success'));
-      assert(log.includes('[/latest/] 🟢 Synced dir success'));
-      assert(log.includes('[/latest/docs/] 🟢 Synced dir success'));
+      assert.ok(log.includes('[/] 🟢 Synced dir success'));
+      assert.ok(log.includes('[/latest/] 🟢 Synced dir success'));
+      assert.ok(log.includes('[/latest/docs/] 🟢 Synced dir success'));
     });
 
     it('should execute "node" task with ApiBinary when sourceRegistryIsCNpm=true', async () => {
@@ -355,7 +355,7 @@ describe('test/core/service/BinarySyncerService/executeTask.test.ts', () => {
       mock(app.config.cnpmcore, 'sourceRegistryIsCNpm', true);
       await binarySyncerService.createTask('node', {});
       let task = await binarySyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       mock(ApiBinary.prototype, 'fetch', async (dir: string) => {
         if (dir === '/') {
           return {
@@ -406,29 +406,29 @@ describe('test/core/service/BinarySyncerService/executeTask.test.ts', () => {
         return { items: [] };
       });
       await binarySyncerService.executeTask(task);
-      assert(!(await TaskModel.findOne({ taskId: task.taskId })));
-      assert(await HistoryTaskModel.findOne({ taskId: task.taskId }));
+      assert.ok(!(await TaskModel.findOne({ taskId: task.taskId })));
+      assert.ok(await HistoryTaskModel.findOne({ taskId: task.taskId }));
       let stream = await binarySyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       let log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('Syncing diff: 2 => 2'));
-      assert(log.includes('[/] 🟢 Synced dir success'));
-      assert(log.includes('[/latest/] 🟢 Synced dir success'));
-      assert(log.includes('[/latest/docs/] 🟢 Synced dir success'));
+      assert.ok(log.includes('Syncing diff: 2 => 2'));
+      assert.ok(log.includes('[/] 🟢 Synced dir success'));
+      assert.ok(log.includes('[/latest/] 🟢 Synced dir success'));
+      assert.ok(log.includes('[/latest/docs/] 🟢 Synced dir success'));
 
       // sync again
       await binarySyncerService.createTask('node', {});
       task = await binarySyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await binarySyncerService.executeTask(task);
       stream = await binarySyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('reason: revalidate latest version'));
-      assert(log.includes('Syncing diff: 2 => 1'));
-      assert(log.includes('[/] 🟢 Synced dir success'));
+      assert.ok(log.includes('reason: revalidate latest version'));
+      assert.ok(log.includes('Syncing diff: 2 => 1'));
+      assert.ok(log.includes('[/] 🟢 Synced dir success'));
       app.mockAgent().assertNoPendingInterceptors();
     });
 
@@ -449,7 +449,7 @@ describe('test/core/service/BinarySyncerService/executeTask.test.ts', () => {
       );
       await binarySyncerService.createTask('node', {});
       let task = await binarySyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       mock(NodeBinary.prototype, 'fetch', async (dir: string) => {
         if (dir === '/') {
           return {
@@ -501,29 +501,29 @@ describe('test/core/service/BinarySyncerService/executeTask.test.ts', () => {
       });
       await binarySyncerService.executeTask(task);
       app.mockAgent().assertNoPendingInterceptors();
-      assert(!(await TaskModel.findOne({ taskId: task.taskId })));
-      assert(await HistoryTaskModel.findOne({ taskId: task.taskId }));
+      assert.ok(!(await TaskModel.findOne({ taskId: task.taskId })));
+      assert.ok(await HistoryTaskModel.findOne({ taskId: task.taskId }));
       let stream = await binarySyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       let log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('Syncing diff: 2 => 2'));
-      assert(log.includes('[/] 🟢 Synced dir success'));
-      assert(log.includes('[/latest/] 🟢 Synced dir success'));
-      assert(log.includes('[/latest/docs/] 🟢 Synced dir success'));
+      assert.ok(log.includes('Syncing diff: 2 => 2'));
+      assert.ok(log.includes('[/] 🟢 Synced dir success'));
+      assert.ok(log.includes('[/latest/] 🟢 Synced dir success'));
+      assert.ok(log.includes('[/latest/docs/] 🟢 Synced dir success'));
 
       // sync again
       await binarySyncerService.createTask('node', {});
       task = await binarySyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await binarySyncerService.executeTask(task);
       stream = await binarySyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('reason: revalidate latest version'));
-      assert(log.includes('Syncing diff: 2 => 1'));
-      assert(log.includes('[/] 🟢 Synced dir success'));
+      assert.ok(log.includes('reason: revalidate latest version'));
+      assert.ok(log.includes('Syncing diff: 2 => 1'));
+      assert.ok(log.includes('[/] 🟢 Synced dir success'));
 
       // mock version change
       // console.log(binaryRepository.findBinary('node'));
@@ -588,22 +588,22 @@ describe('test/core/service/BinarySyncerService/executeTask.test.ts', () => {
 
       await binarySyncerService.createTask('node', {});
       task = await binarySyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await binarySyncerService.executeTask(task);
       stream = await binarySyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('"name":"apilinks2.json"'));
-      assert(log.includes('Syncing diff: 2 => 1'));
-      assert(log.includes('[/] 🟢 Synced dir success'));
+      assert.ok(log.includes('"name":"apilinks2.json"'));
+      assert.ok(log.includes('Syncing diff: 2 => 1'));
+      assert.ok(log.includes('[/] 🟢 Synced dir success'));
       app.mockAgent().assertNoPendingInterceptors();
       const binaryRepository = await app.getEggObject(BinaryRepository);
       const BinaryItems = await binaryRepository.listBinaries(
         'node',
         '/latest/docs/'
       );
-      assert(BinaryItems.length === 2);
+      assert.ok(BinaryItems.length === 2);
     });
 
     it('should fetch with task data', async () => {
@@ -625,7 +625,7 @@ describe('test/core/service/BinarySyncerService/executeTask.test.ts', () => {
         'mock-data': '2333',
       });
       let task = await binarySyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       let binaryName: string | undefined;
       let lastData: SyncBinaryTaskData | undefined;
       mock(

--- a/test/core/service/BugVersionService/fixPackageBugVersion.test.ts
+++ b/test/core/service/BugVersionService/fixPackageBugVersion.test.ts
@@ -199,7 +199,7 @@ describe('test/core/service/BugVersionService/fixPackageBugVersion.test.ts', () 
       'colors',
       manifest
     );
-    assert(newManifest === manifest);
+    assert.ok(newManifest === manifest);
   });
 
   it('should should not fix if fixed version not exits', async () => {
@@ -229,6 +229,6 @@ describe('test/core/service/BugVersionService/fixPackageBugVersion.test.ts', () 
       'colors',
       manifest
     );
-    assert(newManifest === manifest);
+    assert.ok(newManifest === manifest);
   });
 });

--- a/test/core/service/ChangesStreamService.test.ts
+++ b/test/core/service/ChangesStreamService.test.ts
@@ -28,7 +28,7 @@ describe('test/core/service/ChangesStreamService.test.ts', () => {
     registryManagerService = await app.getEggObject(RegistryManagerService);
     scopeManagerService = await app.getEggObject(ScopeManagerService);
     queueAdapter = await app.getEggObject(RedisQueueAdapter);
-    assert(changesStreamService);
+    assert.ok(changesStreamService);
     task = Task.createChangesStream('GLOBAL_WORKER', '', '9527');
     taskService.createTask(task, false);
 
@@ -63,27 +63,27 @@ describe('test/core/service/ChangesStreamService.test.ts', () => {
 
   describe('prepareRegistry()', () => {
     it('should init since', async () => {
-      assert(task.data.since === '9527');
+      assert.ok(task.data.since === '9527');
     });
     it('should create default registry by config', async () => {
       await changesStreamService.prepareRegistry(task);
       let registries = await registryManagerService.listRegistries({});
-      assert(registries.count === 3);
+      assert.ok(registries.count === 3);
 
       // only create once
       await changesStreamService.prepareRegistry(task);
       registries = await registryManagerService.listRegistries({});
-      assert(registries.count === 3);
+      assert.ok(registries.count === 3);
     });
 
     it('should throw error when invalid registryId', async () => {
       await changesStreamService.prepareRegistry(task);
       const registries = await registryManagerService.listRegistries({});
-      assert(registries.count === 3);
+      assert.ok(registries.count === 3);
 
       // remove the registry
       const registryId = task.data.registryId;
-      assert(registryId);
+      assert.ok(registryId);
       await registryManagerService.remove({ registryId });
 
       await assert.rejects(
@@ -104,12 +104,12 @@ describe('test/core/service/ChangesStreamService.test.ts', () => {
         npmRegistry,
         '@cnpm/test'
       );
-      assert(res);
+      assert.ok(res);
     });
 
     it('unscoped package should sync default registry', async () => {
       const res = await changesStreamService.needSync(npmRegistry, 'banana');
-      assert(res);
+      assert.ok(res);
     });
 
     it('scoped package should sync default registry', async () => {
@@ -117,7 +117,7 @@ describe('test/core/service/ChangesStreamService.test.ts', () => {
         npmRegistry,
         '@gogogo/banana'
       );
-      assert(res);
+      assert.ok(res);
     });
 
     it('scoped package should sync custom registry', async () => {
@@ -125,14 +125,14 @@ describe('test/core/service/ChangesStreamService.test.ts', () => {
         cnpmRegistry,
         '@cnpm/banana'
       );
-      assert(res);
+      assert.ok(res);
       res = await changesStreamService.needSync(cnpmRegistry, '@dnpmjs/banana');
-      assert(!res);
+      assert.ok(!res);
     });
 
     it('unscoped package should not sync custom registry', async () => {
       const res = await changesStreamService.needSync(cnpmRegistry, 'banana');
-      assert(!res);
+      assert.ok(!res);
     });
 
     it('the package does not exist should not sync with any registry', async () => {
@@ -143,9 +143,9 @@ describe('test/core/service/ChangesStreamService.test.ts', () => {
         registryId: npmRegistry.registryId,
       });
       let res = await changesStreamService.needSync(npmRegistry, 'banana');
-      assert(!res);
+      assert.ok(!res);
       res = await changesStreamService.needSync(npmRegistry, '@cnpm/test');
-      assert(res);
+      assert.ok(res);
     });
   });
 
@@ -158,7 +158,7 @@ describe('test/core/service/ChangesStreamService.test.ts', () => {
         },
       });
       const since = await changesStreamService.getInitialSince(task);
-      assert(since === '9517');
+      assert.ok(since === '9517');
     });
   });
 
@@ -171,7 +171,7 @@ describe('test/core/service/ChangesStreamService.test.ts', () => {
         },
       });
       const since = await changesStreamService.getInitialSince(task);
-      assert(since === '9517');
+      assert.ok(since === '9517');
     });
   });
 
@@ -245,19 +245,19 @@ describe('test/core/service/ChangesStreamService.test.ts', () => {
     });
     it('should work', async () => {
       const task = await changesStreamService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await changesStreamService.executeTask(task);
-      assert(task.state === 'processing');
+      assert.ok(task.state === 'processing');
 
       let len = await queueAdapter.length('changes_stream');
-      assert(len === 0);
+      assert.ok(len === 0);
       await changesStreamService.suspendSync(true);
       const newTask = await taskService.findTask(task.taskId);
-      assert(newTask);
-      assert(newTask.taskId === task.taskId);
-      assert(newTask.state === 'waiting');
+      assert.ok(newTask);
+      assert.ok(newTask.taskId === task.taskId);
+      assert.ok(newTask.state === 'waiting');
       len = await queueAdapter.length('changes_stream');
-      assert(len === 1);
+      assert.ok(len === 1);
 
       app.expectLog('[ChangesStreamService.suspendSync:suspend] taskId');
     });
@@ -266,19 +266,19 @@ describe('test/core/service/ChangesStreamService.test.ts', () => {
       mock(app.config.cnpmcore, 'enableChangesStream', true);
 
       const task = await changesStreamService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       mock(changesStreamService, 'executeSync', async () => {
         throw new Error('mock error');
       });
       await changesStreamService.executeTask(task);
 
       const newTask = await taskService.findTask(task.taskId);
-      assert(newTask);
-      assert(newTask.state === 'waiting');
+      assert.ok(newTask);
+      assert.ok(newTask.state === 'waiting');
       // still sync nexttick;
-      assert(app.config.cnpmcore.enableChangesStream === true);
+      assert.ok(app.config.cnpmcore.enableChangesStream === true);
       const len = await queueAdapter.length('changes_stream');
-      assert(len === 1);
+      assert.ok(len === 1);
       app.expectLog('[ChangesStreamService.suspendSync:start]');
       app.expectLog('[ChangesStreamService.suspendSync:suspend] taskId');
     });

--- a/test/core/service/ChangesStreamService.test.ts
+++ b/test/core/service/ChangesStreamService.test.ts
@@ -232,7 +232,7 @@ describe('test/core/service/ChangesStreamService.test.ts', () => {
       app.mockLog();
       mock(app.config.cnpmcore, 'enableChangesStream', true);
       app.mockHttpclient(
-        'https://replicate.npmjs.com/_changes?since=9527',
+        'https://replicate.npmjs.com/registry/_changes?since=9527',
         'GET',
         () => {
           return {

--- a/test/core/service/CreateHookTriggerService.test.ts
+++ b/test/core/service/CreateHookTriggerService.test.ts
@@ -38,7 +38,7 @@ describe('test/core/service/CreateHookTriggerService.test.ts', () => {
       }
     );
     const user = await userRepository.findUserByName(username);
-    assert(user);
+    assert.ok(user);
     userId = user.userId;
   });
 
@@ -75,7 +75,7 @@ describe('test/core/service/CreateHookTriggerService.test.ts', () => {
         const pushTask = await taskRepository.findTaskByBizId(
           `TriggerHook:${change.changeId}:${hook.hookId}`
         );
-        assert(pushTask);
+        assert.ok(pushTask);
       });
     });
 
@@ -99,7 +99,7 @@ describe('test/core/service/CreateHookTriggerService.test.ts', () => {
         const pushTask = await taskRepository.findTaskByBizId(
           `TriggerHook:${change.changeId}:${hook.hookId}`
         );
-        assert(pushTask);
+        assert.ok(pushTask);
       });
     });
 
@@ -123,7 +123,7 @@ describe('test/core/service/CreateHookTriggerService.test.ts', () => {
         const pushTask = await taskRepository.findTaskByBizId(
           `TriggerHook:${change.changeId}:${hook.hookId}`
         );
-        assert(pushTask);
+        assert.ok(pushTask);
       });
     });
   });

--- a/test/core/service/HookManageService/createHook.test.ts
+++ b/test/core/service/HookManageService/createHook.test.ts
@@ -43,7 +43,7 @@ describe('test/core/service/HookManageService/createHook.test.ts', () => {
       endpoint: 'http://foo.com',
       secret: 'mock_secret',
     });
-    assert(hook);
-    assert(hook.enable === true);
+    assert.ok(hook);
+    assert.ok(hook.enable === true);
   });
 });

--- a/test/core/service/HookManageService/deleteHook.test.ts
+++ b/test/core/service/HookManageService/deleteHook.test.ts
@@ -56,6 +56,6 @@ describe('test/core/service/HookManageService/deleteHook.test.ts', () => {
       hookId: hook.hookId,
       operatorId: 'mock_owner_id',
     });
-    assert(deleteHook);
+    assert.ok(deleteHook);
   });
 });

--- a/test/core/service/HookManageService/getHookByOwnerId.test.ts
+++ b/test/core/service/HookManageService/getHookByOwnerId.test.ts
@@ -56,6 +56,6 @@ describe('test/core/service/HookManageService/getHookByOwnerId.test.ts', () => {
       hook.hookId,
       'mock_owner_id'
     );
-    assert(getHook);
+    assert.ok(getHook);
   });
 });

--- a/test/core/service/HookManageService/updateHook.test.ts
+++ b/test/core/service/HookManageService/updateHook.test.ts
@@ -62,8 +62,8 @@ describe('test/core/service/HookManageService/updateHook.test.ts', () => {
       endpoint: 'http://new.com',
       secret: 'new_mock_secret',
     });
-    assert(updatedHook);
-    assert(updatedHook.endpoint === 'http://new.com');
-    assert(updatedHook.secret === 'new_mock_secret');
+    assert.ok(updatedHook);
+    assert.ok(updatedHook.endpoint === 'http://new.com');
+    assert.ok(updatedHook.secret === 'new_mock_secret');
   });
 });

--- a/test/core/service/HookTriggerService.test.ts
+++ b/test/core/service/HookTriggerService.test.ts
@@ -45,7 +45,7 @@ describe('test/core/service/HookTriggerService.test.ts', () => {
       }
     );
     const user = await userRepository.findUserByName(username);
-    assert(user);
+    assert.ok(user);
     userId = user.userId;
   });
 
@@ -123,25 +123,25 @@ describe('test/core/service/HookTriggerService.test.ts', () => {
         `TriggerHook:${versionChange.changeId}:${hook.hookId}`
       )) as TriggerHookTask;
       await hookTriggerService.executeTask(pushTask);
-      assert(callEndpoint === hook.endpoint);
-      assert(callOptions);
-      assert(callOptions.method === 'POST');
-      assert(callOptions.headers);
-      assert(callOptions.headers['x-npm-signature']);
+      assert.ok(callEndpoint === hook.endpoint);
+      assert.ok(callOptions);
+      assert.ok(callOptions.method === 'POST');
+      assert.ok(callOptions.headers);
+      assert.ok(callOptions.headers['x-npm-signature']);
       const data = JSON.parse(callOptions.data);
-      assert(data.event === 'package:publish');
-      assert(data.name === pkgName);
-      assert(data.type === 'package');
-      assert(data.version === '1.0.0');
+      assert.ok(data.event === 'package:publish');
+      assert.ok(data.name === pkgName);
+      assert.ok(data.type === 'package');
+      assert.ok(data.version === '1.0.0');
       assert.deepStrictEqual(data.hookOwner, {
         username,
       });
-      assert(data.payload);
+      assert.ok(data.payload);
       assert.deepStrictEqual(data.change, {
         version: '1.0.0',
         'dist-tag': 'latest',
       });
-      assert(data.time === pushTask.data.hookEvent.time);
+      assert.ok(data.time === pushTask.data.hookEvent.time);
     });
 
     it('should create each event', async () => {

--- a/test/core/service/PackageManagerService/block.test.ts
+++ b/test/core/service/PackageManagerService/block.test.ts
@@ -24,7 +24,7 @@ describe('test/core/service/PackageManagerService/block.test.ts', () => {
         pkg.name,
         'xxx'
       );
-      assert(blockRes.packageVersionBlockId);
+      assert.ok(blockRes.packageVersionBlockId);
 
       assert.doesNotReject(
         packageManagerService.unblockPackageByFullname(pkg.name || '')

--- a/test/core/service/PackageManagerService/publish.test.ts
+++ b/test/core/service/PackageManagerService/publish.test.ts
@@ -55,7 +55,7 @@ describe('test/core/service/PackageManagerService/publish.test.ts', () => {
         packageId,
         '1.0.0'
       );
-      assert(pkgVersion);
+      assert.ok(pkgVersion);
       assert.equal(pkgVersion.version, '1.0.0');
       // another version
       await packageManagerService.publish(
@@ -78,7 +78,7 @@ describe('test/core/service/PackageManagerService/publish.test.ts', () => {
         packageId,
         '1.0.1'
       );
-      assert(pkgVersion);
+      assert.ok(pkgVersion);
       assert.equal(pkgVersion.version, '1.0.1');
       // expect aop async timer
       // 2022-06-03 13:55:39,152 INFO 79813 [-/127.0.0.1/cb81b2f0-e301-11ec-94f3-bf6547f48233/112.523ms GET /] [0.311] [NFSAdapter:uploadBytes|T]
@@ -107,7 +107,7 @@ describe('test/core/service/PackageManagerService/publish.test.ts', () => {
         packageId,
         '1.0.0'
       );
-      assert(pkgVersion);
+      assert.ok(pkgVersion);
       assert.equal(pkgVersion.version, '1.0.0');
       const pkg = await packageRepository.findPackage('', 'foo');
       assert.equal(pkg?.description, '~'.repeat(1024 * 10));
@@ -136,7 +136,7 @@ describe('test/core/service/PackageManagerService/publish.test.ts', () => {
         packageId,
         '1.1.0'
       );
-      assert(pkgVersion);
+      assert.ok(pkgVersion);
       assert.equal(pkgVersion.version, '1.1.0');
       assert.equal(pkgVersion.tarDist.size, 2672);
     });
@@ -172,7 +172,7 @@ describe('test/core/service/PackageManagerService/publish.test.ts', () => {
         );
       }, /deps invalid-pkg@some-semver-not-exits not found/);
 
-      assert(checked);
+      assert.ok(checked);
     });
   });
 });

--- a/test/core/service/PackageSyncerService/createTask.test.ts
+++ b/test/core/service/PackageSyncerService/createTask.test.ts
@@ -56,7 +56,7 @@ describe('test/core/service/PackageSyncerService/createTask.test.ts', () => {
     const task = await packageSyncerService.createTask('binary-mirror-config', {
       registryId: 'sync_registry_id',
     });
-    assert(task);
+    assert.ok(task);
   });
 
   it('should work when pkg not exists', async () => {
@@ -66,7 +66,7 @@ describe('test/core/service/PackageSyncerService/createTask.test.ts', () => {
         registryId: 'sync_registry_id',
       }
     );
-    assert(task);
+    assert.ok(task);
   });
 
   it('should merge task when processing', async () => {
@@ -84,7 +84,7 @@ describe('test/core/service/PackageSyncerService/createTask.test.ts', () => {
         return await packageSyncerService.createTask(pkgName);
       })(),
     ]);
-    assert(res[1].taskId === task.taskId);
+    assert.ok(res[1].taskId === task.taskId);
   });
 
   it('should append specific version to waiting task.', async () => {
@@ -96,10 +96,10 @@ describe('test/core/service/PackageSyncerService/createTask.test.ts', () => {
       specificVersions: ['2.0.0'],
     });
     const task = await packageSyncerService.findExecuteTask();
-    assert(task);
+    assert.ok(task);
     assert.equal(task.targetName, name);
-    assert(task.data.specificVersions);
-    assert(task.data.specificVersions.length === 2);
+    assert.ok(task.data.specificVersions);
+    assert.ok(task.data.specificVersions.length === 2);
   });
 
   it('should remove specific version, switch waiting task to sync all versions.', async () => {
@@ -109,14 +109,14 @@ describe('test/core/service/PackageSyncerService/createTask.test.ts', () => {
     });
     await packageSyncerService.createTask(name);
     const task = await packageSyncerService.findExecuteTask();
-    assert(task);
+    assert.ok(task);
     assert.equal(task.targetName, name);
-    assert(task.data.specificVersions === undefined);
+    assert.ok(task.data.specificVersions === undefined);
   });
 
   it('should not duplicate task when waiting', async () => {
     const task = await packageSyncerService.createTask(pkgName);
     const newTask = await packageSyncerService.createTask(pkgName);
-    assert(newTask.taskId === task.taskId);
+    assert.ok(newTask.taskId === task.taskId);
   });
 });

--- a/test/core/service/PackageSyncerService/executeTask.test.ts
+++ b/test/core/service/PackageSyncerService/executeTask.test.ts
@@ -76,23 +76,23 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         skipDependencies: true,
       });
       let task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
-      assert(!(await TaskModel.findOne({ taskId: task.taskId })));
-      assert(await HistoryTaskModel.findOne({ taskId: task.taskId }));
+      assert.ok(!(await TaskModel.findOne({ taskId: task.taskId })));
+      assert.ok(await HistoryTaskModel.findOne({ taskId: task.taskId }));
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
       const model = await PackageModel.findOne({ scope: '', name: 'foobar' });
-      assert(model);
+      assert.ok(model);
       assert.equal(model.isPrivate, false);
-      assert(log.includes(', skipDependencies: true'));
+      assert.ok(log.includes(', skipDependencies: true'));
 
       // sync again
       await packageSyncerService.createTask('foobar');
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       const manifests = await packageManagerService.listPackageFullManifests(
         '',
@@ -100,15 +100,15 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       );
       // console.log(JSON.stringify(manifests, null, 2));
       // should have 2 maintainers
-      assert(manifests.data?.maintainers);
-      assert(manifests.data.maintainers.length > 0);
+      assert.ok(manifests.data?.maintainers);
+      assert.ok(manifests.data.maintainers.length > 0);
       const abbreviatedManifests =
         await packageManagerService.listPackageAbbreviatedManifests(
           '',
           'foobar'
         );
       // console.log(JSON.stringify(abbreviatedManifests, null, 2));
-      assert(abbreviatedManifests.data);
+      assert.ok(abbreviatedManifests.data);
       assert.equal(abbreviatedManifests.data.name, manifests.data.name);
       app.mockAgent().assertNoPendingInterceptors();
     });
@@ -145,7 +145,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         skipDependencies: true,
       });
       let task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
 
       await packageSyncerService.createTask('foobar', {
@@ -153,14 +153,14 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         skipDependencies: true,
       });
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       const stream2 = await packageSyncerService.findTaskLog(task);
-      assert(stream2);
+      assert.ok(stream2);
       const log2 = await TestUtil.readStreamToLog(stream2);
       // console.log(log2);
-      assert(/Remove version 1\.0\.0 for force sync history/.test(log2));
-      assert(/Syncing version 1\.0\.0/.test(log2));
+      assert.ok(/Remove version 1\.0\.0 for force sync history/.test(log2));
+      assert.ok(/Syncing version 1\.0\.0/.test(log2));
       app.mockAgent().assertNoPendingInterceptors();
     });
 
@@ -199,20 +199,20 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         skipDependencies: false,
       });
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, 'foobar');
       await packageSyncerService.executeTask(task);
-      assert(!(await TaskModel.findOne({ taskId: task.taskId })));
-      assert(await HistoryTaskModel.findOne({ taskId: task.taskId }));
+      assert.ok(!(await TaskModel.findOne({ taskId: task.taskId })));
+      assert.ok(await HistoryTaskModel.findOne({ taskId: task.taskId }));
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
       const model = await PackageModel.findOne({ scope: '', name: 'foobar' });
-      assert(model);
+      assert.ok(model);
       assert.equal(model.isPrivate, false);
-      assert(log.includes(', taskQueue: 3/2'));
-      assert(log.includes(', skipDependencies: true'));
+      assert.ok(log.includes(', taskQueue: 3/2'));
+      assert.ok(log.includes(', skipDependencies: true'));
       app.mockAgent().assertNoPendingInterceptors();
     });
 
@@ -237,10 +237,10 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       );
       await packageSyncerService.createTask('@node-rs/xxhash');
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
-      assert(!(await TaskModel.findOne({ taskId: task.taskId })));
-      assert(await HistoryTaskModel.findOne({ taskId: task.taskId }));
+      assert.ok(!(await TaskModel.findOne({ taskId: task.taskId })));
+      assert.ok(await HistoryTaskModel.findOne({ taskId: task.taskId }));
 
       const manifests = await packageManagerService.listPackageFullManifests(
         '@node-rs',
@@ -254,11 +254,13 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
           'xxhash'
         );
       // console.log(JSON.stringify(abbreviatedManifests, null, 2));
-      assert(abbreviatedManifests.data);
-      assert(manifests.data);
+      assert.ok(abbreviatedManifests.data);
+      assert.ok(manifests.data);
       assert.equal(abbreviatedManifests.data.name, manifests.data.name);
-      assert(abbreviatedManifests.data.versions['1.0.0']);
-      assert(abbreviatedManifests.data.versions['1.0.0'].optionalDependencies);
+      assert.ok(abbreviatedManifests.data.versions['1.0.0']);
+      assert.ok(
+        abbreviatedManifests.data.versions['1.0.0'].optionalDependencies
+      );
       app.mockAgent().assertNoPendingInterceptors();
     });
 
@@ -286,14 +288,14 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       let task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       let manifests = await packageManagerService.listPackageFullManifests(
         '',
         name
       );
-      assert(manifests.data);
-      assert(manifests.data.versions['0.0.0']);
+      assert.ok(manifests.data);
+      assert.ok(manifests.data.versions['0.0.0']);
 
       assert.equal(
         manifests.data.versions['0.0.0'].deprecated,
@@ -302,8 +304,8 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       assert.equal(manifests.data.versions['0.0.0']._hasShrinkwrap, false);
       let abbreviatedManifests =
         await packageManagerService.listPackageAbbreviatedManifests('', name);
-      assert(abbreviatedManifests.data);
-      assert(abbreviatedManifests.data.versions['0.0.0']);
+      assert.ok(abbreviatedManifests.data);
+      assert.ok(abbreviatedManifests.data.versions['0.0.0']);
       assert.equal(
         abbreviatedManifests.data.versions['0.0.0'].deprecated,
         'only test for cnpmcore'
@@ -326,13 +328,13 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       );
       await packageSyncerService.createTask(name);
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       let stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       let log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes(`] 🟢 Package "${name}" was removed in remote registry`)
       );
 
@@ -340,12 +342,12 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         '',
         name
       );
-      assert(manifests.data);
-      assert(manifests.data.time.unpublished);
+      assert.ok(manifests.data);
+      assert.ok(manifests.data.time.unpublished);
       abbreviatedManifests =
         await packageManagerService.listPackageAbbreviatedManifests('', name);
-      assert(abbreviatedManifests.data);
-      assert(abbreviatedManifests.data.time?.unpublished);
+      assert.ok(abbreviatedManifests.data);
+      assert.ok(abbreviatedManifests.data.time?.unpublished);
       app.mockAgent().assertNoPendingInterceptors();
 
       // sync again
@@ -371,19 +373,19 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       );
       await packageSyncerService.createTask(name);
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
       manifests = await packageManagerService.listPackageFullManifests(
         '',
         name
       );
-      assert(manifests.data);
-      assert(!manifests.data.time.unpublished);
-      assert(manifests.data.versions['0.0.0']);
+      assert.ok(manifests.data);
+      assert.ok(!manifests.data.time.unpublished);
+      assert.ok(manifests.data.versions['0.0.0']);
       assert.equal(
         manifests.data.versions['0.0.0'].deprecated,
         'only test for cnpmcore'
@@ -391,9 +393,9 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       assert.equal(manifests.data.versions['0.0.0']._hasShrinkwrap, false);
       abbreviatedManifests =
         await packageManagerService.listPackageAbbreviatedManifests('', name);
-      assert(abbreviatedManifests.data);
-      assert(!abbreviatedManifests.data.time?.unpublished);
-      assert(abbreviatedManifests.data.versions['0.0.0']);
+      assert.ok(abbreviatedManifests.data);
+      assert.ok(!abbreviatedManifests.data.time?.unpublished);
+      assert.ok(abbreviatedManifests.data.versions['0.0.0']);
       assert.equal(
         abbreviatedManifests.data.versions['0.0.0'].deprecated,
         'only test for cnpmcore'
@@ -429,14 +431,14 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       let task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       const manifests = await packageManagerService.listPackageFullManifests(
         '',
         name
       );
-      assert(manifests.data);
-      assert(manifests.data.versions['0.0.0']);
+      assert.ok(manifests.data);
+      assert.ok(manifests.data.versions['0.0.0']);
 
       assert.equal(
         manifests.data.versions['0.0.0'].deprecated,
@@ -445,7 +447,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       assert.equal(manifests.data.versions['0.0.0']._hasShrinkwrap, false);
       const abbreviatedManifests =
         await packageManagerService.listPackageAbbreviatedManifests('', name);
-      assert(abbreviatedManifests.data?.versions['0.0.0']);
+      assert.ok(abbreviatedManifests.data?.versions['0.0.0']);
       assert.equal(
         abbreviatedManifests.data.versions['0.0.0'].deprecated,
         'only test for cnpmcore'
@@ -468,16 +470,16 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       );
       await packageSyncerService.createTask(name);
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         !log.includes(`] 🟢 Package "${name}" was removed in remote registry`)
       );
-      assert(log.includes('Package not found, status 404'));
+      assert.ok(log.includes('Package not found, status 404'));
       app.mockAgent().assertNoPendingInterceptors();
     });
 
@@ -494,13 +496,13 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-package-not-exists';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('Package not found, status 404'));
+      assert.ok(log.includes('Package not found, status 404'));
       app.mockAgent().assertNoPendingInterceptors();
     });
 
@@ -535,13 +537,13 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('] 🔗'));
+      assert.ok(log.includes('] 🔗'));
       app.mockAgent().assertNoPendingInterceptors();
     });
 
@@ -576,13 +578,13 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('] 🔗'));
+      assert.ok(log.includes('] 🔗'));
       app.mockAgent().assertNoPendingInterceptors();
     });
 
@@ -610,14 +612,14 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       let name = 'cnpmcore-test-sync-dependencies';
       await packageSyncerService.createTask(name);
       let task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       let stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       let log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes(
           '] 📦 Add dependency "cnpmcore-test-sync-deprecated" sync task: '
         )
@@ -647,14 +649,14 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes(
           'Sync cause by "cnpmcore-test-sync-dependencies" dependencies, parent task: '
         )
@@ -688,19 +690,19 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       );
       name = 'cnpmcore-test-sync-dependencies';
       const task = await packageSyncerService.createTask(name);
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         !log.includes(
           '] 📦 Add dependency "cnpmcore-test-sync-deprecated" sync task: '
         )
       );
-      assert(
+      assert.ok(
         log.includes(
           '] 📖 Has dependency "cnpmcore-test-sync-deprecated" sync task: '
         )
@@ -731,10 +733,10 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       await packageSyncerService.executeTask(task);
       app.mockAgent().assertNoPendingInterceptors();
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes(
           '] 📦 Add dependency "@resvg/resvg-js-win32-x64-msvc" sync task: '
         )
@@ -799,7 +801,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         skipDependencies: true,
       });
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       assert.equal(fullManifestsHeader?.authorization, `Bearer ${testToken}`);
       assert.equal(tgzBuffer1_0_0Header?.authorization, `Bearer ${testToken}`);
@@ -830,19 +832,19 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-deprecated';
       mock.error(packageManagerService.constructor.prototype, 'publish');
       const task = await packageSyncerService.createTask(name);
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes(
           '❌ [1] Synced version 0.0.0 error, publish error: MockError: mm mock error'
         )
       );
-      assert(log.includes('❌ All versions sync fail, package not exists'));
+      assert.ok(log.includes('❌ All versions sync fail, package not exists'));
 
       const res = await app
         .httpRequest()
@@ -879,13 +881,13 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       err.name = 'ForbiddenError';
       mock.error(packageManagerService.constructor.prototype, 'publish', err);
       const task = await packageSyncerService.createTask(name);
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
-      assert(
+      assert.ok(
         log.includes(
           '🐛 [1] Synced version 0.0.0 already exists, skip publish, try to set in local manifest'
         )
@@ -916,20 +918,20 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       );
       const name = 'cnpmcore-test-sync-deprecated';
       const task = await packageSyncerService.createTask(name);
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       app.mockAgent().assertNoPendingInterceptors();
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes(
           '❌ [1] Synced version 0.0.0 fail, download tarball error: DownloadStatusInvalidError: Download https://registry.npmjs.org/cnpmcore-test-sync-deprecated/-/cnpmcore-test-sync-deprecated-0.0.0.tgz status(500) invalid'
         )
       );
-      assert(log.includes('❌ All versions sync fail, package not exists'));
+      assert.ok(log.includes('❌ All versions sync fail, package not exists'));
     });
 
     describe('sync version idempotence', async () => {
@@ -970,17 +972,17 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         const name = '@cnpmcore/test-sync-package-has-two-versions';
         await packageSyncerService.createTask(name);
         let task = await packageSyncerService.findExecuteTask();
-        assert(task);
+        assert.ok(task);
         assert.equal(task.targetName, name);
         await packageSyncerService.executeTask(task);
         let stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         let log = await TestUtil.readStreamToLog(stream);
         // console.log(log);
-        assert(
+        assert.ok(
           log.includes('] 🟢 Synced updated 2 versions, removed 0 versions')
         );
-        assert(log.includes('] 🚧 Syncing versions 0 => 2'));
+        assert.ok(log.includes('] 🚧 Syncing versions 0 => 2'));
 
         // mock listPackageFullManifests return only one version
         // 如果 version publish 同步中断了，没有刷新 manifests，会导致下一次同步重新 version publish，然后报错
@@ -990,7 +992,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
           scopedAndName[0],
           scopedAndName[1]
         );
-        assert(manifests.data);
+        assert.ok(manifests.data);
         delete manifests.data.versions['1.0.0'];
         mock.data(
           PackageManagerService.prototype,
@@ -1000,20 +1002,20 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
 
         await packageSyncerService.createTask(name);
         task = await packageSyncerService.findExecuteTask();
-        assert(task);
+        assert.ok(task);
         assert.equal(task.targetName, name);
         await packageSyncerService.executeTask(task);
         stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         log = await TestUtil.readStreamToLog(stream);
         // console.log(log);
-        assert(
+        assert.ok(
           log.includes(
             'Synced version 1.0.0 already exists, skip publish, try to set in local manifest'
           )
         );
-        assert(log.includes('] 🟢 Synced updated'));
-        assert(log.includes('] 🚧 Syncing versions 1 => 2'));
+        assert.ok(log.includes('] 🟢 Synced updated'));
+        assert.ok(log.includes('] 🚧 Syncing versions 1 => 2'));
         app.mockAgent().assertNoPendingInterceptors();
         await mock.restore();
 
@@ -1030,7 +1032,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
             scopedAndName[0],
             scopedAndName[1]
           );
-        assert(abbrs.data);
+        assert.ok(abbrs.data);
         delete abbrs.data.versions['1.0.0'];
         mock.data(
           PackageManagerService.prototype,
@@ -1040,20 +1042,20 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
 
         await packageSyncerService.createTask(name);
         task = await packageSyncerService.findExecuteTask();
-        assert(task);
+        assert.ok(task);
         assert.equal(task.targetName, name);
         await packageSyncerService.executeTask(task);
         stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         log = await TestUtil.readStreamToLog(stream);
         // console.log(log);
-        assert(
+        assert.ok(
           log.includes(
             '] 🐛 Remote version 1.0.0 not exists on local abbreviated manifests, need to refresh'
           )
         );
-        assert(log.includes('] 🟢 Synced updated'));
-        assert(log.includes('] 🚧 Syncing versions 2 => 2'));
+        assert.ok(log.includes('] 🟢 Synced updated'));
+        assert.ok(log.includes('] 🚧 Syncing versions 2 => 2'));
         app.mockAgent().assertNoPendingInterceptors();
         await mock.restore();
 
@@ -1074,20 +1076,20 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         mock.data(PackageManagerService.prototype, 'savePackageTag', null);
         await packageSyncerService.createTask(name);
         task = await packageSyncerService.findExecuteTask();
-        assert(task);
+        assert.ok(task);
         await packageSyncerService.executeTask(task);
         stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         log = await TestUtil.readStreamToLog(stream);
         // console.log(log);
-        assert(
+        assert.ok(
           log.includes(
             '] 🚧 Remote tag(foo: 2.0.0) not exists in local dist-tags'
           )
         );
-        assert(!log.includes('] 🚧 Refreshing manifests to dists ......'));
-        assert(log.includes('] 🚧 Syncing versions 2 => 2'));
-        assert(
+        assert.ok(!log.includes('] 🚧 Refreshing manifests to dists ......'));
+        assert.ok(log.includes('] 🚧 Syncing versions 2 => 2'));
+        assert.ok(
           log.includes(
             `] 📖 @cnpmcore/test-sync-package-has-two-versions latest version: ${latestVersion}, published time: ${JSON.stringify(result.data.time[latestVersion])}`
           )
@@ -1100,7 +1102,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         const name = '@cnpmcore/test-sync-package-has-two-versions';
         await packageSyncerService.createTask(name);
         const task = await packageSyncerService.findExecuteTask();
-        assert(task);
+        assert.ok(task);
         assert.equal(task.targetName, name);
 
         const { user } = await userService.create({
@@ -1129,7 +1131,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
           publishCmd,
           user
         );
-        assert(pkgVersion.version === '1.0.0');
+        assert.ok(pkgVersion.version === '1.0.0');
 
         const publishCmd2 = {
           scope: '@cnpmcore',
@@ -1150,28 +1152,28 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
           publishCmd2,
           user
         );
-        assert(pkgVersion2.version === '2.0.0');
+        assert.ok(pkgVersion2.version === '2.0.0');
 
         await packageSyncerService.executeTask(task);
 
         const stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         const log = await TestUtil.readStreamToLog(stream);
         // console.log(log);
-        assert(
+        assert.ok(
           log.includes(
             'Synced version 2.0.0 already exists, skip publish, try to set in local manifest'
           )
         );
-        assert(log.includes('] 🚧 Syncing versions 1 => 2'));
+        assert.ok(log.includes('] 🚧 Syncing versions 1 => 2'));
 
         const fullManifests =
           await packageManagerService.listPackageFullManifests(
             '@cnpmcore',
             'test-sync-package-has-two-versions'
           );
-        assert(fullManifests.data);
-        assert(fullManifests.data.versions['2.0.0']);
+        assert.ok(fullManifests.data);
+        assert.ok(fullManifests.data.versions['2.0.0']);
       });
 
       it('should skip self registry', async () => {
@@ -1204,18 +1206,18 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
           publishCmd,
           user
         );
-        assert(pkgVersion.version === '1.0.0');
+        assert.ok(pkgVersion.version === '1.0.0');
 
         await packageSyncerService.createTask(name);
         const task = await packageSyncerService.findExecuteTask();
-        assert(task);
+        assert.ok(task);
         await packageSyncerService.executeTask(task);
 
         const stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         const log = await TestUtil.readStreamToLog(stream);
         // console.log(log);
-        assert(
+        assert.ok(
           log.includes(
             `${name} has been published to the self registry, skip sync ❌❌❌❌❌`
           )
@@ -1227,7 +1229,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         const name = '@cnpmcore/test-sync-package-has-two-versions';
         await packageSyncerService.createTask(name);
         const task = await packageSyncerService.findExecuteTask();
-        assert(task);
+        assert.ok(task);
         assert.equal(task.targetName, name);
 
         const { user } = await userService.create({
@@ -1256,7 +1258,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
           publishCmd,
           user
         );
-        assert(pkgVersion.version === '1.0.0');
+        assert.ok(pkgVersion.version === '1.0.0');
 
         const publishCmd2 = {
           scope: '@cnpmcore',
@@ -1277,7 +1279,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
           publishCmd2,
           user
         );
-        assert(pkgVersion2.version === '2.0.0');
+        assert.ok(pkgVersion2.version === '2.0.0');
 
         // 模拟查询未发现版本重复，写入时异常
         mock(packageRepository, 'findPackageVersion', async () => {
@@ -1286,15 +1288,15 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         await packageSyncerService.executeTask(task);
 
         const stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         const log = await TestUtil.readStreamToLog(stream);
         // console.log(log);
-        assert(
+        assert.ok(
           log.includes(
             'Synced version 2.0.0 already exists, skip publish, try to set in local manifest'
           )
         );
-        assert(log.includes('] 🚧 Syncing versions 1 => 2'));
+        assert.ok(log.includes('] 🚧 Syncing versions 1 => 2'));
       });
 
       it('should skip version when insert error', async () => {
@@ -1302,7 +1304,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         const name = '@cnpmcore/test-sync-package-has-two-versions';
         await packageSyncerService.createTask(name);
         const task = await packageSyncerService.findExecuteTask();
-        assert(task);
+        assert.ok(task);
         assert.equal(task.targetName, name);
         const { user } = await userService.create({
           name: 'test-user',
@@ -1330,7 +1332,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
           publishCmd,
           user
         );
-        assert(pkgVersion.version === '1.0.0');
+        assert.ok(pkgVersion.version === '1.0.0');
 
         // 模拟查询未发现版本重复，写入时异常
         mock(packageRepository, 'findPackageVersion', async () => {
@@ -1343,9 +1345,11 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         await packageSyncerService.executeTask(task);
 
         const stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         const log = await TestUtil.readStreamToLog(stream);
-        assert(log.includes(' Synced updated 0 versions, removed 0 versions'));
+        assert.ok(
+          log.includes(' Synced updated 0 versions, removed 0 versions')
+        );
       });
 
       it('event cork should work', async () => {
@@ -1353,12 +1357,12 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         const name = '@cnpmcore/test-sync-package-has-two-versions';
         await packageSyncerService.createTask(name);
         const task = await packageSyncerService.findExecuteTask();
-        assert(task);
+        assert.ok(task);
         assert.equal(task.targetName, name);
 
         await packageSyncerService.executeTask(task);
         const stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
 
         const finishedTask = (await taskService.findTask(
           task.taskId
@@ -1370,7 +1374,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         const taskFinishedDate = new Date(finishedTask.updatedAt);
 
         // 任务结束后一起触发
-        assert(firstChangeDate.getTime() - taskFinishedDate.getTime() > 0);
+        assert.ok(firstChangeDate.getTime() - taskFinishedDate.getTime() > 0);
       });
 
       it('should bulk update maintainer dist', async () => {
@@ -1378,7 +1382,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         const name = '@cnpmcore/test-sync-package-has-two-versions';
         await packageSyncerService.createTask(name);
         const task = await packageSyncerService.findExecuteTask();
-        assert(task);
+        assert.ok(task);
         assert.equal(task.targetName, name);
         let called = 0;
 
@@ -1391,7 +1395,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         );
         await packageSyncerService.executeTask(task);
         const stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
 
         const finishedTask = (await taskService.findTask(
           task.taskId
@@ -1407,40 +1411,44 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = '@cnpmcore/test-sync-package-has-two-versions';
       await packageSyncerService.createTask(name);
       let task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       let stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       let log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes('] 🟢 Synced updated 2 versions, removed 0 versions')
       );
-      assert(log.includes('] 🚧 Syncing versions 0 => 2'));
+      assert.ok(log.includes('] 🚧 Syncing versions 0 => 2'));
 
       const pkg = await packageRepository.findPackage(
         '@cnpmcore',
         'test-sync-package-has-two-versions'
       );
-      assert(pkg);
+      assert.ok(pkg);
       await packageRepository.removePackageVersions(pkg.packageId);
 
       await packageSyncerService.createTask(name);
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         !log.includes('] 🟢 Synced updated 0 versions, removed 0 versions')
       );
-      assert(log.includes('] 🐛 Remote version 1.0.0 not exists on database'));
-      assert(log.includes('] 🐛 Remote version 2.0.0 not exists on database'));
-      assert(log.includes('] 🚧 Syncing versions 2 => 2'));
+      assert.ok(
+        log.includes('] 🐛 Remote version 1.0.0 not exists on database')
+      );
+      assert.ok(
+        log.includes('] 🐛 Remote version 2.0.0 not exists on database')
+      );
+      assert.ok(log.includes('] 🚧 Syncing versions 2 => 2'));
     });
 
     it('should sync removed versions', async () => {
@@ -1475,14 +1483,14 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = '@cnpmcore/test-sync-package-has-two-versions';
       await packageSyncerService.createTask(name);
       let task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       let stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       let log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('] 🟢 Synced updated 2 versions'));
+      assert.ok(log.includes('] 🟢 Synced updated 2 versions'));
       app.mockAgent().assertNoPendingInterceptors();
 
       app.mockHttpclient(
@@ -1496,22 +1504,22 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       );
       await packageSyncerService.createTask(name);
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('removed 1 versions'));
-      assert(log.includes('] 🟢 Removed version 1.0.0 success'));
+      assert.ok(log.includes('removed 1 versions'));
+      assert.ok(log.includes('] 🟢 Removed version 1.0.0 success'));
       const r = await packageManagerService.listPackageFullManifests(
         '@cnpmcore',
         'test-sync-package-has-two-versions'
       );
-      assert(r.data);
+      assert.ok(r.data);
       assert.equal(Object.keys(r.data.versions).length, 1);
-      assert(!r.data.versions['1.0.0'], '1.0.0 should not exists');
+      assert.ok(!r.data.versions['1.0.0'], '1.0.0 should not exists');
     });
 
     it('should work on unpublished package', async () => {
@@ -1527,17 +1535,17 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       // ignore unpublished when local package not exists
       await packageSyncerService.createTask(name);
       let task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       let stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       let log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes(`] 🟢 Package "${name}" was removed in remote registry`)
       );
       let data = await packageManagerService.listPackageFullManifests('', name);
-      assert(data.data === null);
+      assert.ok(data.data === null);
 
       // sync unpublished
       app.mockHttpclient(
@@ -1563,18 +1571,18 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('] 🟢 Synced '));
+      assert.ok(log.includes('] 🟢 Synced '));
       data = await packageManagerService.listPackageFullManifests('', name);
       // console.log(data.data);
-      assert(data.data);
-      assert(!data.data.time.unpublished);
-      assert(data.data.maintainers);
+      assert.ok(data.data);
+      assert.ok(!data.data.time.unpublished);
+      assert.ok(data.data.maintainers);
       app.mockAgent().assertNoPendingInterceptors();
 
       app.mockHttpclient(
@@ -1587,19 +1595,19 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       );
       await packageSyncerService.createTask(name);
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes(`] 🟢 Package "${name}" was removed in remote registry`)
       );
       data = await packageManagerService.listPackageFullManifests('', name);
       // console.log(data.data);
-      assert(data.data?.time.unpublished);
-      assert(!data.data?.maintainers);
+      assert.ok(data.data?.time.unpublished);
+      assert.ok(!data.data?.maintainers);
       app.mockAgent().assertNoPendingInterceptors();
     });
 
@@ -1631,13 +1639,13 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-dependencies';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes(
           '] 📦 Add dependency "cnpmcore-test-sync-deprecated" sync task: '
         )
@@ -1646,7 +1654,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         '',
         name
       );
-      assert(data);
+      assert.ok(data);
       assert.equal(data.readme, '');
     });
 
@@ -1673,16 +1681,16 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       let task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       let stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       let log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('🚧 Syncing versions 0 => 1'));
+      assert.ok(log.includes('🚧 Syncing versions 0 => 1'));
       let res = await packageManagerService.listPackageFullManifests('', name);
-      assert(res.data);
-      assert(res.data.versions);
+      assert.ok(res.data);
+      assert.ok(res.data.versions);
       assert.equal(
         res.data.versions[res.data['dist-tags'].latest]?.hasInstallScript,
         undefined
@@ -1699,24 +1707,24 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       );
       await packageSyncerService.createTask(name);
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('🚧 Syncing versions 1 => 1'));
-      assert(res.data);
+      assert.ok(log.includes('🚧 Syncing versions 1 => 1'));
+      assert.ok(res.data);
       res = await packageManagerService.listPackageFullManifests('', name);
-      assert(res.data?.versions);
-      assert(
+      assert.ok(res.data?.versions);
+      assert.ok(
         res.data.versions[res.data['dist-tags'].latest]?.hasInstallScript ===
           true
       );
       const abbrRes =
         await packageManagerService.listPackageAbbreviatedManifests('', name);
-      assert(abbrRes.data);
-      assert(
+      assert.ok(abbrRes.data);
+      assert.ok(
         abbrRes.data.versions[abbrRes.data['dist-tags'].latest]
           ?.hasInstallScript === true
       );
@@ -1745,13 +1753,13 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes(
           '] 🔗 https://registry.npmjs.org/cnpmcore-test-sync-deprecated'
         )
@@ -1760,7 +1768,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         '',
         name
       );
-      assert(data);
+      assert.ok(data);
       assert.equal(data.readme, 'mock readme content');
       assert.equal(data.versions['0.0.0']?.readme, undefined);
     });
@@ -1787,10 +1795,10 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const data = await packageManagerService.listPackageFullManifests(
         '',
         name
@@ -1821,14 +1829,14 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       let task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       let stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       let log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('[1] Synced version 0.0.0 success'));
-      assert(
+      assert.ok(log.includes('[1] Synced version 0.0.0 success'));
+      assert.ok(
         log.includes(
           '🟢 Synced 1 tags: [{"action":"change","tag":"latest","version":"0.0.0"}]'
         )
@@ -1848,20 +1856,20 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
 
       await packageSyncerService.createTask(name);
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(!log.includes('[1] Synced version 0.0.0 success'));
-      assert(
+      assert.ok(!log.includes('[1] Synced version 0.0.0 success'));
+      assert.ok(
         log.includes(
           '🟢 Synced 1 tags: [{"action":"change","tag":"beta","version":"0.0.0"}]'
         )
       );
       data = await packageManagerService.listPackageFullManifests('', name);
-      assert(data.data);
+      assert.ok(data.data);
       assert.deepEqual(data.data['dist-tags'], {
         latest: '0.0.0',
         beta: '0.0.0',
@@ -1878,16 +1886,16 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       );
       await packageSyncerService.createTask(name);
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(!log.includes('[1] Synced version 0.0.0 success'));
-      assert(!log.includes('🟢 Synced 1 tags: '));
+      assert.ok(!log.includes('[1] Synced version 0.0.0 success'));
+      assert.ok(!log.includes('🟢 Synced 1 tags: '));
       data = await packageManagerService.listPackageFullManifests('', name);
-      assert(data.data);
+      assert.ok(data.data);
       assert.deepEqual(data.data['dist-tags'], {
         latest: '0.0.0',
         beta: '0.0.0',
@@ -1904,16 +1912,18 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       );
       await packageSyncerService.createTask(name);
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(!log.includes('[1] Synced version 0.0.0 success'));
-      assert(log.includes('Synced 1 tags: [{"action":"remove","tag":"beta"}]'));
+      assert.ok(!log.includes('[1] Synced version 0.0.0 success'));
+      assert.ok(
+        log.includes('Synced 1 tags: [{"action":"remove","tag":"beta"}]')
+      );
       data = await packageManagerService.listPackageFullManifests('', name);
-      assert(data.data);
+      assert.ok(data.data);
       assert.deepEqual(data.data['dist-tags'], { latest: '0.0.0' });
       app.mockAgent().assertNoPendingInterceptors();
     });
@@ -1953,14 +1963,14 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         specificVersions: ['1.0.0'],
       });
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
-      assert(log.includes('] 🟢 Synced updated 1 versions'));
-      assert(app.mockAgent().pendingInterceptors().length === 1);
+      assert.ok(log.includes('] 🟢 Synced updated 1 versions'));
+      assert.ok(app.mockAgent().pendingInterceptors().length === 1);
     });
 
     it('should sync specific versions and latest version.', async () => {
@@ -1997,14 +2007,14 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         specificVersions: ['1.0.0'],
       });
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
-      assert(log.includes('] 🟢 Synced updated 2 versions'));
-      assert(app.mockAgent().pendingInterceptors().length === 0);
+      assert.ok(log.includes('] 🟢 Synced updated 2 versions'));
+      assert.ok(app.mockAgent().pendingInterceptors().length === 0);
     });
 
     it('should sync specific versions and latest version.', async () => {
@@ -2031,13 +2041,13 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         specificVersions: ['1.0.0', '9.99.9'],
       });
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
-      assert(
+      assert.ok(
         log.includes('🚧 Some specific versions are not available: 👉 9.99.9')
       );
     });
@@ -2067,13 +2077,13 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         specificVersions: ['1.0.0', '9.99.9'],
       });
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
-      assert(
+      assert.ok(
         log.includes('🚧 Some specific versions are not available: 👉 9.99.9')
       );
       const manifest =
@@ -2081,7 +2091,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
           '@cnpmcore',
           'test-sync-package-has-two-versions'
         );
-      assert(manifest.data?.['dist-tags']);
+      assert.ok(manifest.data?.['dist-tags']);
       assert.equal(manifest.data?.['dist-tags'].latest, '1.0.0');
     });
 
@@ -2113,20 +2123,20 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes(', syncUpstream: true'));
-      assert(
+      assert.ok(log.includes(', syncUpstream: true'));
+      assert.ok(
         log.includes(
           '][UP] 🚧🚧🚧🚧🚧 Waiting sync "cnpmcore-test-sync-deprecated" task on https://r.cnpmjs.org 🚧'
         )
       );
-      assert(
+      assert.ok(
         log.includes(
           '][UP] 🟢🟢🟢🟢🟢 https://r.cnpmjs.org/cnpmcore-test-sync-deprecated 🟢'
         )
@@ -2162,16 +2172,16 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       await packageSyncerService.createTask(name);
       await packageSyncerService.createTask(name + '-foo');
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes(', syncUpstream: false'));
-      assert(log.includes(', taskQueue: 1/1'));
-      assert(
+      assert.ok(log.includes(', syncUpstream: false'));
+      assert.ok(log.includes(', taskQueue: 1/1'));
+      assert.ok(
         !log.includes(
           '][UP] 🚧🚧🚧🚧🚧 Waiting sync "cnpmcore-test-sync-deprecated" task on https://r.cnpmjs.org 🚧'
         )
@@ -2205,14 +2215,14 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         !log.includes(
           '][UP] 🟢🟢🟢🟢🟢 https://r.cnpmjs.org/cnpmcore-test-sync-deprecated 🟢'
         )
@@ -2248,15 +2258,15 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('🚮 give up 🚮 ❌❌❌❌❌'));
-      assert(
+      assert.ok(log.includes('🚮 give up 🚮 ❌❌❌❌❌'));
+      assert.ok(
         log.includes(`][UP] ❌ Sync ${name} fail, create sync task error:`)
       );
       app.mockAgent().assertNoPendingInterceptors();
@@ -2293,15 +2303,15 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('🚮 give up 🚮 ❌❌❌❌❌'));
-      assert(log.includes(`][UP] ❌ Sync ${name} fail, missing logId`));
+      assert.ok(log.includes('🚮 give up 🚮 ❌❌❌❌❌'));
+      assert.ok(log.includes(`][UP] ❌ Sync ${name} fail, missing logId`));
       app.mockAgent().assertNoPendingInterceptors();
     });
 
@@ -2352,15 +2362,15 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('🚮 give up 🚮 ❌❌❌❌❌'));
-      assert(log.includes('][UP] 🚧 HTTP [200]'));
+      assert.ok(log.includes('🚮 give up 🚮 ❌❌❌❌❌'));
+      assert.ok(log.includes('][UP] 🚧 HTTP [200]'));
       assert.match(log, /\]\[UP\] 🚧 HTTP \[unknow\] \[\d+ms\] error: /);
       app.mockAgent().assertNoPendingInterceptors();
     });
@@ -2416,15 +2426,15 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('🚮 give up 🚮 ❌❌❌❌❌'));
-      assert(log.includes(`][UP] ❌ Sync ${name} fail, timeout`));
+      assert.ok(log.includes('🚮 give up 🚮 ❌❌❌❌❌'));
+      assert.ok(log.includes(`][UP] ❌ Sync ${name} fail, timeout`));
       app.mockAgent().assertNoPendingInterceptors();
     });
 
@@ -2433,19 +2443,21 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-dependencies';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes(`❌❌❌❌❌ ${name} ❌❌❌❌❌`));
-      assert(log.includes(`❌ Synced ${name} fail, request manifests error`));
+      assert.ok(log.includes(`❌❌❌❌❌ ${name} ❌❌❌❌❌`));
+      assert.ok(
+        log.includes(`❌ Synced ${name} fail, request manifests error`)
+      );
       // retry task
       const task2 = await packageSyncerService.findExecuteTask();
-      assert(task2);
-      assert(task2.id === task.id);
+      assert.ok(task2);
+      assert.ok(task2.id === task.id);
     });
 
     it('should mock getFullManifests invalid maintainers error', async () => {
@@ -2459,15 +2471,15 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-dependencies';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes(`❌❌❌❌❌ ${name} ❌❌❌❌❌`));
-      assert(log.includes('❌ invalid maintainers: '));
+      assert.ok(log.includes(`❌❌❌❌❌ ${name} ❌❌❌❌❌`));
+      assert.ok(log.includes('❌ invalid maintainers: '));
     });
 
     it('should try to use latest tag version maintainers instead', async () => {
@@ -2493,17 +2505,17 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes('📖 Use the latest version(0.0.0) maintainers instead')
       );
-      assert(log.includes('] 🔗'));
+      assert.ok(log.includes('] 🔗'));
       app.mockAgent().assertNoPendingInterceptors();
     });
 
@@ -2529,13 +2541,13 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       await packageSyncerService.executeTask(task);
 
       const pkg = await packageRepository.findPackage('', name);
-      assert(pkg);
+      assert.ok(pkg);
       const pkgVersion = await packageRepository.findPackageVersion(
         pkg.packageId,
         '0.0.0'
       );
       assert.equal(pkg.name, name);
-      assert(pkgVersion);
+      assert.ok(pkgVersion);
 
       // mock unpublish
       app.mockHttpclient(`https://registry.npmjs.org/${name}`, 'GET', {
@@ -2549,11 +2561,11 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       await packageSyncerService.executeTask(task);
 
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
 
-      assert(
+      assert.ok(
         log.includes(`] 🟢 Package "${name}" was removed in remote registry`)
       );
     });
@@ -2563,15 +2575,15 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       mock(app.config.cnpmcore, 'syncPackageBlockList', [name, 'foo']);
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes(`❌❌❌❌❌ ${name} ❌❌❌❌❌`));
-      assert(
+      assert.ok(log.includes(`❌❌❌❌❌ ${name} ❌❌❌❌❌`));
+      assert.ok(
         log.includes(
           '❌ stop sync by block list: ["cnpmcore-test-sync-blocklist","foo"]'
         )
@@ -2598,26 +2610,26 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'D';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes('🚧🚧🚧🚧🚧 Syncing from https://registry.npmjs.org/D, ')
       );
-      assert(log.includes('🔗'));
+      assert.ok(log.includes('🔗'));
       const res = await app
         .httpRequest()
         .get(`/${name}`)
         .expect(200)
         .expect('content-type', 'application/json; charset=utf-8');
       const data = res.body;
-      assert(data.name === name);
+      assert.ok(data.name === name);
       // assert(data.dist === name);
-      assert(
+      assert.ok(
         data.versions[data['dist-tags'].latest].dist.tarball.includes('/D/-/D-')
       );
       app.mockAgent().assertNoPendingInterceptors();
@@ -2641,27 +2653,27 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'Buffer';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes(
           '🚧🚧🚧🚧🚧 Syncing from https://registry.npmjs.org/Buffer, '
         )
       );
-      assert(log.includes('🔗'));
+      assert.ok(log.includes('🔗'));
       const res = await app
         .httpRequest()
         .get(`/${name}`)
         .expect(200)
         .expect('content-type', 'application/json; charset=utf-8');
       const data = res.body;
-      assert(data.name === name);
-      assert(
+      assert.ok(data.name === name);
+      assert.ok(
         data.versions[data['dist-tags'].latest].dist.tarball.includes(
           '/Buffer/-/Buffer-'
         )
@@ -2693,14 +2705,14 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-security-holding-package';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes(`] 🟢 Package "${name}" was removed in remote registry`)
       );
     });
@@ -2733,19 +2745,21 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes(`❌❌❌❌❌ ${name} ❌❌❌❌❌`));
-      assert(
+      assert.ok(log.includes(`❌❌❌❌❌ ${name} ❌❌❌❌❌`));
+      assert.ok(
         log.includes('Synced version 1.0.0 fail, missing tarball, dist: ')
       );
-      assert(log.includes('❌ All versions sync fail, package not exists'));
-      assert(log.includes('Synced version 2.0.0 fail, download tarball error'));
+      assert.ok(log.includes('❌ All versions sync fail, package not exists'));
+      assert.ok(
+        log.includes('Synced version 2.0.0 fail, download tarball error')
+      );
       app.mockAgent().assertNoPendingInterceptors();
     });
 
@@ -2772,16 +2786,16 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'cnpmcore-test-sync-dependencies';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes(`❌❌❌❌❌ ${name} ❌❌❌❌❌`));
-      assert(log.includes('❌ All versions sync fail, package not exists'));
-      assert(
+      assert.ok(log.includes(`❌❌❌❌❌ ${name} ❌❌❌❌❌`));
+      assert.ok(log.includes('❌ All versions sync fail, package not exists'));
+      assert.ok(
         log.includes(
           'Synced version 2.0.0 fail, download tarball error: DownloadStatusInvalidError: Download http://foo.com/a.tgz status(500) invalid'
         )
@@ -2832,26 +2846,26 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         tips: 'sync test tips here',
       });
       let task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       let stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       let log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes(
           'Synced version 2.0.0 success, different meta: {"peerDependenciesMeta":{"bufferutil":{"optional":true},"utf-8-validate":{"optional":true}},"os":["linux"],"cpu":["x64"],"_npmUser":{"name":"fengmk2","email":"fengmk2@gmail.com"}}'
         )
       );
-      assert(
+      assert.ok(
         log.includes('Z] 👉👉👉👉👉 Tips: sync test tips here 👈👈👈👈👈')
       );
-      assert(log.includes(', skipDependencies: false'));
+      assert.ok(log.includes(', skipDependencies: false'));
       let manifests = await packageManagerService.listPackageFullManifests(
         '',
         name
       );
-      assert(manifests.data?.versions['2.0.0']);
+      assert.ok(manifests.data?.versions['2.0.0']);
       assert.equal(
         manifests.data.versions['2.0.0'].peerDependenciesMeta?.bufferutil
           .optional,
@@ -2864,7 +2878,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       let abbreviatedManifests =
         await packageManagerService.listPackageAbbreviatedManifests('', name);
       // console.log(JSON.stringify(abbreviatedManifests.data, null, 2));
-      assert(abbreviatedManifests.data?.versions['2.0.0']);
+      assert.ok(abbreviatedManifests.data?.versions['2.0.0']);
       assert.equal(
         abbreviatedManifests.data.versions['2.0.0'].peerDependenciesMeta
           ?.bufferutil.optional,
@@ -2890,13 +2904,15 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       );
       await packageSyncerService.createTask(name);
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(!log.includes('🟢 Synced version 2.0.0 success, different meta:'));
+      assert.ok(
+        !log.includes('🟢 Synced version 2.0.0 success, different meta:')
+      );
       app.mockAgent().assertNoPendingInterceptors();
 
       // should delete readme
@@ -2918,13 +2934,13 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       );
       await packageSyncerService.createTask(name);
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes(
           '🟢 Synced version 2.0.0 success, different meta: {}, delete exists readme'
         )
@@ -2935,30 +2951,30 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         '',
         name
       );
-      assert(manifests.data?.versions['2.0.0']);
+      assert.ok(manifests.data?.versions['2.0.0']);
       assert.equal(manifests.data.versions['2.0.0'].readme, undefined);
 
       // should sync missing cpu on abbreviated manifests
       const pkg = await packageRepository.findPackage('', name);
-      assert(pkg);
+      assert.ok(pkg);
       const pkgVersion = await packageRepository.findPackageVersion(
         pkg.packageId,
         '2.0.0'
       );
-      assert(pkgVersion);
+      assert.ok(pkgVersion);
       await packageManagerService.savePackageVersionManifest(
         pkgVersion,
         {},
         { cpu: undefined, libc: ['glibc'] }
       );
-      assert(pkg);
+      assert.ok(pkg);
       await packageManagerService.refreshPackageChangeVersionsToDists(pkg, [
         '2.0.0',
       ]);
       abbreviatedManifests =
         await packageManagerService.listPackageAbbreviatedManifests('', name);
-      assert(abbreviatedManifests.data?.versions);
-      assert(!abbreviatedManifests.data.versions['2.0.0']?.cpu);
+      assert.ok(abbreviatedManifests.data?.versions);
+      assert.ok(!abbreviatedManifests.data.versions['2.0.0']?.cpu);
       assert.deepStrictEqual(
         abbreviatedManifests.data.versions['2.0.0']?.libc,
         ['glibc']
@@ -2976,13 +2992,13 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       );
       await packageSyncerService.createTask(name);
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes(
           '🟢 Synced version 2.0.0 success, different meta: {"cpu":["x64"]}'
         )
@@ -2991,10 +3007,10 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       await mock.restore();
       abbreviatedManifests =
         await packageManagerService.listPackageAbbreviatedManifests('', name);
-      assert(abbreviatedManifests.data);
-      assert(abbreviatedManifests.data.versions['2.0.0']);
+      assert.ok(abbreviatedManifests.data);
+      assert.ok(abbreviatedManifests.data.versions['2.0.0']);
       assert.equal(abbreviatedManifests.data.versions['2.0.0'].cpu?.[0], 'x64');
-      assert(!abbreviatedManifests.data.versions['2.0.0'].libc);
+      assert.ok(!abbreviatedManifests.data.versions['2.0.0'].libc);
     });
 
     it('should sync missing acceptDependencies with different metas', async () => {
@@ -3040,27 +3056,27 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         tips: 'sync test tips here',
       });
       let task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       let stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       let log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(
+      assert.ok(
         log.includes(
           'Synced version 2.0.0 success, different meta: {"peerDependenciesMeta":{"bufferutil":{"optional":true},"utf-8-validate":{"optional":true}},"os":["linux"],"cpu":["x64"],"_npmUser":{"name":"fengmk2","email":"fengmk2@gmail.com"},"acceptDependencies":{"webpack":"^4.46.x"}}'
         )
       );
-      assert(
+      assert.ok(
         log.includes('Z] 👉👉👉👉👉 Tips: sync test tips here 👈👈👈👈👈')
       );
-      assert(log.includes(', skipDependencies: false'));
+      assert.ok(log.includes(', skipDependencies: false'));
       const manifests = await packageManagerService.listPackageFullManifests(
         '',
         name
       );
-      assert(manifests.data);
-      assert(manifests.data.versions['2.0.0']);
+      assert.ok(manifests.data);
+      assert.ok(manifests.data.versions['2.0.0']);
       assert.equal(
         manifests.data.versions['2.0.0'].peerDependenciesMeta?.bufferutil
           .optional,
@@ -3073,8 +3089,8 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const abbreviatedManifests =
         await packageManagerService.listPackageAbbreviatedManifests('', name);
       // console.log(JSON.stringify(abbreviatedManifests.data, null, 2));
-      assert(abbreviatedManifests.data);
-      assert(abbreviatedManifests.data.versions['2.0.0']);
+      assert.ok(abbreviatedManifests.data);
+      assert.ok(abbreviatedManifests.data.versions['2.0.0']);
       assert.equal(
         abbreviatedManifests.data.versions['2.0.0'].peerDependenciesMeta
           ?.bufferutil.optional,
@@ -3104,13 +3120,15 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       );
       await packageSyncerService.createTask(name);
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       await packageSyncerService.executeTask(task);
       stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(!log.includes('🟢 Synced version 2.0.0 success, different meta:'));
+      assert.ok(
+        !log.includes('🟢 Synced version 2.0.0 success, different meta:')
+      );
       app.mockAgent().assertNoPendingInterceptors();
     });
 
@@ -3163,16 +3181,16 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'pedding';
       await packageSyncerService.createTask(name, { syncDownloadData: true });
       let task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       let stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       let log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('][DownloadData] 🟢 202101: 31 days'));
-      assert(log.includes('][DownloadData] 🟢🟢🟢🟢🟢'));
-      assert(log.includes('] 🟢🟢🟢🟢🟢'));
+      assert.ok(log.includes('][DownloadData] 🟢 202101: 31 days'));
+      assert.ok(log.includes('][DownloadData] 🟢🟢🟢🟢🟢'));
+      assert.ok(log.includes('] 🟢🟢🟢🟢🟢'));
 
       let res = await app
         .httpRequest()
@@ -3180,23 +3198,23 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         .expect(200)
         .expect('content-type', 'application/json; charset=utf-8');
       let data = res.body;
-      assert(data.downloads.length > 0);
-      assert(Object.keys(data.versions).length === 0);
+      assert.ok(data.downloads.length > 0);
+      assert.ok(Object.keys(data.versions).length === 0);
       // console.log('%j', data);
 
       // again should sync download data only
       await packageSyncerService.createTask(name, { syncDownloadData: true });
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('][DownloadData] 🟢 202110: 31 days'));
-      assert(log.includes('][DownloadData] 🟢🟢🟢🟢🟢'));
-      assert(
+      assert.ok(log.includes('][DownloadData] 🟢 202110: 31 days'));
+      assert.ok(log.includes('][DownloadData] 🟢🟢🟢🟢🟢'));
+      assert.ok(
         log.includes(
           `] 🟢🟢🟢🟢🟢 Sync "${name}" download data success 🟢🟢🟢🟢🟢`
         )
@@ -3208,8 +3226,8 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         .expect(200)
         .expect('content-type', 'application/json; charset=utf-8');
       data = res.body;
-      assert(data.downloads.length > 0);
-      assert(Object.keys(data.versions).length === 0);
+      assert.ok(data.downloads.length > 0);
+      assert.ok(Object.keys(data.versions).length === 0);
       // console.log('%j', data);
       app.mockAgent().assertNoPendingInterceptors();
     });
@@ -3245,15 +3263,15 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'pedding';
       await packageSyncerService.createTask(name, { syncDownloadData: true });
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(!log.includes('][DownloadData] 🟢 202111: 10 days'));
-      assert(!log.includes('][DownloadData] 🟢🟢🟢🟢🟢'));
+      assert.ok(!log.includes('][DownloadData] 🟢 202111: 10 days'));
+      assert.ok(!log.includes('][DownloadData] 🟢🟢🟢🟢🟢'));
 
       const res = await app
         .httpRequest()
@@ -3261,7 +3279,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         .expect(200)
         .expect('content-type', 'application/json; charset=utf-8');
       const data = res.body;
-      assert(data.downloads.length === 0);
+      assert.ok(data.downloads.length === 0);
       app.mockAgent().assertNoPendingInterceptors();
     });
 
@@ -3304,15 +3322,15 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const name = 'pedding';
       await packageSyncerService.createTask(name, { syncDownloadData: true });
       const task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, name);
       await packageSyncerService.executeTask(task);
       const stream = await packageSyncerService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert(log.includes('][DownloadData] ❌ Get download data error: '));
-      assert(
+      assert.ok(log.includes('][DownloadData] ❌ Get download data error: '));
+      assert.ok(
         log.includes('][DownloadData] ❌❌❌❌❌ 🚮 give up 🚮 ❌❌❌❌❌')
       );
       app.mockAgent().assertNoPendingInterceptors();
@@ -3358,14 +3376,14 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         const name = '@dnpm/banana';
         await packageSyncerService.createTask(name);
         const task = await packageSyncerService.findExecuteTask();
-        assert(task);
+        assert.ok(task);
         assert.equal(task.targetName, name);
         await packageSyncerService.executeTask(task);
         const stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         const log = await TestUtil.readStreamToLog(stream);
         // console.log(log);
-        assert(log.includes('syncUpstream: false'));
+        assert.ok(log.includes('syncUpstream: false'));
       });
 
       it('should sync from target registry & default registry', async () => {
@@ -3384,9 +3402,11 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         let task = await packageSyncerService.findExecuteTask();
         await packageSyncerService.executeTask(task);
         let stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         let log = await TestUtil.readStreamToLog(stream);
-        assert(log.includes('Syncing from https://custom.npmjs.com/cnpm-pkg'));
+        assert.ok(
+          log.includes('Syncing from https://custom.npmjs.com/cnpm-pkg')
+        );
 
         // default registry
         app.mockHttpclient('https://default.npmjs.org/npm-pkg', 'GET', {
@@ -3403,9 +3423,11 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         );
         await packageSyncerService.executeTask(task);
         stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         log = await TestUtil.readStreamToLog(stream);
-        assert(log.includes('Syncing from https://default.npmjs.org/npm-pkg'));
+        assert.ok(
+          log.includes('Syncing from https://default.npmjs.org/npm-pkg')
+        );
         app.mockAgent().assertNoPendingInterceptors();
       });
 
@@ -3441,9 +3463,9 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         const task = await packageSyncerService.findExecuteTask();
         await packageSyncerService.executeTask(task);
         const stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         const log = await TestUtil.readStreamToLog(stream);
-        assert(
+        assert.ok(
           log.includes(
             'Syncing from https://registry.npmjs.org/@cnpmcore/sync_not_match_registry_name'
           )
@@ -3478,9 +3500,9 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         });
         await packageSyncerService.executeTask(task);
         const stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         const log = await TestUtil.readStreamToLog(stream);
-        assert(
+        assert.ok(
           log.includes('Syncing from https://custom.npmjs.com/@cnpm/banana')
         );
 
@@ -3507,9 +3529,9 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         });
         await packageSyncerService.executeTask(task);
         const stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         const log = await TestUtil.readStreamToLog(stream);
-        assert(
+        assert.ok(
           log.includes('Syncing from https://custom.npmjs.com/@cnpm/banana')
         );
       });
@@ -3535,9 +3557,9 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         const task = await packageSyncerService.findExecuteTask();
         await packageSyncerService.executeTask(task);
         const stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         const log = await TestUtil.readStreamToLog(stream);
-        assert(log.includes('skip sync'));
+        assert.ok(log.includes('skip sync'));
       });
     });
 
@@ -3575,10 +3597,10 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
           skipDependencies: true,
         });
         const task = await packageSyncerService.findExecuteTask();
-        assert(task);
+        assert.ok(task);
         await packageSyncerService.executeTask(task);
-        assert(!(await TaskModel.findOne({ taskId: task.taskId })));
-        assert(await HistoryTaskModel.findOne({ taskId: task.taskId }));
+        assert.ok(!(await TaskModel.findOne({ taskId: task.taskId })));
+        assert.ok(await HistoryTaskModel.findOne({ taskId: task.taskId }));
       });
 
       it('should ignore when upstream is removed', async () => {
@@ -3593,22 +3615,22 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
           skipDependencies: true,
         });
         const task = await packageSyncerService.findExecuteTask();
-        assert(task);
+        assert.ok(task);
         await packageSyncerService.executeTask(task);
-        assert(!(await TaskModel.findOne({ taskId: task.taskId })));
-        assert(await HistoryTaskModel.findOne({ taskId: task.taskId }));
+        assert.ok(!(await TaskModel.findOne({ taskId: task.taskId })));
+        assert.ok(await HistoryTaskModel.findOne({ taskId: task.taskId }));
         const stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         const log = await TestUtil.readStreamToLog(stream);
-        assert(log);
+        assert.ok(log);
         // console.log(log);
         const model = await PackageModel.findOne({ scope: '', name: 'foobar' });
-        assert(model);
+        assert.ok(model);
         const versions = await PackageVersion.find({
           packageId: model.packageId,
         });
         assert.equal(model.isPrivate, false);
-        assert(versions.length === 2);
+        assert.ok(versions.length === 2);
       });
 
       it('should block when upstream is removed', async () => {
@@ -3623,32 +3645,32 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
           skipDependencies: true,
         });
         const task = await packageSyncerService.findExecuteTask();
-        assert(task);
+        assert.ok(task);
         await packageSyncerService.executeTask(task);
-        assert(!(await TaskModel.findOne({ taskId: task.taskId })));
-        assert(await HistoryTaskModel.findOne({ taskId: task.taskId }));
+        assert.ok(!(await TaskModel.findOne({ taskId: task.taskId })));
+        assert.ok(await HistoryTaskModel.findOne({ taskId: task.taskId }));
         const stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         const log = await TestUtil.readStreamToLog(stream);
-        assert(log);
+        assert.ok(log);
         // console.log(log);
         const model = await PackageModel.findOne({ scope: '', name: 'foobar' });
-        assert(model);
+        assert.ok(model);
         const versions = await PackageVersion.find({
           packageId: model.packageId,
         });
         assert.equal(model.isPrivate, false);
-        assert(versions.length === 2);
+        assert.ok(versions.length === 2);
 
         const manifests = await packageManagerService.listPackageFullManifests(
           '',
           'foobar'
         );
-        assert(manifests.blockReason === 'Removed in remote registry');
-        assert(manifests.data);
-        assert(manifests.data.block === 'Removed in remote registry');
+        assert.ok(manifests.blockReason === 'Removed in remote registry');
+        assert.ok(manifests.data);
+        assert.ok(manifests.data.block === 'Removed in remote registry');
         const pkg = await packageRepository.findPackage('', 'foobar');
-        assert(pkg);
+        assert.ok(pkg);
 
         await app.httpRequest().get(`/${pkg.name}`).expect(451);
 
@@ -3668,21 +3690,21 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
           skipDependencies: true,
         });
         let task = await packageSyncerService.findExecuteTask();
-        assert(task);
+        assert.ok(task);
         await packageSyncerService.executeTask(task);
-        assert(!(await TaskModel.findOne({ taskId: task.taskId })));
-        assert(await HistoryTaskModel.findOne({ taskId: task.taskId }));
+        assert.ok(!(await TaskModel.findOne({ taskId: task.taskId })));
+        assert.ok(await HistoryTaskModel.findOne({ taskId: task.taskId }));
         const stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         const log = await TestUtil.readStreamToLog(stream);
-        assert(log);
+        assert.ok(log);
         // console.log(log);
         const model = await PackageModel.findOne({ scope: '', name: 'foobar' });
-        assert(model);
+        assert.ok(model);
         const versions = await PackageVersion.find({
           packageId: model.packageId,
         });
-        assert(versions.length === 0);
+        assert.ok(versions.length === 0);
 
         // resync
         app.mockLog();
@@ -3691,7 +3713,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         });
         task = await packageSyncerService.findExecuteTask();
         await packageSyncerService.executeTask(task);
-        assert(task);
+        assert.ok(task);
         const pkg = await packageRepository.findPackage('', 'foobar');
         app.expectLog(
           `[packageManagerService.unpublishPackage:skip] ${pkg?.packageId} already unpublished`
@@ -3741,7 +3763,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
           skipDependencies: true,
         });
         let task = await packageSyncerService.findExecuteTask();
-        assert(task);
+        assert.ok(task);
         await packageSyncerService.executeTask(task);
 
         // should sync publisher
@@ -3765,13 +3787,13 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
           skipDependencies: true,
         });
         task = await packageSyncerService.findExecuteTask();
-        assert(task);
+        assert.ok(task);
         await packageSyncerService.executeTask(task);
         const stream2 = await packageSyncerService.findTaskLog(task);
-        assert(stream2);
+        assert.ok(stream2);
         const log2 = await TestUtil.readStreamToLog(stream2);
         // console.log(log2);
-        assert(
+        assert.ok(
           /different meta: {"_npmUser":{"name":"banana","email":"banana@cnpmjs.org"}}/.test(
             log2
           )
@@ -3812,24 +3834,24 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
           skipDependencies: true,
         });
         const task = await packageSyncerService.findExecuteTask();
-        assert(task);
+        assert.ok(task);
         await packageSyncerService.executeTask(task);
         // assert(!await TaskModel.findOne({ taskId: task.taskId }));
         // assert(await HistoryTaskModel.findOne({ taskId: task.taskId }));
         const stream = await packageSyncerService.findTaskLog(task);
-        assert(stream);
+        assert.ok(stream);
         const log = await TestUtil.readStreamToLog(stream);
-        assert(log);
+        assert.ok(log);
         // console.log(log);
         const model = await PackageModel.findOne({
           scope: '',
           name: 'invalid-deps',
         });
-        assert(!model);
+        assert.ok(!model);
 
         // shoud requeue
         const reTask = await packageSyncerService.findExecuteTask();
-        assert(reTask.attempts === 2);
+        assert.ok(reTask.attempts === 2);
       });
     });
   });

--- a/test/core/service/PackageSyncerService/findExecuteTask.test.ts
+++ b/test/core/service/PackageSyncerService/findExecuteTask.test.ts
@@ -18,38 +18,38 @@ describe('test/core/service/PackageSyncerService/findExecuteTask.test.ts', () =>
   describe('findExecuteTask()', () => {
     it('should get a task to execute', async () => {
       let task = await packageSyncerService.findExecuteTask();
-      assert(!task);
+      assert.ok(!task);
 
       await packageSyncerService.createTask('foo');
       await packageSyncerService.createTask('bar');
       await packageSyncerService.createTask('ok');
       const task1 = await packageSyncerService.findExecuteTask();
-      assert(task1);
-      assert(task1.state === 'processing');
-      assert(task1.updatedAt > task1.createdAt);
-      assert(task1.attempts === 1);
+      assert.ok(task1);
+      assert.ok(task1.state === 'processing');
+      assert.ok(task1.updatedAt > task1.createdAt);
+      assert.ok(task1.attempts === 1);
       // console.log(task1, task1.updatedAt.getTime() - task1.createdAt.getTime());
       const task2 = await packageSyncerService.findExecuteTask();
-      assert(task2);
-      assert(task2.state === 'processing');
-      assert(task2.updatedAt > task2.createdAt);
-      assert(task1.attempts === 1);
+      assert.ok(task2);
+      assert.ok(task2.state === 'processing');
+      assert.ok(task2.updatedAt > task2.createdAt);
+      assert.ok(task1.attempts === 1);
       // console.log(task2, task2.updatedAt.getTime() - task2.createdAt.getTime());
       const task3 = await packageSyncerService.findExecuteTask();
-      assert(task3);
-      assert(task3.state === 'processing');
-      assert(task3.updatedAt > task3.createdAt);
-      assert(task1.attempts === 1);
+      assert.ok(task3);
+      assert.ok(task3.state === 'processing');
+      assert.ok(task3.updatedAt > task3.createdAt);
+      assert.ok(task1.attempts === 1);
       // console.log(task3, task3.updatedAt.getTime() - task3.createdAt.getTime());
-      assert(task3.id);
-      assert(task2.id);
-      assert(task1.id);
-      assert(task3.id > task2.id);
-      assert(task2.id > task1.id);
+      assert.ok(task3.id);
+      assert.ok(task2.id);
+      assert.ok(task1.id);
+      assert.ok(task3.id > task2.id);
+      assert.ok(task2.id > task1.id);
 
       // again will empty
       task = await packageSyncerService.findExecuteTask();
-      assert(!task);
+      assert.ok(!task);
 
       // mock timeout
       await TaskModel.update(
@@ -64,16 +64,16 @@ describe('test/core/service/PackageSyncerService/findExecuteTask.test.ts', () =>
       app.expectLog('[TaskService.retryExecuteTimeoutTasks:retry]');
 
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
-      assert(task.id === task3.id);
-      assert(task.updatedAt > task3.updatedAt);
-      assert(task.attempts === 2);
-      assert(task.logPath.endsWith('-1.log'));
-      assert(task.logStorePosition === '');
+      assert.ok(task);
+      assert.ok(task.id === task3.id);
+      assert.ok(task.updatedAt > task3.updatedAt);
+      assert.ok(task.attempts === 2);
+      assert.ok(task.logPath.endsWith('-1.log'));
+      assert.ok(task.logStorePosition === '');
 
       // again will empty
       task = await packageSyncerService.findExecuteTask();
-      assert(!task);
+      assert.ok(!task);
 
       // attempts > 3 will be set to timeout task and save to history
       await TaskModel.update(
@@ -85,9 +85,9 @@ describe('test/core/service/PackageSyncerService/findExecuteTask.test.ts', () =>
       app.expectLog('[TaskService.retryExecuteTimeoutTasks:retry]');
 
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
-      assert(task.attempts === 3);
-      assert(task.logPath.endsWith('-2.log'));
+      assert.ok(task);
+      assert.ok(task.attempts === 3);
+      assert.ok(task.logPath.endsWith('-2.log'));
 
       await TaskModel.update(
         { id: task3.id },
@@ -95,27 +95,27 @@ describe('test/core/service/PackageSyncerService/findExecuteTask.test.ts', () =>
       );
       app.mockLog();
       let result = await taskService.retryExecuteTimeoutTasks();
-      assert(result.processing === 1);
-      assert(result.waiting === 0);
+      assert.ok(result.processing === 1);
+      assert.ok(result.waiting === 0);
       app.expectLog('[TaskService.retryExecuteTimeoutTasks:timeout]');
 
       // again should not effect
       result = await taskService.retryExecuteTimeoutTasks();
-      assert(result.processing === 0);
-      assert(result.waiting === 0);
+      assert.ok(result.processing === 0);
+      assert.ok(result.waiting === 0);
 
       task = await packageSyncerService.findExecuteTask();
-      assert(!task);
+      assert.ok(!task);
       const history = await HistoryTaskModel.findOne({ taskId: task3.taskId });
-      assert(history);
-      assert(history.state === 'timeout');
-      assert(history.attempts === 3);
-      assert(!(await TaskModel.findOne({ id: task3.id })));
+      assert.ok(history);
+      assert.ok(history.state === 'timeout');
+      assert.ok(history.attempts === 3);
+      assert.ok(!(await TaskModel.findOne({ id: task3.id })));
     });
 
     it('should mock waiting timeout task', async () => {
       let task = await packageSyncerService.findExecuteTask();
-      assert(!task);
+      assert.ok(!task);
 
       task = await packageSyncerService.createTask('foo');
 
@@ -127,8 +127,8 @@ describe('test/core/service/PackageSyncerService/findExecuteTask.test.ts', () =>
         }
       );
       let result = await taskService.retryExecuteTimeoutTasks();
-      assert(result.processing === 0);
-      assert(result.waiting === 0);
+      assert.ok(result.processing === 0);
+      assert.ok(result.waiting === 0);
 
       // mock timeout 30mins
       await TaskModel.update(
@@ -140,18 +140,18 @@ describe('test/core/service/PackageSyncerService/findExecuteTask.test.ts', () =>
       app.mockLog();
       result = await taskService.retryExecuteTimeoutTasks();
       app.expectLog('[TaskService.retryExecuteTimeoutTasks:retryWaiting]');
-      assert(result.processing === 0);
-      assert(result.waiting === 1);
+      assert.ok(result.processing === 0);
+      assert.ok(result.waiting === 1);
 
       result = await taskService.retryExecuteTimeoutTasks();
-      assert(result.processing === 0);
-      assert(result.waiting === 0);
+      assert.ok(result.processing === 0);
+      assert.ok(result.waiting === 0);
 
       // has one tasks in queue
       task = await packageSyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       task = await packageSyncerService.findExecuteTask();
-      assert(!task);
+      assert.ok(!task);
     });
   });
 });

--- a/test/core/service/PackageVersionService.test.ts
+++ b/test/core/service/PackageVersionService.test.ts
@@ -119,7 +119,7 @@ describe('test/core/service/PackageVersionService.test.ts', () => {
             npa('mock_package@*'),
             true
           );
-          assert(manifest);
+          assert.ok(manifest);
           assert.equal(manifest.version, '1.1.0');
         });
 
@@ -140,7 +140,7 @@ describe('test/core/service/PackageVersionService.test.ts', () => {
             npa('mock_package@*'),
             true
           );
-          assert(manifest);
+          assert.ok(manifest);
           assert.equal(manifest.version, '1.1.0');
         });
 
@@ -150,7 +150,7 @@ describe('test/core/service/PackageVersionService.test.ts', () => {
             npa('mock_package@^*||~x'),
             true
           );
-          assert(manifest);
+          assert.ok(manifest);
           assert.equal(manifest.version, '1.1.0');
         });
       });
@@ -173,7 +173,7 @@ describe('test/core/service/PackageVersionService.test.ts', () => {
           distRepository,
           'findPackageVersionManifest',
           async (_: string, version: string) => {
-            assert(version === '0.0.9');
+            assert.ok(version === '0.0.9');
             return {
               name: 'mock_package',
               version: '0.0.9',
@@ -198,7 +198,7 @@ describe('test/core/service/PackageVersionService.test.ts', () => {
           npa('mock_package@latest'),
           true
         );
-        assert(manifest);
+        assert.ok(manifest);
         assert.equal(
           manifest.deprecated,
           '[WARNING] Use 0.0.9 instead of 1.0.0, reason: mock bug version'
@@ -281,7 +281,7 @@ describe('test/core/service/PackageVersionService.test.ts', () => {
           distRepository,
           'findPackageVersionManifest',
           async (_: string, version: string) => {
-            assert(version === '0.0.9');
+            assert.ok(version === '0.0.9');
             return {
               name: 'mock_package',
               version: '0.0.9',
@@ -349,8 +349,8 @@ describe('test/core/service/PackageVersionService.test.ts', () => {
             npa('mock_package@^1.0.0'),
             true
           );
-          assert(manifest);
-          assert(manifest.version === '1.0.0');
+          assert.ok(manifest);
+          assert.ok(manifest.version === '1.0.0');
         });
       });
 
@@ -361,8 +361,8 @@ describe('test/core/service/PackageVersionService.test.ts', () => {
             npa('mock_package@^2.0.0'),
             true
           );
-          assert(manifest);
-          assert(manifest.version === '2.2.0');
+          assert.ok(manifest);
+          assert.ok(manifest.version === '2.2.0');
         });
       });
     });
@@ -511,7 +511,7 @@ describe('test/core/service/PackageVersionService.test.ts', () => {
       const version = await packageVersionService.getVersion(
         npa('mock_package@<18.0.0')
       );
-      assert(version, '17.0.18');
+      assert.ok(version, '17.0.18');
     });
   });
 });

--- a/test/core/service/ProxyCacheService.test.ts
+++ b/test/core/service/ProxyCacheService.test.ts
@@ -21,11 +21,14 @@ describe('test/core/service/ProxyCacheService/index.test.ts', () => {
   describe('getPackageVersionTarResponse()', () => {
     it('should stop proxy when hit block list', async () => {
       const name = 'cnpmcore-test-sync-blocklist';
-      mock(app.config.cnpmcore, 'syncPackageBlockList', [ name ]);
+      mock(app.config.cnpmcore, 'syncPackageBlockList', [name]);
       try {
-        await proxyCacheService.getPackageVersionTarResponse(name, app.mockContext());
+        await proxyCacheService.getPackageVersionTarResponse(
+          name,
+          app.mockContext()
+        );
       } catch (error) {
-        assert(error.options.message.includes('block list'));
+        assert.ok(error.options.message.includes('block list'));
       }
     });
   });
@@ -37,7 +40,7 @@ describe('test/core/service/ProxyCacheService/index.test.ts', () => {
       });
       const manifest = await proxyCacheService.getPackageManifest(
         'foo',
-        DIST_NAMES.FULL_MANIFESTS,
+        DIST_NAMES.FULL_MANIFESTS
       );
       assert.equal(manifest.name, 'mock info');
     });
@@ -51,14 +54,14 @@ describe('test/core/service/ProxyCacheService/index.test.ts', () => {
         ProxyCache.create({
           fullname: 'foo',
           fileType: DIST_NAMES.FULL_MANIFESTS,
-        }),
+        })
       );
       mock(nfsAdapter, 'getBytes', async () => {
         return Buffer.from('{"name": "nfs mock info"}');
       });
       const manifest = await proxyCacheService.getPackageManifest(
         'foo',
-        DIST_NAMES.FULL_MANIFESTS,
+        DIST_NAMES.FULL_MANIFESTS
       );
       assert.equal(manifest.name, 'nfs mock info');
     });
@@ -72,7 +75,7 @@ describe('test/core/service/ProxyCacheService/index.test.ts', () => {
       const manifest = await proxyCacheService.getPackageVersionManifest(
         'foo',
         DIST_NAMES.MANIFEST,
-        '1.0.0',
+        '1.0.0'
       );
       assert.equal(manifest.name, 'mock package version info');
     });
@@ -87,7 +90,7 @@ describe('test/core/service/ProxyCacheService/index.test.ts', () => {
           fullname: 'foo',
           fileType: DIST_NAMES.MANIFEST,
           version: '1.0.0',
-        }),
+        })
       );
       mock(nfsAdapter, 'getBytes', async () => {
         return Buffer.from('{"name": "package version nfs mock info"}');
@@ -95,7 +98,7 @@ describe('test/core/service/ProxyCacheService/index.test.ts', () => {
       const manifest = await proxyCacheService.getPackageVersionManifest(
         'foo',
         DIST_NAMES.MANIFEST,
-        '1.0.0',
+        '1.0.0'
       );
       assert.equal(manifest.name, 'package version nfs mock info');
     });
@@ -103,7 +106,7 @@ describe('test/core/service/ProxyCacheService/index.test.ts', () => {
     it('should get correct verison via tag and cache the pkg manifest', async () => {
       app.mockHttpclient('https://registry.npmjs.org/foobar/latest', 'GET', {
         data: await TestUtil.readFixturesFile(
-          'registry.npmjs.org/foobar/1.0.0/abbreviated.json',
+          'registry.npmjs.org/foobar/1.0.0/abbreviated.json'
         ),
         persist: false,
       });
@@ -112,7 +115,7 @@ describe('test/core/service/ProxyCacheService/index.test.ts', () => {
         return {
           status: 200,
           data: await TestUtil.readJSONFile(
-            TestUtil.getFixtures('registry.npmjs.org/abbreviated_foobar.json'),
+            TestUtil.getFixtures('registry.npmjs.org/abbreviated_foobar.json')
           ),
         };
       });
@@ -121,9 +124,9 @@ describe('test/core/service/ProxyCacheService/index.test.ts', () => {
         await proxyCacheService.getPackageVersionManifest(
           'foobar',
           DIST_NAMES.MANIFEST,
-          'latest',
+          'latest'
         );
-      assert(pkgVersionManifest);
+      assert.ok(pkgVersionManifest);
       assert.equal(pkgVersionManifest.version, '1.0.0');
     });
   });
@@ -135,19 +138,19 @@ describe('test/core/service/ProxyCacheService/index.test.ts', () => {
           fullname: 'foo-bar',
           fileType: DIST_NAMES.ABBREVIATED,
           version: '1.0.0',
-        }),
+        })
       );
 
       await proxyCacheService.removeProxyCache(
         'foobar',
         DIST_NAMES.ABBREVIATED,
-        '1.0.0',
+        '1.0.0'
       );
 
       const resultAfter = await proxyCacheRepository.findProxyCache(
         'foobar',
         DIST_NAMES.ABBREVIATED,
-        '1.0.0',
+        '1.0.0'
       );
       assert.equal(resultAfter, undefined);
     });
@@ -160,9 +163,9 @@ describe('test/core/service/ProxyCacheService/index.test.ts', () => {
         {
           fullname: 'foo',
           fileType: DIST_NAMES.FULL_MANIFESTS,
-        },
+        }
       );
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, `foobar/${DIST_NAMES.FULL_MANIFESTS}`);
       const task2 = await proxyCacheService.findExecuteTask();
       assert.equal(task.id, task2?.id);
@@ -175,7 +178,7 @@ describe('test/core/service/ProxyCacheService/index.test.ts', () => {
           {
             fullname: 'foo',
             fileType: DIST_NAMES.MANIFEST,
-          },
+          }
         );
       } catch (error) {
         assert.equal(error.status, 500);
@@ -191,13 +194,13 @@ describe('test/core/service/ProxyCacheService/index.test.ts', () => {
         {
           fullname: 'foo',
           fileType: DIST_NAMES.FULL_MANIFESTS,
-        },
+        }
       );
       await proxyCacheService.executeTask(task);
       const stream = await taskService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
-      assert(log.includes('can not found record in repo'));
+      assert.ok(log.includes('can not found record in repo'));
     });
 
     it('should update success', async () => {
@@ -206,28 +209,28 @@ describe('test/core/service/ProxyCacheService/index.test.ts', () => {
         ProxyCache.create({
           fullname: 'foobar',
           fileType: DIST_NAMES.FULL_MANIFESTS,
-        }),
+        })
       );
       const task = await proxyCacheService.createTask(
         `foobar/${DIST_NAMES.FULL_MANIFESTS}`,
         {
           fullname: 'foobar',
           fileType: DIST_NAMES.FULL_MANIFESTS,
-        },
+        }
       );
       mock(proxyCacheService, 'getPackageVersionManifest', async () => {
         return {
           status: 200,
           data: await TestUtil.readJSONFile(
-            TestUtil.getFixtures('registry.npmjs.org/foobar.json'),
+            TestUtil.getFixtures('registry.npmjs.org/foobar.json')
           ),
         };
       });
       await proxyCacheService.executeTask(task);
       const stream = await taskService.findTaskLog(task);
-      assert(stream);
+      assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
-      assert(log.includes('Update Success'));
+      assert.ok(log.includes('Update Success'));
     });
   });
 });

--- a/test/core/service/RegistryManagerService/index.test.ts
+++ b/test/core/service/RegistryManagerService/index.test.ts
@@ -49,7 +49,7 @@ describe('test/core/service/RegistryManagerService/index.test.ts', () => {
         const queryRes = await registryManagerService.listRegistries({});
         assert.equal(queryRes.count, 2);
         const [_, registry] = queryRes.data;
-        assert(_);
+        assert.ok(_);
         assert.equal(registry.name, 'custom2');
       });
 
@@ -133,7 +133,7 @@ describe('test/core/service/RegistryManagerService/index.test.ts', () => {
           targetName,
           TaskType.ChangesStream
         );
-        assert(task);
+        assert.ok(task);
         assert.equal(
           (task.data as ChangesStreamTaskData).registryId,
           registry.registryId
@@ -183,7 +183,7 @@ describe('test/core/service/RegistryManagerService/index.test.ts', () => {
           targetName,
           TaskType.ChangesStream
         );
-        assert(task);
+        assert.ok(task);
         assert.equal((task.data as ChangesStreamTaskData).since, '');
       });
     });

--- a/test/core/service/ScopeManagerService/index.test.ts
+++ b/test/core/service/ScopeManagerService/index.test.ts
@@ -21,7 +21,7 @@ describe('test/core/service/ScopeManagerService/index.test.ts', () => {
   describe('ScopeManagerService', () => {
     it('query should work', async () => {
       const queryRes = await scopeManagerService.listScopes({});
-      assert(queryRes.data[0].name === 'custom');
+      assert.ok(queryRes.data[0].name === 'custom');
     });
 
     it('query after create work', async () => {
@@ -33,8 +33,8 @@ describe('test/core/service/ScopeManagerService/index.test.ts', () => {
 
       const queryRes = await scopeManagerService.listScopes({});
       const [_, otherScope] = queryRes.data;
-      assert(_);
-      assert(otherScope.name === 'custom2');
+      assert.ok(_);
+      assert.ok(otherScope.name === 'custom2');
     });
   });
 });

--- a/test/core/service/TaskService/findExecuteTask.test.ts
+++ b/test/core/service/TaskService/findExecuteTask.test.ts
@@ -20,33 +20,33 @@ describe('test/core/service/TaskService/findExecuteTask.test.ts', () => {
   describe('findExecuteTask()', () => {
     it('should get a task to execute', async () => {
       let task = await taskService.findExecuteTask(TaskType.SyncPackage);
-      assert(!task);
+      assert.ok(!task);
 
       const newTask = await packageSyncerService.createTask('foo');
-      assert(newTask);
+      assert.ok(newTask);
       app.expectLog(/queue size: 1/);
-      assert(!newTask.data.taskWorker);
+      assert.ok(!newTask.data.taskWorker);
       // same task not create again
       const newTask2 = await packageSyncerService.createTask('foo');
-      assert(newTask2);
-      assert(newTask2.taskId === newTask.taskId);
-      assert(!newTask2.data.taskWorker);
+      assert.ok(newTask2);
+      assert.ok(newTask2.taskId === newTask.taskId);
+      assert.ok(!newTask2.data.taskWorker);
       app.expectLog(/queue size: 1/);
 
       // find other task type
       task = await taskService.findExecuteTask(TaskType.SyncBinary);
-      assert(!task);
+      assert.ok(!task);
 
       task = await taskService.findExecuteTask(TaskType.SyncPackage);
-      assert(task);
-      assert(task.targetName === 'foo');
-      assert(task.taskId === newTask.taskId);
-      assert(task.data.taskWorker);
-      assert(task.state === TaskState.Processing);
+      assert.ok(task);
+      assert.ok(task.targetName === 'foo');
+      assert.ok(task.taskId === newTask.taskId);
+      assert.ok(task.data.taskWorker);
+      assert.ok(task.state === TaskState.Processing);
 
       // find again will null
       task = await taskService.findExecuteTask(TaskType.SyncPackage);
-      assert(!task);
+      assert.ok(!task);
     });
 
     it('should get multi tasks to execute', async () => {
@@ -55,15 +55,15 @@ describe('test/core/service/TaskService/findExecuteTask.test.ts', () => {
       }
       for (let i = 0; i < 10; i++) {
         const task = await taskService.findExecuteTask(TaskType.SyncPackage);
-        assert(task);
+        assert.ok(task);
       }
       let task = await taskService.findExecuteTask(TaskType.SyncPackage);
-      assert(!task);
+      assert.ok(!task);
       await packageSyncerService.createTask('foo');
       task = await taskService.findExecuteTask(TaskType.SyncPackage);
-      assert(task);
+      assert.ok(task);
       task = await taskService.findExecuteTask(TaskType.SyncPackage);
-      assert(!task);
+      assert.ok(!task);
     });
 
     it('should check task state before execute', async () => {
@@ -102,7 +102,7 @@ describe('test/core/service/TaskService/findExecuteTask.test.ts', () => {
         taskService.findExecuteTask(task1.type),
         taskService.findExecuteTask(task1.type),
       ]);
-      assert(tasks[0]?.taskId !== tasks[1]?.taskId);
+      assert.ok(tasks[0]?.taskId !== tasks[1]?.taskId);
     });
   });
 });

--- a/test/core/util/EntityUtil.test.ts
+++ b/test/core/util/EntityUtil.test.ts
@@ -9,14 +9,14 @@ describe('test/core/util/EntityUtil.test.ts', () => {
         pageIndex: 1,
         pageSize: 10,
       });
-      assert(res.limit === 10);
-      assert(res.offset === 10);
+      assert.ok(res.limit === 10);
+      assert.ok(res.offset === 10);
     });
 
     it('should work for default value', async () => {
       const res = EntityUtil.convertPageOptionsToLimitOption({});
-      assert(res.limit === 20);
-      assert(res.offset === 0);
+      assert.ok(res.limit === 20);
+      assert.ok(res.offset === 0);
     });
 
     it('should validate params', async () => {

--- a/test/infra/QueueAdapter.test.ts
+++ b/test/infra/QueueAdapter.test.ts
@@ -14,12 +14,12 @@ describe('test/infra/QueueAdapter.test.ts', () => {
     const queueName = 'duplicate_test';
     const taskId = 'task_id_1';
     let res = await queueAdapter.push(queueName, taskId);
-    assert(res === true);
+    assert.ok(res === true);
     res = await queueAdapter.push(queueName, taskId);
-    assert(res === false);
+    assert.ok(res === false);
     const length = await queueAdapter.length(queueName);
-    assert(length === 1);
+    assert.ok(length === 1);
     const queueTaskId = await queueAdapter.pop(queueName);
-    assert(queueTaskId === taskId);
+    assert.ok(queueTaskId === taskId);
   });
 });

--- a/test/port/controller/AccessController/listCollaborators.test.ts
+++ b/test/port/controller/AccessController/listCollaborators.test.ts
@@ -15,7 +15,7 @@ describe('test/port/controller/AccessController/listCollaborators.test.ts', () =
         .get(`/-/package/${pkg.name}/collaborators`)
         .expect(200);
 
-      assert(res.body['banana-owner'] === 'write');
+      assert.ok(res.body['banana-owner'] === 'write');
     });
 
     it('should 403 when pkg not exists', async () => {
@@ -66,8 +66,8 @@ describe('test/port/controller/AccessController/listCollaborators.test.ts', () =
         .get(`/-/package/${pkg.name}/collaborators`)
         .expect(200);
 
-      assert(res.body['banana-owner'] === 'write');
-      assert(res.body['banana-maintainer'] === 'write');
+      assert.ok(res.body['banana-owner'] === 'write');
+      assert.ok(res.body['banana-maintainer'] === 'write');
     });
   });
 });

--- a/test/port/controller/BinarySyncController/showBinary.test.ts
+++ b/test/port/controller/BinarySyncController/showBinary.test.ts
@@ -23,26 +23,28 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
   describe('[GET /binary.html] showBinaryHTML()', () => {
     it('should 200', async () => {
       const res = await app.httpRequest().get('/binary.html');
-      assert(res.status === 200);
-      assert(res.headers['content-type'] === 'text/html; charset=utf-8');
-      assert(res.text.includes('<body>'));
+      assert.ok(res.status === 200);
+      assert.ok(res.headers['content-type'] === 'text/html; charset=utf-8');
+      assert.ok(res.text.includes('<body>'));
     });
   });
 
   describe('[GET /-/binary/:binary/(.*)] showBinary()', () => {
     it('should show root dirs', async () => {
       const res = await app.httpRequest().get('/-/binary/');
-      assert(res.status === 200);
-      assert(res.headers['content-type'] === 'application/json; charset=utf-8');
+      assert.ok(res.status === 200);
+      assert.ok(
+        res.headers['content-type'] === 'application/json; charset=utf-8'
+      );
       const items = res.body;
-      assert(items.length > 0);
+      assert.ok(items.length > 0);
       for (const item of items) {
-        assert(item.type === 'dir');
-        assert(item.name);
-        assert(item.url);
-        assert(item.repoUrl);
-        assert(item.distUrl);
-        assert(item.description);
+        assert.ok(item.type === 'dir');
+        assert.ok(item.name);
+        assert.ok(item.url);
+        assert.ok(item.repoUrl);
+        assert.ok(item.distUrl);
+        assert.ok(item.description);
       }
     });
 
@@ -58,17 +60,19 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
         })
       );
       const res = await app.httpRequest().get('/-/binary/');
-      assert(res.status === 200);
-      assert(res.headers['content-type'] === 'application/json; charset=utf-8');
+      assert.ok(res.status === 200);
+      assert.ok(
+        res.headers['content-type'] === 'application/json; charset=utf-8'
+      );
       const items = res.body;
-      assert(items.length > 0);
+      assert.ok(items.length > 0);
       for (const item of items) {
-        assert(item.type === 'dir');
-        assert(item.name);
-        assert(item.url);
-        assert(item.repoUrl);
-        assert(item.distUrl);
-        assert(item.description);
+        assert.ok(item.type === 'dir');
+        assert.ok(item.name);
+        assert.ok(item.url);
+        assert.ok(item.repoUrl);
+        assert.ok(item.distUrl);
+        assert.ok(item.description);
       }
 
       const item = items.filter((item: Binary) => item.name === 'nwjs/');
@@ -138,8 +142,10 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
       const res = await app
         .httpRequest()
         .get('/-/binary/node-canvas-prebuilt/');
-      assert(res.status === 200);
-      assert(res.headers['content-type'] === 'application/json; charset=utf-8');
+      assert.ok(res.status === 200);
+      assert.ok(
+        res.headers['content-type'] === 'application/json; charset=utf-8'
+      );
       const items = TestUtil.pickKeys(res.body, [
         'category',
         'name',
@@ -182,8 +188,10 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
       const res = await app
         .httpRequest()
         .get('/-/binary/node-canvas-prebuilt/v2.6.1/');
-      assert(res.status === 200);
-      assert(res.headers['content-type'] === 'application/json; charset=utf-8');
+      assert.ok(res.status === 200);
+      assert.ok(
+        res.headers['content-type'] === 'application/json; charset=utf-8'
+      );
       const items = TestUtil.pickKeys(res.body, [
         'category',
         'name',
@@ -191,7 +199,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
         'type',
         'url',
       ]);
-      assert(items.length > 0);
+      assert.ok(items.length > 0);
 
       assert.deepStrictEqual(items, [
         {
@@ -238,7 +246,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
       );
       await binarySyncerService.createTask('node', {});
       const task = await binarySyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       mock(NodeBinary.prototype, 'fetch', async (dir: string) => {
         if (dir === '/') {
           return {
@@ -291,79 +299,93 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
       await binarySyncerService.executeTask(task);
 
       let res = await app.httpRequest().get('/-/binary/node/');
-      assert(res.status === 200);
-      assert(res.headers['content-type'] === 'application/json; charset=utf-8');
+      assert.ok(res.status === 200);
+      assert.ok(
+        res.headers['content-type'] === 'application/json; charset=utf-8'
+      );
       let items = res.body;
-      assert(items.length === 2);
+      assert.ok(items.length === 2);
 
       res = await app.httpRequest().get('/-/binary/node');
-      assert(res.status === 200);
-      assert(res.headers['content-type'] === 'application/json; charset=utf-8');
+      assert.ok(res.status === 200);
+      assert.ok(
+        res.headers['content-type'] === 'application/json; charset=utf-8'
+      );
       items = res.body;
-      assert(items.length === 2);
+      assert.ok(items.length === 2);
 
       res = await app.httpRequest().get('/-/binary/node/latest/');
-      assert(res.status === 200);
-      assert(res.headers['content-type'] === 'application/json; charset=utf-8');
+      assert.ok(res.status === 200);
+      assert.ok(
+        res.headers['content-type'] === 'application/json; charset=utf-8'
+      );
       items = res.body;
-      assert(items.length === 1);
-      assert(items[0].name === 'docs/');
-      assert(items[0].category === 'node');
-      assert(items[0].type === 'dir');
-      assert(items[0].size === undefined);
-      assert(items[0].date);
-      assert(items[0].id);
-      assert(items[0].modified);
-      assert(items[0].url.startsWith('http://'));
+      assert.ok(items.length === 1);
+      assert.ok(items[0].name === 'docs/');
+      assert.ok(items[0].category === 'node');
+      assert.ok(items[0].type === 'dir');
+      assert.ok(items[0].size === undefined);
+      assert.ok(items[0].date);
+      assert.ok(items[0].id);
+      assert.ok(items[0].modified);
+      assert.ok(items[0].url.startsWith('http://'));
 
       res = await app.httpRequest().get('/-/binary/node/latest/docs/');
-      assert(res.status === 200);
-      assert(res.headers['content-type'] === 'application/json; charset=utf-8');
+      assert.ok(res.status === 200);
+      assert.ok(
+        res.headers['content-type'] === 'application/json; charset=utf-8'
+      );
       items = res.body;
-      assert(items.length === 1);
-      assert(items[0].name === 'apilinks.json');
-      assert(items[0].category === 'node');
-      assert(items[0].type === 'file');
-      assert(items[0].date);
-      assert(items[0].id);
-      assert(items[0].modified);
-      assert(items[0].size > 0);
-      assert(items[0].url.startsWith('http://'));
+      assert.ok(items.length === 1);
+      assert.ok(items[0].name === 'apilinks.json');
+      assert.ok(items[0].category === 'node');
+      assert.ok(items[0].type === 'file');
+      assert.ok(items[0].date);
+      assert.ok(items[0].id);
+      assert.ok(items[0].modified);
+      assert.ok(items[0].size > 0);
+      assert.ok(items[0].url.startsWith('http://'));
 
       res = await app
         .httpRequest()
         .get('/-/binary/node/latest/docs/apilinks.json');
       if (res.status === 200) {
-        assert(
+        assert.ok(
           res.headers['content-type'] === 'application/json; charset=utf-8'
         );
-        assert(
+        assert.ok(
           res.headers['content-disposition'] ===
             'attachment; filename="apilinks.json"'
         );
       } else {
-        assert(res.status === 302);
+        assert.ok(res.status === 302);
       }
 
       res = await app.httpRequest().get('/-/binary/node/foo/');
-      assert(res.status === 404);
-      assert(res.headers['content-type'] === 'application/json; charset=utf-8');
+      assert.ok(res.status === 404);
+      assert.ok(
+        res.headers['content-type'] === 'application/json; charset=utf-8'
+      );
       let data = res.body;
-      assert(data.error === '[NOT_FOUND] Binary "node/foo/" not found');
+      assert.ok(data.error === '[NOT_FOUND] Binary "node/foo/" not found');
 
       res = await app.httpRequest().get('/-/binary/node/foo.json');
-      assert(res.status === 404);
-      assert(res.headers['content-type'] === 'application/json; charset=utf-8');
+      assert.ok(res.status === 404);
+      assert.ok(
+        res.headers['content-type'] === 'application/json; charset=utf-8'
+      );
       data = res.body;
-      assert(data.error === '[NOT_FOUND] Binary "node/foo.json" not found');
+      assert.ok(data.error === '[NOT_FOUND] Binary "node/foo.json" not found');
 
       res = await app
         .httpRequest()
         .get('/-/binary/node/latest/docs/apilinks-404.json');
-      assert(res.status === 404);
-      assert(res.headers['content-type'] === 'application/json; charset=utf-8');
+      assert.ok(res.status === 404);
+      assert.ok(
+        res.headers['content-type'] === 'application/json; charset=utf-8'
+      );
       data = res.body;
-      assert(
+      assert.ok(
         data.error ===
           '[NOT_FOUND] Binary "node/latest/docs/apilinks-404.json" not found'
       );
@@ -383,7 +405,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
       );
       await binarySyncerService.createTask('@journeyapps/sqlcipher', {});
       const task = await binarySyncerService.findExecuteTask();
-      assert(task);
+      assert.ok(task);
       mock(SqlcipherBinary.prototype, 'fetch', async (dir: string) => {
         if (dir === '/') {
           return {
@@ -425,7 +447,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
         'application/json; charset=utf-8'
       );
       let items = res.body;
-      assert(items.length === 1);
+      assert.ok(items.length === 1);
 
       res = await app.httpRequest().get('/-/binary/@journeyapps/sqlcipher');
       assert.equal(res.status, 200);
@@ -434,11 +456,11 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
         'application/json; charset=utf-8'
       );
       items = res.body;
-      assert(items.length === 1);
-      assert(items[0].name === 'v5.3.1/');
-      assert(items[0].category === '@journeyapps/sqlcipher');
-      assert(items[0].type === 'dir');
-      assert(items[0].size === undefined);
+      assert.ok(items.length === 1);
+      assert.ok(items[0].name === 'v5.3.1/');
+      assert.ok(items[0].category === '@journeyapps/sqlcipher');
+      assert.ok(items[0].type === 'dir');
+      assert.ok(items[0].size === undefined);
 
       res = await app
         .httpRequest()
@@ -449,17 +471,17 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
         'application/json; charset=utf-8'
       );
       items = res.body;
-      assert(items.length === 1);
-      assert(items[0].name === 'napi-v6-win32-ia32.tar.gz');
-      assert(items[0].category === '@journeyapps/sqlcipher');
-      assert(items[0].type === 'file');
+      assert.ok(items.length === 1);
+      assert.ok(items[0].name === 'napi-v6-win32-ia32.tar.gz');
+      assert.ok(items[0].category === '@journeyapps/sqlcipher');
+      assert.ok(items[0].type === 'file');
       // assert(items[0].size === 1856939);
       // mock size
-      assert(items[0].size === 10_240);
-      assert(items[0].date === '2021-12-14T13:12:31.587Z');
-      assert(items[0].id);
-      assert(items[0].modified);
-      assert(items[0].url.startsWith('http://'));
+      assert.ok(items[0].size === 10_240);
+      assert.ok(items[0].date === '2021-12-14T13:12:31.587Z');
+      assert.ok(items[0].id);
+      assert.ok(items[0].modified);
+      assert.ok(items[0].url.startsWith('http://'));
 
       res = await app
         .httpRequest()
@@ -535,7 +557,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
       let res = await app.httpRequest().get('/-/binary/canvas');
 
       assert.strictEqual(res.status, 200);
-      assert(res.body);
+      assert.ok(res.body);
       let stableData = TestUtil.pickKeys(res.body, [
         'category',
         'name',
@@ -563,7 +585,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
       res = await app.httpRequest().get('/-/binary/node-canvas-prebuilt');
 
       assert.strictEqual(res.status, 200);
-      assert(res.body);
+      assert.ok(res.body);
       stableData = TestUtil.pickKeys(res.body, [
         'category',
         'name',
@@ -591,7 +613,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
       res = await app.httpRequest().get('/-/binary/canvas/v2.7.0/');
 
       assert.strictEqual(res.status, 200);
-      assert(res.body);
+      assert.ok(res.body);
       stableData = TestUtil.pickKeys(res.body, [
         'category',
         'name',
@@ -613,7 +635,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
       res = await app.httpRequest().get('/-/binary/canvas/v2.6.1/');
 
       assert.strictEqual(res.status, 200);
-      assert(res.body);
+      assert.ok(res.body);
       stableData = TestUtil.pickKeys(res.body, [
         'category',
         'name',
@@ -637,7 +659,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
         .get('/-/binary/node-canvas-prebuilt/v2.6.1/');
 
       assert.strictEqual(res.status, 200);
-      assert(res.body);
+      assert.ok(res.body);
       stableData = TestUtil.pickKeys(res.body, [
         'category',
         'name',

--- a/test/port/controller/ChangesStreamController/listChanges.test.ts
+++ b/test/port/controller/ChangesStreamController/listChanges.test.ts
@@ -32,7 +32,7 @@ describe('test/port/controller/ChangesStreamController/listChanges.test.ts', () 
       );
       assert.equal(res.body.results[0].type, 'PACKAGE_VERSION_ADDED');
       assert.equal(res.body.results[0].id, pkg.name);
-      assert(res.body.results[0].seq);
+      assert.ok(res.body.results[0].seq);
       assert.equal(
         res.body.results[0].changes.length,
         1,

--- a/test/port/controller/DownloadController/showPackageDownloads.test.ts
+++ b/test/port/controller/DownloadController/showPackageDownloads.test.ts
@@ -125,7 +125,7 @@ describe('test/port/controller/DownloadController/showPackageDownloads.test.ts',
         .expect('content-type', 'application/json; charset=utf-8');
       let data = res.body;
       // console.log(data);
-      assert(data.downloads.length > 0);
+      assert.ok(data.downloads.length > 0);
       assert.equal(data.downloads[0].downloads, 4);
       assert.equal(data.versions['1.0.0'][0].downloads, 3);
 
@@ -136,9 +136,9 @@ describe('test/port/controller/DownloadController/showPackageDownloads.test.ts',
         .expect('content-type', 'application/json; charset=utf-8');
       data = res.body;
       // console.log(data);
-      assert(data.downloads.length > 0);
-      assert(data.downloads[0].downloads === 1);
-      assert(data.versions['1.0.0'][0].downloads === 1);
+      assert.ok(data.downloads.length > 0);
+      assert.ok(data.downloads[0].downloads === 1);
+      assert.ok(data.versions['1.0.0'][0].downloads === 1);
 
       // __total__
       res = await app
@@ -148,9 +148,9 @@ describe('test/port/controller/DownloadController/showPackageDownloads.test.ts',
         .expect('content-type', 'application/json; charset=utf-8');
       data = res.body;
       // console.log(data);
-      assert(data.downloads.length > 0);
+      assert.ok(data.downloads.length > 0);
       assert.equal(data.downloads[0].downloads, 6);
-      assert(!data.versions);
+      assert.ok(!data.versions);
 
       // scope
       res = await app
@@ -160,9 +160,9 @@ describe('test/port/controller/DownloadController/showPackageDownloads.test.ts',
         .expect('content-type', 'application/json; charset=utf-8');
       data = res.body;
       // console.log(data);
-      assert(data.downloads.length > 0);
+      assert.ok(data.downloads.length > 0);
       assert.equal(data.downloads[0].downloads, 4);
-      assert(!data.versions);
+      assert.ok(!data.versions);
 
       res = await app
         .httpRequest()
@@ -171,9 +171,9 @@ describe('test/port/controller/DownloadController/showPackageDownloads.test.ts',
         .expect('content-type', 'application/json; charset=utf-8');
       data = res.body;
       // console.log(data);
-      assert(data.downloads.length > 0);
+      assert.ok(data.downloads.length > 0);
       assert.equal(data.downloads[0].downloads, 1);
-      assert(!data.versions);
+      assert.ok(!data.versions);
     });
 
     it('should get package download infos auto handle start and end position', async () => {
@@ -209,8 +209,8 @@ describe('test/port/controller/DownloadController/showPackageDownloads.test.ts',
         .expect('content-type', 'application/json; charset=utf-8');
       const data = res.body;
       // console.log(data);
-      assert(data.downloads.length > 0);
-      assert(data.versions);
+      assert.ok(data.downloads.length > 0);
+      assert.ok(data.versions);
     });
 
     it('should get package download infos with empty data', async () => {

--- a/test/port/controller/HomeController/cors.test.ts
+++ b/test/port/controller/HomeController/cors.test.ts
@@ -16,7 +16,7 @@ describe('test/port/controller/HomeController/cors.test.ts', () => {
         'https://www.test-cors.org'
       );
       assert.equal(res.headers['access-control-allow-credentials'], 'true');
-      assert(!res.headers['access-control-allow-methods']);
+      assert.ok(!res.headers['access-control-allow-methods']);
     });
 
     it('should OPTIONS work', async () => {

--- a/test/port/controller/HomeController/ping.test.ts
+++ b/test/port/controller/HomeController/ping.test.ts
@@ -5,9 +5,9 @@ describe('test/port/controller/HomeController/ping.test.ts', () => {
   describe('[GET /-/ping] ping()', () => {
     it('should 200', async () => {
       const res = await app.httpRequest().get('/-/ping').expect(200);
-      assert(res.body.pong === true);
+      assert.ok(res.body.pong === true);
       // console.log(res.body, res.headers['x-readtime']);
-      assert(res.headers['x-frame-options'] === 'SAMEORIGIN');
+      assert.ok(res.headers['x-frame-options'] === 'SAMEORIGIN');
     });
   });
 });

--- a/test/port/controller/HomeController/showTotal.test.ts
+++ b/test/port/controller/HomeController/showTotal.test.ts
@@ -287,7 +287,8 @@ describe('test/port/controller/HomeController/showTotal.test.ts', () => {
         const [upstream] = data.upstream_registries;
         assert.ok(upstream.registry_name === 'default');
         assert.ok(
-          upstream.changes_stream_url === 'https://replicate.npmjs.com/_changes'
+          upstream.changes_stream_url ===
+            'https://replicate.npmjs.com/registry/_changes'
         );
         assert.ok(upstream.source_registry === 'https://registry.npmjs.org');
       });
@@ -336,7 +337,7 @@ describe('test/port/controller/HomeController/showTotal.test.ts', () => {
         assert.ok(defaultRegistry.registry_name === 'default');
         assert.ok(
           defaultRegistry.changes_stream_url ===
-            'https://replicate.npmjs.com/_changes'
+            'https://replicate.npmjs.com/registry/_changes'
         );
         assert.ok(
           defaultRegistry.source_registry === 'https://registry.npmjs.org'

--- a/test/port/controller/HomeController/showTotal.test.ts
+++ b/test/port/controller/HomeController/showTotal.test.ts
@@ -40,19 +40,21 @@ describe('test/port/controller/HomeController/showTotal.test.ts', () => {
       totalRepository = await app.getEggObject(TotalRepository);
       await totalRepository.reset();
       let res = await app.httpRequest().get('/');
-      assert(res.status === 200);
-      assert(res.headers['content-type'] === 'application/json; charset=utf-8');
+      assert.ok(res.status === 200);
+      assert.ok(
+        res.headers['content-type'] === 'application/json; charset=utf-8'
+      );
       let data = res.body;
-      assert(typeof data.doc_count === 'number');
-      assert(typeof data.doc_version_count === 'number');
-      assert(typeof data.download.today === 'number');
-      assert(data.engine === app.config.orm.client);
-      assert(data.node_version === process.version);
+      assert.ok(typeof data.doc_count === 'number');
+      assert.ok(typeof data.doc_version_count === 'number');
+      assert.ok(typeof data.download.today === 'number');
+      assert.ok(data.engine === app.config.orm.client);
+      assert.ok(data.node_version === process.version);
       assert.match(data.egg_version, /^\d+\.\d+\.\d+/);
-      assert(data.instance_start_time);
-      assert(data.sync_model === 'none');
-      assert(data.sync_binary === false);
-      assert(typeof data.cache_time === 'string');
+      assert.ok(data.instance_start_time);
+      assert.ok(data.sync_model === 'none');
+      assert.ok(data.sync_binary === false);
+      assert.ok(typeof data.cache_time === 'string');
 
       // downloads count
       const publisher = await TestUtil.createUser();
@@ -100,20 +102,20 @@ describe('test/port/controller/HomeController/showTotal.test.ts', () => {
       await app.runSchedule(UpdateTotalDataPath);
 
       res = await app.httpRequest().get('/');
-      assert(res.status === 200);
+      assert.ok(res.status === 200);
       data = res.body;
-      assert(data.last_package === '@cnpm/home2');
-      assert(data.last_package_version === '@cnpm/home1@1.0.1');
+      assert.ok(data.last_package === '@cnpm/home2');
+      assert.ok(data.last_package_version === '@cnpm/home1@1.0.1');
       assert.equal(data.doc_count, 2);
-      assert(data.doc_version_count === 3);
-      assert(data.download.today === 3);
-      assert(data.download.yesterday === 0);
-      assert(data.download.thisweek === 3);
-      assert(data.download.thismonth === 3);
-      assert(data.download.thisyear === 3);
-      assert(data.download.lastweek === 0);
-      assert(data.download.lastmonth === 0);
-      assert(data.download.lastyear === 0);
+      assert.ok(data.doc_version_count === 3);
+      assert.ok(data.download.today === 3);
+      assert.ok(data.download.yesterday === 0);
+      assert.ok(data.download.thisweek === 3);
+      assert.ok(data.download.thismonth === 3);
+      assert.ok(data.download.thisyear === 3);
+      assert.ok(data.download.lastweek === 0);
+      assert.ok(data.download.lastmonth === 0);
+      assert.ok(data.download.lastyear === 0);
 
       // mock yesterday lastweek lastmonth
       const today = dayjs();
@@ -204,23 +206,23 @@ describe('test/port/controller/HomeController/showTotal.test.ts', () => {
 
       await app.runSchedule(UpdateTotalDataPath);
       res = await app.httpRequest().get('/');
-      assert(res.status === 200);
+      assert.ok(res.status === 200);
       data = res.body;
-      assert(data.last_package === '@cnpm/home2');
-      assert(data.last_package_version === '@cnpm/home1@1.0.1');
-      assert(data.doc_count === 2);
-      assert(data.doc_version_count === 3);
-      assert(data.download.today === 3);
-      assert(data.download.yesterday === 1);
-      assert(data.download.thisweek >= 3);
-      assert(data.download.thismonth >= 3);
-      assert(data.download.thisyear >= 3);
-      assert(data.download.samedayLastweek === 1);
-      assert(data.download.lastweek >= 1);
-      assert(data.download.lastmonth >= 1);
-      assert(data.download.lastyear >= 1);
-      assert(data.cache_time);
-      assert(data.update_seq > 0);
+      assert.ok(data.last_package === '@cnpm/home2');
+      assert.ok(data.last_package_version === '@cnpm/home1@1.0.1');
+      assert.ok(data.doc_count === 2);
+      assert.ok(data.doc_version_count === 3);
+      assert.ok(data.download.today === 3);
+      assert.ok(data.download.yesterday === 1);
+      assert.ok(data.download.thisweek >= 3);
+      assert.ok(data.download.thismonth >= 3);
+      assert.ok(data.download.thisyear >= 3);
+      assert.ok(data.download.samedayLastweek === 1);
+      assert.ok(data.download.lastweek >= 1);
+      assert.ok(data.download.lastmonth >= 1);
+      assert.ok(data.download.lastyear >= 1);
+      assert.ok(data.cache_time);
+      assert.ok(data.update_seq > 0);
       // console.log(data);
     });
 
@@ -232,7 +234,7 @@ describe('test/port/controller/HomeController/showTotal.test.ts', () => {
         .expect(200)
         .expect('content-type', 'application/json; charset=utf-8');
       const data = res.body;
-      assert(data.sync_model === 'all');
+      assert.ok(data.sync_model === 'all');
     });
 
     it('should show sync enableSyncBinary = true', async () => {
@@ -243,7 +245,7 @@ describe('test/port/controller/HomeController/showTotal.test.ts', () => {
         .expect(200)
         .expect('content-type', 'application/json; charset=utf-8');
       const data = res.body;
-      assert(data.sync_binary === true);
+      assert.ok(data.sync_binary === true);
     });
 
     describe('upstream_registries', async () => {
@@ -261,7 +263,7 @@ describe('test/port/controller/HomeController/showTotal.test.ts', () => {
           .expect(200)
           .expect('content-type', 'application/json; charset=utf-8');
         const data = res.body;
-        assert(data.upstream_registries.length === 0);
+        assert.ok(data.upstream_registries.length === 0);
       });
       it('should show default registry', async () => {
         // create default registry
@@ -271,9 +273,9 @@ describe('test/port/controller/HomeController/showTotal.test.ts', () => {
           type: TaskType.ChangesStream,
         });
         await changesStreamService.executeTask(tasks[0] as ChangesStreamTask);
-        assert(tasks.length === 1);
+        assert.ok(tasks.length === 1);
 
-        assert(registryManagerService);
+        assert.ok(registryManagerService);
         await app.runSchedule(UpdateTotalDataPath);
         const res = await app
           .httpRequest()
@@ -281,13 +283,13 @@ describe('test/port/controller/HomeController/showTotal.test.ts', () => {
           .expect(200)
           .expect('content-type', 'application/json; charset=utf-8');
         const data = res.body;
-        assert(data.upstream_registries.length === 1);
+        assert.ok(data.upstream_registries.length === 1);
         const [upstream] = data.upstream_registries;
-        assert(upstream.registry_name === 'default');
-        assert(
+        assert.ok(upstream.registry_name === 'default');
+        assert.ok(
           upstream.changes_stream_url === 'https://replicate.npmjs.com/_changes'
         );
-        assert(upstream.source_registry === 'https://registry.npmjs.org');
+        assert.ok(upstream.source_registry === 'https://registry.npmjs.org');
       });
 
       it('should show custom registry', async () => {
@@ -314,7 +316,7 @@ describe('test/port/controller/HomeController/showTotal.test.ts', () => {
         const tasks = await taskRepository.findTasksByCondition({
           type: TaskType.ChangesStream,
         });
-        assert(tasks.length === 2);
+        assert.ok(tasks.length === 2);
         for (const task of tasks) {
           await changesStreamService.executeTask(task as ChangesStreamTask);
         }
@@ -327,27 +329,27 @@ describe('test/port/controller/HomeController/showTotal.test.ts', () => {
           .expect(200)
           .expect('content-type', 'application/json; charset=utf-8');
         const data = res.body;
-        assert(data.upstream_registries.length === 2);
+        assert.ok(data.upstream_registries.length === 2);
         const [defaultRegistry] = data.upstream_registries.filter(
           (item: UpstreamRegistryInfo) => item.registry_name === 'default'
         );
-        assert(defaultRegistry.registry_name === 'default');
-        assert(
+        assert.ok(defaultRegistry.registry_name === 'default');
+        assert.ok(
           defaultRegistry.changes_stream_url ===
             'https://replicate.npmjs.com/_changes'
         );
-        assert(
+        assert.ok(
           defaultRegistry.source_registry === 'https://registry.npmjs.org'
         );
 
         const [customRegistry] = data.upstream_registries.filter(
           (item: UpstreamRegistryInfo) => item.registry_name === 'custom'
         );
-        assert(customRegistry.registry_name === 'custom');
-        assert(
+        assert.ok(customRegistry.registry_name === 'custom');
+        assert.ok(
           customRegistry.changes_stream_url === 'https://r.cnpmjs.org/_changes'
         );
-        assert(customRegistry.source_registry === 'https://cnpmjs.org');
+        assert.ok(customRegistry.source_registry === 'https://cnpmjs.org');
       });
     });
   });

--- a/test/port/controller/PackageBlockController/blockPackage.test.ts
+++ b/test/port/controller/PackageBlockController/blockPackage.test.ts
@@ -19,9 +19,9 @@ describe('test/port/controller/PackageBlockController/blockPackage.test.ts', () 
         .send({
           reason: 'only for tests',
         });
-      assert(res.status === 201);
-      assert(res.body.ok === true);
-      assert(res.body.id);
+      assert.ok(res.status === 201);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.id);
       const blockId = res.body.id;
 
       // block again should work
@@ -32,19 +32,19 @@ describe('test/port/controller/PackageBlockController/blockPackage.test.ts', () 
         .send({
           reason: 'only for tests again',
         });
-      assert(res.status === 201);
-      assert(res.body.ok === true);
-      assert(res.body.id === blockId);
+      assert.ok(res.status === 201);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.id === blockId);
 
       // get blocks
       res = await app.httpRequest().get(`/-/package/${pkg.name}/blocks`);
-      assert(res.status === 200);
-      assert(res.body.data.length === 1);
-      assert(res.body.data[0].id === blockId);
-      assert(res.body.data[0].version === '*');
-      assert(res.body.data[0].created);
-      assert(res.body.data[0].modified);
-      assert(
+      assert.ok(res.status === 200);
+      assert.ok(res.body.data.length === 1);
+      assert.ok(res.body.data[0].id === blockId);
+      assert.ok(res.body.data[0].version === '*');
+      assert.ok(res.body.data[0].created);
+      assert.ok(res.body.data[0].modified);
+      assert.ok(
         res.body.data[0].reason.includes(
           'only for tests again (operator: cnpmcore_admin/'
         )
@@ -52,16 +52,16 @@ describe('test/port/controller/PackageBlockController/blockPackage.test.ts', () 
 
       // request manifests will status 451
       res = await app.httpRequest().get(`/${pkg.name}`);
-      assert(res.status === 451);
-      assert(!res.headers.etag);
-      assert(!res.headers['cache-control']);
-      assert(res.body.error);
-      assert(
+      assert.ok(res.status === 451);
+      assert.ok(!res.headers.etag);
+      assert.ok(!res.headers['cache-control']);
+      assert.ok(res.body.error);
+      assert.ok(
         res.body.error.startsWith(
           '[UNAVAILABLE_FOR_LEGAL_REASONS] @cnpm/testmodule was blocked, reason: '
         )
       );
-      assert(
+      assert.ok(
         res.body.error.includes(
           'only for tests again (operator: cnpmcore_admin/'
         )
@@ -69,15 +69,15 @@ describe('test/port/controller/PackageBlockController/blockPackage.test.ts', () 
 
       res = await app.httpRequest().get(`/${pkg.name}/latest`);
       assert.equal(res.status, 451);
-      assert(!res.headers.etag);
-      assert(!res.headers['cache-control']);
-      assert(res.body.error);
-      assert(
+      assert.ok(!res.headers.etag);
+      assert.ok(!res.headers['cache-control']);
+      assert.ok(res.body.error);
+      assert.ok(
         res.body.error.startsWith(
           '[UNAVAILABLE_FOR_LEGAL_REASONS] @cnpm/testmodule@latest was blocked, reason: '
         )
       );
-      assert(
+      assert.ok(
         res.body.error.includes(
           'only for tests again (operator: cnpmcore_admin/'
         )
@@ -86,16 +86,16 @@ describe('test/port/controller/PackageBlockController/blockPackage.test.ts', () 
       // check cdn cache
       mock(app.config.cnpmcore, 'enableCDN', true);
       res = await app.httpRequest().get(`/${pkg.name}`);
-      assert(res.status === 451);
-      assert(!res.headers.etag);
+      assert.ok(res.status === 451);
+      assert.ok(!res.headers.etag);
       assert.equal(res.headers['cache-control'], 'public, max-age=300');
-      assert(res.body.error);
-      assert(
+      assert.ok(res.body.error);
+      assert.ok(
         res.body.error.startsWith(
           '[UNAVAILABLE_FOR_LEGAL_REASONS] @cnpm/testmodule was blocked, reason: '
         )
       );
-      assert(
+      assert.ok(
         res.body.error.includes(
           'only for tests again (operator: cnpmcore_admin/'
         )
@@ -103,15 +103,15 @@ describe('test/port/controller/PackageBlockController/blockPackage.test.ts', () 
 
       res = await app.httpRequest().get(`/${pkg.name}/1.0.0`);
       assert.equal(res.status, 451);
-      assert(!res.headers.etag);
+      assert.ok(!res.headers.etag);
       assert.equal(res.headers['cache-control'], 'public, max-age=300');
-      assert(res.body.error);
-      assert(
+      assert.ok(res.body.error);
+      assert.ok(
         res.body.error.startsWith(
           '[UNAVAILABLE_FOR_LEGAL_REASONS] @cnpm/testmodule@1.0.0 was blocked, reason: '
         )
       );
-      assert(
+      assert.ok(
         res.body.error.includes(
           'only for tests again (operator: cnpmcore_admin/'
         )
@@ -127,8 +127,8 @@ describe('test/port/controller/PackageBlockController/blockPackage.test.ts', () 
         .send({
           reason: 'only for tests',
         });
-      assert(res.status === 403);
-      assert(
+      assert.ok(res.status === 403);
+      assert.ok(
         res.body.error ===
           '[FORBIDDEN] Can\'t block private package "@cnpm/testmodule"'
       );
@@ -144,14 +144,14 @@ describe('test/port/controller/PackageBlockController/blockPackage.test.ts', () 
         .send({
           reason: 'only for tests',
         });
-      assert(res.status === 403);
-      assert(res.body.error === '[FORBIDDEN] Not allow to access');
+      assert.ok(res.status === 403);
+      assert.ok(res.body.error === '[FORBIDDEN] Not allow to access');
 
       res = await app.httpRequest().put(`/-/package/${pkg.name}/blocks`).send({
         reason: 'only for tests',
       });
-      assert(res.status === 403);
-      assert(res.body.error === '[FORBIDDEN] Not allow to access');
+      assert.ok(res.status === 403);
+      assert.ok(res.body.error === '[FORBIDDEN] Not allow to access');
     });
   });
 });

--- a/test/port/controller/PackageBlockController/unblockPackage.test.ts
+++ b/test/port/controller/PackageBlockController/unblockPackage.test.ts
@@ -16,8 +16,8 @@ describe('test/port/controller/PackageBlockController/unblockPackage.test.ts', (
         .httpRequest()
         .delete(`/-/package/${pkg.name}/blocks`)
         .set('authorization', adminUser.authorization);
-      assert(res.status === 200);
-      assert(res.body.ok === true);
+      assert.ok(res.status === 200);
+      assert.ok(res.body.ok === true);
 
       res = await app
         .httpRequest()
@@ -26,21 +26,21 @@ describe('test/port/controller/PackageBlockController/unblockPackage.test.ts', (
         .send({
           reason: 'only for tests',
         });
-      assert(res.status === 201);
-      assert(res.body.ok === true);
-      assert(res.body.id);
+      assert.ok(res.status === 201);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.id);
 
       res = await app
         .httpRequest()
         .delete(`/-/package/${pkg.name}/blocks`)
         .set('authorization', adminUser.authorization);
-      assert(res.status === 200);
-      assert(res.body.ok === true);
+      assert.ok(res.status === 200);
+      assert.ok(res.body.ok === true);
 
       // get blocks
       res = await app.httpRequest().get(`/-/package/${pkg.name}/blocks`);
-      assert(res.status === 200);
-      assert(res.body.data.length === 0);
+      assert.ok(res.status === 200);
+      assert.ok(res.body.data.length === 0);
 
       // block again
       res = await app
@@ -50,22 +50,22 @@ describe('test/port/controller/PackageBlockController/unblockPackage.test.ts', (
         .send({
           reason: 'only for tests',
         });
-      assert(res.status === 201);
-      assert(res.body.ok === true);
+      assert.ok(res.status === 201);
+      assert.ok(res.body.ok === true);
       res = await app.httpRequest().get(`/-/package/${pkg.name}/blocks`);
-      assert(res.status === 200);
-      assert(res.body.data.length === 1);
+      assert.ok(res.status === 200);
+      assert.ok(res.body.data.length === 1);
 
       // unblock gain
       res = await app
         .httpRequest()
         .delete(`/-/package/${pkg.name}/blocks`)
         .set('authorization', adminUser.authorization);
-      assert(res.status === 200);
-      assert(res.body.ok === true);
+      assert.ok(res.status === 200);
+      assert.ok(res.body.ok === true);
       res = await app.httpRequest().get(`/-/package/${pkg.name}/blocks`);
-      assert(res.status === 200);
-      assert(res.body.data.length === 0);
+      assert.ok(res.status === 200);
+      assert.ok(res.body.data.length === 0);
     });
 
     it('should 403 block private package', async () => {
@@ -74,8 +74,8 @@ describe('test/port/controller/PackageBlockController/unblockPackage.test.ts', (
         .httpRequest()
         .delete(`/-/package/${pkg.name}/blocks`)
         .set('authorization', adminUser.authorization);
-      assert(res.status === 403);
-      assert(
+      assert.ok(res.status === 403);
+      assert.ok(
         res.body.error ===
           '[FORBIDDEN] Can\'t unblock private package "@cnpm/testmodule"'
       );
@@ -88,12 +88,12 @@ describe('test/port/controller/PackageBlockController/unblockPackage.test.ts', (
         .httpRequest()
         .delete(`/-/package/${pkg.name}/blocks`)
         .set('authorization', user.authorization);
-      assert(res.status === 403);
-      assert(res.body.error === '[FORBIDDEN] Not allow to access');
+      assert.ok(res.status === 403);
+      assert.ok(res.body.error === '[FORBIDDEN] Not allow to access');
 
       res = await app.httpRequest().delete(`/-/package/${pkg.name}/blocks`);
-      assert(res.status === 403);
-      assert(res.body.error === '[FORBIDDEN] Not allow to access');
+      assert.ok(res.status === 403);
+      assert.ok(res.body.error === '[FORBIDDEN] Not allow to access');
     });
   });
 });

--- a/test/port/controller/PackageSyncController/createSyncTask.test.ts
+++ b/test/port/controller/PackageSyncController/createSyncTask.test.ts
@@ -20,7 +20,7 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
         .httpRequest()
         .put('/-/package/koa/syncs')
         .expect(403);
-      assert(res.body.error === '[FORBIDDEN] Not allow to sync package');
+      assert.ok(res.body.error === '[FORBIDDEN] Not allow to sync package');
     });
 
     it('should 403 when syncMode = admin', async () => {
@@ -29,7 +29,9 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
         .httpRequest()
         .put('/-/package/koa/syncs')
         .expect(403);
-      assert(res.body.error === '[FORBIDDEN] Only admin allow to sync package');
+      assert.ok(
+        res.body.error === '[FORBIDDEN] Only admin allow to sync package'
+      );
     });
 
     it('should 201 when syncMode = admin & login as admin', async () => {
@@ -48,7 +50,7 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
         .httpRequest()
         .put('/-/package/koa/syncs')
         .expect(401);
-      assert(res.body.error === '[UNAUTHORIZED] Login first');
+      assert.ok(res.body.error === '[UNAUTHORIZED] Login first');
     });
 
     it('should 403 if when sync private package', async () => {
@@ -67,7 +69,7 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
         .httpRequest()
         .put(`/-/package/${pkg.name}/syncs`)
         .expect(403);
-      assert(
+      assert.ok(
         res.body.error === '[FORBIDDEN] Can\'t sync private package "@cnpm/koa"'
       );
     });
@@ -93,10 +95,10 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
         .put('/-/package/koa/syncs')
         .set('authorization', publisher.authorization)
         .expect(201);
-      assert(res.body.ok === true);
-      assert(res.body.type === 'sync_package');
-      assert(res.body.state === 'waiting');
-      assert(res.body.id);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.type === 'sync_package');
+      assert.ok(res.body.state === 'waiting');
+      assert.ok(res.body.id);
     });
 
     it('should 201 if user login when alwaysAuth = false', async () => {
@@ -106,9 +108,9 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
         .put('/-/package/koa/syncs')
         .set('authorization', publisher.authorization)
         .expect(201);
-      assert(res.body.ok === true);
-      assert(res.body.state === 'waiting');
-      assert(res.body.id);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.state === 'waiting');
+      assert.ok(res.body.id);
       app.notExpectLog(
         '[PackageSyncController.createSyncTask:execute-immediately]'
       );
@@ -122,9 +124,9 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
         .set('authorization', publisher.authorization)
         .send({ force: true })
         .expect(201);
-      assert(res.body.ok === true);
-      assert(res.body.state === 'waiting');
-      assert(res.body.id);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.state === 'waiting');
+      assert.ok(res.body.id);
       app.notExpectLog(
         '[PackageSyncController.createSyncTask:execute-immediately]'
       );
@@ -144,9 +146,9 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
         .set('authorization', admin.authorization)
         .send({ force: true })
         .expect(201);
-      assert(res.body.ok === true);
-      assert(res.body.state === 'waiting');
-      assert(res.body.id);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.state === 'waiting');
+      assert.ok(res.body.id);
       await setTimeout(100); // await for sync task started
       app.expectLog(
         '[PackageSyncController.createSyncTask:execute-immediately]'
@@ -166,7 +168,7 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
         .send({ registryName: 'invalid' })
         .expect(403);
 
-      assert(res.body.error.includes("Can't find target registry"));
+      assert.ok(res.body.error.includes("Can't find target registry"));
     });
 
     it('should check the packageEntity registryId', async () => {
@@ -196,7 +198,7 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
         .send({ registryName: 'cnpm' })
         .expect(403);
 
-      assert(res.body.error.includes('The package is synced from'));
+      assert.ok(res.body.error.includes('The package is synced from'));
     });
 
     it('should ignore the packageEntity registryId when registry not exists', async () => {
@@ -225,9 +227,9 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
         .set('authorization', admin.authorization)
         .send()
         .expect(201);
-      assert(res.body.ok === true);
-      assert(res.body.state === 'waiting');
-      assert(res.body.id);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.state === 'waiting');
+      assert.ok(res.body.id);
     });
 
     it('should sync immediately and mock executeTask error when admin user request', async () => {
@@ -240,9 +242,9 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
         .set('authorization', admin.authorization)
         .send({ force: true })
         .expect(201);
-      assert(res.body.ok === true);
-      assert(res.body.state === 'waiting');
-      assert(res.body.id);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.state === 'waiting');
+      assert.ok(res.body.id);
       app.expectLog(
         '[PackageSyncController.createSyncTask:execute-immediately]'
       );
@@ -254,27 +256,27 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
 
     it('should 201 if user not login when alwaysAuth = false', async () => {
       let res = await app.httpRequest().put('/-/package/koa/syncs').expect(201);
-      assert(res.body.ok === true);
-      assert(res.body.state === 'waiting');
-      assert(res.body.id);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.state === 'waiting');
+      assert.ok(res.body.id);
       let task = await TaskModel.findOne({ taskId: res.body.id });
-      assert(task);
-      assert(task.data.skipDependencies === false);
-      assert(task.data.syncDownloadData === false);
+      assert.ok(task);
+      assert.ok(task.data.skipDependencies === false);
+      assert.ok(task.data.syncDownloadData === false);
 
       res = await app
         .httpRequest()
         .put('/-/package/ob/syncs')
         .send({ skipDependencies: true, tips: 'foo bar' })
         .expect(201);
-      assert(res.body.ok === true);
-      assert(res.body.state === 'waiting');
-      assert(res.body.id);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.state === 'waiting');
+      assert.ok(res.body.id);
       task = await TaskModel.findOne({ taskId: res.body.id });
-      assert(task);
-      assert(task.data.skipDependencies === true);
-      assert(task.data.syncDownloadData === false);
-      assert(task.data.tips === 'foo bar');
+      assert.ok(task);
+      assert.ok(task.data.skipDependencies === true);
+      assert.ok(task.data.syncDownloadData === false);
+      assert.ok(task.data.tips === 'foo bar');
     });
 
     it('should 422 when enableSyncDownloadData = false', async () => {
@@ -282,8 +284,8 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
         .httpRequest()
         .put('/-/package/ob/syncs')
         .send({ syncDownloadData: true });
-      assert(res.status === 403);
-      assert(
+      assert.ok(res.status === 403);
+      assert.ok(
         res.body.error === '[FORBIDDEN] Not allow to sync package download data'
       );
 
@@ -298,8 +300,8 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
         .httpRequest()
         .put('/-/package/ob/syncs')
         .send({ syncDownloadData: true });
-      assert(res.status === 403);
-      assert(
+      assert.ok(res.status === 403);
+      assert.ok(
         res.body.error === '[FORBIDDEN] Not allow to sync package download data'
       );
 
@@ -310,8 +312,8 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
         .httpRequest()
         .put('/-/package/ob/syncs')
         .send({ syncDownloadData: true });
-      assert(res.status === 403);
-      assert(
+      assert.ok(res.status === 403);
+      assert.ok(
         res.body.error === '[FORBIDDEN] Not allow to sync package download data'
       );
     });
@@ -328,40 +330,40 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
         .httpRequest()
         .put('/-/package/ob/syncs')
         .send({ syncDownloadData: true });
-      assert(res.status === 201);
-      assert(res.body.ok === true);
-      assert(res.body.state === 'waiting');
-      assert(res.body.id);
+      assert.ok(res.status === 201);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.state === 'waiting');
+      assert.ok(res.body.id);
       const task = await TaskModel.findOne({ taskId: res.body.id });
-      assert(task);
-      assert(task.data.syncDownloadData === true);
+      assert.ok(task);
+      assert.ok(task.data.syncDownloadData === true);
     });
 
     it('should dont create exists waiting task', async () => {
       let res = await app.httpRequest().put('/-/package/koa/syncs').expect(201);
-      assert(res.body.ok === true);
-      assert(res.body.state === 'waiting');
-      assert(res.body.id);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.state === 'waiting');
+      assert.ok(res.body.id);
       const firstTaskId = res.body.id;
       // again dont create
       res = await app.httpRequest().put('/-/package/koa/syncs').expect(201);
-      assert(res.body.ok === true);
-      assert(res.body.state === 'waiting');
-      assert(res.body.id === firstTaskId);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.state === 'waiting');
+      assert.ok(res.body.id === firstTaskId);
     });
 
     it('should dont create exists waiting task', async () => {
       let res = await app.httpRequest().put('/-/package/koa/syncs').expect(201);
-      assert(res.body.ok === true);
-      assert(res.body.state === 'waiting');
-      assert(res.body.id);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.state === 'waiting');
+      assert.ok(res.body.id);
       const firstTaskId = res.body.id;
 
       // again dont create
       res = await app.httpRequest().put('/-/package/koa/syncs').expect(201);
-      assert(res.body.ok === true);
-      assert(res.body.state === 'waiting');
-      assert(res.body.id === firstTaskId);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.state === 'waiting');
+      assert.ok(res.body.id === firstTaskId);
 
       // update bigger than 1 min, same task return
       await TaskModel.update(
@@ -369,9 +371,9 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
         { updatedAt: new Date(Date.now() - 60_001) }
       );
       res = await app.httpRequest().put('/-/package/koa/syncs').expect(201);
-      assert(res.body.ok === true);
-      assert(res.body.state === 'waiting');
-      assert(res.body.id === firstTaskId);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.state === 'waiting');
+      assert.ok(res.body.id === firstTaskId);
     });
   });
 
@@ -379,13 +381,15 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
     it('should 403 when syncMode = none', async () => {
       mock(app.config.cnpmcore, 'syncMode', 'none');
       const res = await app.httpRequest().put('/koa/sync').expect(403);
-      assert(res.body.error === '[FORBIDDEN] Not allow to sync package');
+      assert.ok(res.body.error === '[FORBIDDEN] Not allow to sync package');
     });
 
     it('should 403 when syncMode = admin', async () => {
       mock(app.config.cnpmcore, 'syncMode', 'admin');
       const res = await app.httpRequest().put('/koa/sync').expect(403);
-      assert(res.body.error === '[FORBIDDEN] Only admin allow to sync package');
+      assert.ok(
+        res.body.error === '[FORBIDDEN] Only admin allow to sync package'
+      );
     });
 
     it('should 201 when syncMode = admin & login as admin', async () => {
@@ -400,23 +404,23 @@ describe('test/port/controller/PackageSyncController/createSyncTask.test.ts', ()
 
     it('should 201', async () => {
       let res = await app.httpRequest().put('/koa/sync').expect(201);
-      assert(res.body.ok === true);
-      assert(res.body.logId);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.logId);
       let task = await TaskModel.findOne({ taskId: res.body.logId });
-      assert(task);
-      assert(task.data.skipDependencies === false);
+      assert.ok(task);
+      assert.ok(task.data.skipDependencies === false);
 
       res = await app.httpRequest().put('/koa/sync?nodeps=true').expect(201);
-      assert(res.body.ok === true);
-      assert(res.body.logId);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.logId);
 
       res = await app.httpRequest().put('/ob/sync?nodeps=true').expect(201);
-      assert(res.body.ok === true);
-      assert(res.body.logId);
+      assert.ok(res.body.ok === true);
+      assert.ok(res.body.logId);
       // skipDependencies should be true
       task = await TaskModel.findOne({ taskId: res.body.logId });
-      assert(task);
-      assert(task.data.skipDependencies === true);
+      assert.ok(task);
+      assert.ok(task.data.skipDependencies === true);
     });
   });
 });

--- a/test/port/controller/PackageSyncController/showSyncTask.test.ts
+++ b/test/port/controller/PackageSyncController/showSyncTask.test.ts
@@ -59,24 +59,24 @@ describe('test/port/controller/PackageSyncController/showSyncTask.test.ts', () =
 
     it('should 200', async () => {
       let res = await app.httpRequest().put('/-/package/koa/syncs');
-      assert(res.status === 201);
-      assert(res.body.id);
+      assert.ok(res.status === 201);
+      assert.ok(res.body.id);
       const task = await taskRepository.findTask(res.body.id);
-      assert(task);
+      assert.ok(task);
       res = await app.httpRequest().get(`/-/package/koa/syncs/${task.taskId}`);
-      assert(res.status === 200);
-      assert(res.body.id);
+      assert.ok(res.status === 200);
+      assert.ok(res.body.id);
       // waiting state logUrl is not exists
-      assert(!res.body.logUrl);
+      assert.ok(!res.body.logUrl);
 
       task.state = TaskState.Processing;
       await taskRepository.saveTask(task);
       res = await app.httpRequest().get(`/-/package/koa/syncs/${task.taskId}`);
-      assert(res.status === 200);
-      assert(res.body.id);
-      assert(res.body.logUrl);
-      assert(res.body.logUrl.startsWith('http://localhost:7001/-/package/'));
-      assert(res.body.logUrl.endsWith('/log'));
+      assert.ok(res.status === 200);
+      assert.ok(res.body.id);
+      assert.ok(res.body.logUrl);
+      assert.ok(res.body.logUrl.startsWith('http://localhost:7001/-/package/'));
+      assert.ok(res.body.logUrl.endsWith('/log'));
     });
 
     it('should get sucess task after schedule run', async () => {
@@ -106,13 +106,13 @@ describe('test/port/controller/PackageSyncController/showSyncTask.test.ts', () =
         .put(`/-/package/${name}/syncs`)
         .expect(201);
       const taskId = res.body.id;
-      assert(taskId);
+      assert.ok(taskId);
       res = await app
         .httpRequest()
         .get(`/-/package/${name}/syncs/${taskId}`)
         .expect(200);
       // waiting state logUrl is not exists
-      assert(!res.body.logUrl);
+      assert.ok(!res.body.logUrl);
       await app.runSchedule(SyncPackageWorkerPath);
       // again should work
       await app.runSchedule(SyncPackageWorkerPath);
@@ -122,7 +122,7 @@ describe('test/port/controller/PackageSyncController/showSyncTask.test.ts', () =
         .get(`/-/package/${name}/syncs/${taskId}`)
         .expect(200);
       assert.equal(res.body.state, TaskState.Success);
-      assert(res.body.logUrl);
+      assert.ok(res.body.logUrl);
 
       res = await app
         .httpRequest()
@@ -139,16 +139,16 @@ describe('test/port/controller/PackageSyncController/showSyncTask.test.ts', () =
       // check hasInstallScript
       res = await app.httpRequest().get(`/${name}`).expect(200);
       let pkg = res.body.versions['3.0.0'];
-      assert(!('hasInstallScript' in pkg));
-      assert(pkg.scripts);
+      assert.ok(!('hasInstallScript' in pkg));
+      assert.ok(pkg.scripts);
       res = await app
         .httpRequest()
         .get(`/${name}`)
         .set('accept', 'application/vnd.npm.install-v1+json')
         .expect(200);
       pkg = res.body.versions['3.0.0'];
-      assert(pkg.hasInstallScript === true);
-      assert(!pkg.scripts);
+      assert.ok(pkg.hasInstallScript === true);
+      assert.ok(!pkg.scripts);
     });
   });
 
@@ -166,19 +166,19 @@ describe('test/port/controller/PackageSyncController/showSyncTask.test.ts', () =
 
     it('should 200', async () => {
       let res = await app.httpRequest().put('/koa/sync').expect(201);
-      assert(res.body.logId);
+      assert.ok(res.body.logId);
       const task = await taskRepository.findTask(res.body.logId);
-      assert(task);
+      assert.ok(task);
 
       res = await app
         .httpRequest()
         .get(`/koa/sync/log/${task.taskId}`)
         .expect(200);
-      assert(res.body.ok);
+      assert.ok(res.body.ok);
       // waiting state logUrl is not exists
-      assert(!res.body.logUrl);
+      assert.ok(!res.body.logUrl);
       assert.equal(res.body.syncDone, false);
-      assert(res.body.log);
+      assert.ok(res.body.log);
 
       task.state = TaskState.Processing;
       await taskRepository.saveTask(task);
@@ -187,11 +187,11 @@ describe('test/port/controller/PackageSyncController/showSyncTask.test.ts', () =
         .httpRequest()
         .get(`/koa/sync/log/${task.taskId}?t=123`)
         .expect(200);
-      assert(res.body.logUrl);
+      assert.ok(res.body.logUrl);
       assert.match(res.body.logUrl, /^http:\/\/localhost:7001\/-\/package\//);
       assert.match(res.body.logUrl, /\/log$/);
       assert.equal(res.body.syncDone, false);
-      assert(res.body.log);
+      assert.ok(res.body.log);
 
       // finish
       task.state = TaskState.Success;
@@ -201,7 +201,7 @@ describe('test/port/controller/PackageSyncController/showSyncTask.test.ts', () =
         .httpRequest()
         .get(`/koa/sync/log/${task.taskId}`)
         .expect(200);
-      assert(res.body.logUrl);
+      assert.ok(res.body.logUrl);
       assert.match(res.body.logUrl, /^http:\/\//);
       assert.match(res.body.logUrl, /\/log$/);
       assert.equal(res.body.syncDone, true);

--- a/test/port/controller/PackageSyncController/showSyncTaskLog.test.ts
+++ b/test/port/controller/PackageSyncController/showSyncTaskLog.test.ts
@@ -50,9 +50,9 @@ describe('test/port/controller/PackageSyncController/showSyncTaskLog.test.ts', (
 
     it('should 200 and 302', async () => {
       let res = await app.httpRequest().put('/-/package/koa/syncs').expect(201);
-      assert(res.body.id);
+      assert.ok(res.body.id);
       const task = await taskRepository.findTask(res.body.id);
-      assert(task);
+      assert.ok(task);
       // waiting state logUrl is not exists
       res = await app
         .httpRequest()
@@ -99,7 +99,7 @@ describe('test/port/controller/PackageSyncController/showSyncTaskLog.test.ts', (
         assert.equal(res.headers['content-type'], 'text/plain; charset=utf-8');
       } else {
         assert.equal(res.status, 302);
-        assert(res.headers.location);
+        assert.ok(res.headers.location);
         const log = await TestUtil.readStreamToLog(res.headers.location);
         assert.equal(log, 'hello log file 😄\nsencod line here');
       }

--- a/test/port/controller/PackageTagController/showTags.test.ts
+++ b/test/port/controller/PackageTagController/showTags.test.ts
@@ -22,26 +22,26 @@ describe('test/port/controller/PackageTagController/showTags.test.ts', () => {
     it('should 404 when package not exists on syncMode=all', async () => {
       mock(app.config.cnpmcore, 'syncMode', 'all');
       let res = await app.httpRequest().get('/-/package/not-exists/dist-tags');
-      assert(res.status === 404);
-      assert(res.body.error === '[NOT_FOUND] not-exists not found');
+      assert.ok(res.status === 404);
+      assert.ok(res.body.error === '[NOT_FOUND] not-exists not found');
 
       res = await app.httpRequest().get('/-/package/@foo/not-exists/dist-tags');
-      assert(res.status === 404);
-      assert(res.body.error === '[NOT_FOUND] @foo/not-exists not found');
+      assert.ok(res.status === 404);
+      assert.ok(res.body.error === '[NOT_FOUND] @foo/not-exists not found');
     });
 
     it('should 302 when package not exists on syncMode=none', async () => {
       mock(app.config.cnpmcore, 'syncMode', 'none');
       let res = await app.httpRequest().get('/-/package/not-exists/dist-tags');
-      assert(res.status === 302);
-      assert(
+      assert.ok(res.status === 302);
+      assert.ok(
         res.headers.location ===
           'https://registry.npmjs.org/-/package/not-exists/dist-tags'
       );
 
       res = await app.httpRequest().get('/-/package/@foo/not-exists/dist-tags');
-      assert(res.status === 302);
-      assert(
+      assert.ok(res.status === 302);
+      assert.ok(
         res.headers.location ===
           'https://registry.npmjs.org/-/package/@foo/not-exists/dist-tags'
       );

--- a/test/port/controller/PackageVersionFileController/listFiles.test.ts
+++ b/test/port/controller/PackageVersionFileController/listFiles.test.ts
@@ -718,8 +718,8 @@ describe('test/port/controller/PackageVersionFileController/listFiles.test.ts', 
         .httpRequest()
         .get(`/${pkg.name}/1.0.40000404/files`)
         .expect(404);
-      assert(!res.headers.etag);
-      assert(!res.headers['cache-control']);
+      assert.ok(!res.headers.etag);
+      assert.ok(!res.headers['cache-control']);
       assert.equal(
         res.body.error,
         `[NOT_FOUND] ${pkg.name}@1.0.40000404 not found`
@@ -731,8 +731,8 @@ describe('test/port/controller/PackageVersionFileController/listFiles.test.ts', 
         .httpRequest()
         .get('/@cnpm/foonot-exists/1.0.40000404/files')
         .expect(404);
-      assert(!res.headers.etag);
-      assert(!res.headers['cache-control']);
+      assert.ok(!res.headers.etag);
+      assert.ok(!res.headers['cache-control']);
       assert.equal(
         res.body.error,
         '[NOT_FOUND] @cnpm/foonot-exists@1.0.40000404 not found'
@@ -949,7 +949,7 @@ describe('test/port/controller/PackageVersionFileController/listFiles.test.ts', 
           .get('/@cnpm/foo/1.0.0/files/package.json')
           .expect('content-type', 'application/json; charset=utf-8');
         assert.equal(res.status, 200);
-        assert(res.body.name);
+        assert.ok(res.body.name);
       });
 
       it('should 200 when package version in white list', async () => {
@@ -999,7 +999,7 @@ describe('test/port/controller/PackageVersionFileController/listFiles.test.ts', 
           .get('/foo/1.0.0/files/package.json')
           .expect('content-type', 'application/json; charset=utf-8');
         assert.equal(res.status, 200);
-        assert(res.body.name);
+        assert.ok(res.body.name);
 
         pkg = await TestUtil.getFullPackage({
           name: 'foo',
@@ -1021,7 +1021,7 @@ describe('test/port/controller/PackageVersionFileController/listFiles.test.ts', 
           .get('/foo/1.0.1/files/package.json')
           .expect('content-type', 'application/json; charset=utf-8');
         assert.equal(res.status, 200);
-        assert(res.body.name);
+        assert.ok(res.body.name);
 
         // unpkg-white-list change
         pkg = await TestUtil.getFullPackage({
@@ -1126,7 +1126,7 @@ describe('test/port/controller/PackageVersionFileController/listFiles.test.ts', 
           .get('/foo/0.0.0/files/package.json')
           .expect('content-type', 'application/json; charset=utf-8');
         assert.equal(res.status, 200);
-        assert(res.body.name);
+        assert.ok(res.body.name);
 
         pkg = await TestUtil.getFullPackage({
           name: 'foo',
@@ -1148,7 +1148,7 @@ describe('test/port/controller/PackageVersionFileController/listFiles.test.ts', 
           .get('/foo/0.3.0-rc15/files/package.json')
           .expect('content-type', 'application/json; charset=utf-8');
         assert.equal(res.status, 200);
-        assert(res.body.name);
+        assert.ok(res.body.name);
 
         pkg = await TestUtil.getFullPackage({
           name: 'baz',
@@ -1170,7 +1170,7 @@ describe('test/port/controller/PackageVersionFileController/listFiles.test.ts', 
           .get('/baz/0.3.0-rc15/files/package.json')
           .expect('content-type', 'application/json; charset=utf-8');
         assert.equal(res.status, 200);
-        assert(res.body.name);
+        assert.ok(res.body.name);
 
         pkg = await TestUtil.getFullPackage({
           name: 'bar',

--- a/test/port/controller/PackageVersionFileController/raw.test.ts
+++ b/test/port/controller/PackageVersionFileController/raw.test.ts
@@ -62,7 +62,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
       // console.log(res.body);
       assert.equal(res.headers['cache-control'], 'public, max-age=31536000');
       assert.equal(res.headers.vary, 'Origin, Accept, Accept-Encoding');
-      assert(!res.headers['content-disposition']);
+      assert.ok(!res.headers['content-disposition']);
       assert.deepEqual(res.body, {
         name: 'mk2testmodule',
         version: '0.0.1',
@@ -262,8 +262,8 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
         .httpRequest()
         .get('/foo/1.0.0/files/package2.json?meta')
         .expect(404);
-      assert(!res.headers.etag);
-      assert(!res.headers['cache-control']);
+      assert.ok(!res.headers.etag);
+      assert.ok(!res.headers['cache-control']);
       assert.equal(
         res.body.error,
         `[NOT_FOUND] File ${pkg.name}@1.0.0/package2.json not found`
@@ -345,7 +345,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
       res = await app.httpRequest().get(`/${pkg.name}/1.0.0/files/resource/`);
       assert.equal(res.status, 200);
       // console.log(res.body);
-      assert(
+      assert.ok(
         res.body.files.find(
           (file: { path: string }) => file.path === '/resource/ToOneFromχ.js'
         )
@@ -394,7 +394,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
       assert.equal(res.status, 201);
       res = await app.httpRequest().get(`/${pkg.name}/1.0.0/files/`);
       assert.equal(res.status, 200);
-      assert(
+      assert.ok(
         res.body.files.find(
           (file: { path: string }) => file.path === '/package.json'
         )
@@ -445,7 +445,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
         res.body.files.find((file: { path: string }) => file.path === '/.'),
         undefined
       );
-      assert(
+      assert.ok(
         res.body.files.find((file: { path: string }) => file.path === '/dist')
       );
       const packageTagAdded = await app.getEggObject(
@@ -495,7 +495,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
       res = await app.httpRequest().get(`/${pkg.name}/1.0.0/files/`);
       assert.equal(res.status, 200);
       // console.log('%o', res.body);
-      assert(
+      assert.ok(
         res.body.files.find(
           (file: { path: string }) => file.path === '/CONTRIBUTING.md'
         )
@@ -503,7 +503,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
       let testDir = res.body.files.find(
         (file: { path: string }) => file.path === '/tests'
       );
-      assert(testDir);
+      assert.ok(testDir);
       assert.equal(testDir.files.length, 0);
       assert.equal(
         res.headers['cache-control'],
@@ -528,7 +528,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
       res = await app.httpRequest().get(`/${pkg.name}/1.0.0/files?meta=true`);
       assert.equal(res.status, 200);
       // console.log('%o', res.body);
-      assert(
+      assert.ok(
         res.body.files.find(
           (file: { path: string }) => file.path === '/CONTRIBUTING.md'
         )
@@ -536,7 +536,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
       testDir = res.body.files.find(
         (file: { path: string }) => file.path === '/tests'
       );
-      assert(testDir);
+      assert.ok(testDir);
       assert.equal(testDir.files.length, 0);
       assert.equal(
         res.headers['cache-control'],
@@ -597,7 +597,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
         res.headers['content-type'],
         'application/json; charset=utf-8'
       );
-      assert(!res.headers['content-disposition']);
+      assert.ok(!res.headers['content-disposition']);
       assert.deepEqual(res.body, {
         path: '/docs/_site/getting-started.html',
         type: 'file',
@@ -628,7 +628,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
       const integrationDir = res.body.files.find(
         (file: { path: string }) => file.path === '/tests/integration'
       );
-      assert(integrationDir);
+      assert.ok(integrationDir);
       assert.equal(integrationDir.files.length, 0);
       assert.equal(integrationDir.type, 'directory');
 
@@ -641,7 +641,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
         res.headers['content-type'],
         'application/javascript; charset=utf-8'
       );
-      assert(!res.headers['content-disposition']);
+      assert.ok(!res.headers['content-disposition']);
       assert.equal(res.headers['transfer-encoding'], 'chunked');
       assert.match(res.text, /describe\(/);
 
@@ -657,7 +657,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
         res.headers['content-type'],
         'application/json; charset=utf-8'
       );
-      assert(!res.headers['content-disposition']);
+      assert.ok(!res.headers['content-disposition']);
       assert.deepEqual(res.body, {
         path: '/tests/integration/test.http.js',
         type: 'file',
@@ -673,7 +673,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
       assert.equal(res.headers['cache-control'], 'public, max-age=31536000');
       assert.equal(res.headers.vary, 'Origin, Accept, Accept-Encoding');
       assert.equal(res.headers['content-type'], 'text/markdown; charset=utf-8');
-      assert(!res.headers['content-disposition']);
+      assert.ok(!res.headers['content-disposition']);
       assert.equal(res.headers['transfer-encoding'], 'chunked');
       assert.match(res.text, /The Javascript Database that Syncs/);
 
@@ -682,7 +682,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
       assert.equal(res.headers['cache-control'], 'public, max-age=31536000');
       assert.equal(res.headers.vary, 'Origin, Accept, Accept-Encoding');
       assert.equal(res.headers['content-type'], 'text/yaml; charset=utf-8');
-      assert(!res.headers['content-disposition']);
+      assert.ok(!res.headers['content-disposition']);
       assert.equal(res.headers['transfer-encoding'], 'chunked');
       assert.match(res.text, /language: node_js/);
 
@@ -692,7 +692,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
       assert.equal(res.headers.vary, 'Origin, Accept, Accept-Encoding');
       // FIXME: should be text/plain
       assert.equal(res.headers['content-type'], 'text/plain; charset=utf-8');
-      assert(!res.headers['content-disposition']);
+      assert.ok(!res.headers['content-disposition']);
       assert.equal(res.headers['transfer-encoding'], 'chunked');
       assert.match(res.text, /Apache License/);
 
@@ -702,7 +702,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
       assert.equal(res.headers.vary, 'Origin, Accept, Accept-Encoding');
       // FIXME: should be text/plain
       assert.equal(res.headers['content-type'], 'text/plain; charset=utf-8');
-      assert(!res.headers['content-disposition']);
+      assert.ok(!res.headers['content-disposition']);
       assert.equal(res.headers['transfer-encoding'], 'chunked');
 
       res = await app
@@ -712,7 +712,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
       assert.equal(res.headers['cache-control'], 'public, max-age=31536000');
       assert.equal(res.headers.vary, 'Origin, Accept, Accept-Encoding');
       assert.equal(res.headers['content-type'], 'application/x-sh');
-      assert(!res.headers['content-disposition']);
+      assert.ok(!res.headers['content-disposition']);
       assert.equal(res.headers['transfer-encoding'], 'chunked');
       assert.match(res.text, /#!\/bin\/bash/);
 
@@ -726,7 +726,7 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
         res.headers['content-type'],
         'text/cache-manifest; charset=utf-8'
       );
-      assert(!res.headers['content-disposition']);
+      assert.ok(!res.headers['content-disposition']);
       assert.equal(res.headers['transfer-encoding'], 'chunked');
       assert.match(res.text, /CACHE MANIFEST/);
     });
@@ -772,8 +772,8 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
         .httpRequest()
         .get(`/${pkg.name}/1.0.40000404/files/foo.json`)
         .expect(404);
-      assert(!res.headers.etag);
-      assert(!res.headers['cache-control']);
+      assert.ok(!res.headers.etag);
+      assert.ok(!res.headers['cache-control']);
       assert.equal(
         res.body.error,
         `[NOT_FOUND] ${pkg.name}@1.0.40000404 not found`
@@ -783,8 +783,8 @@ describe('test/port/controller/PackageVersionFileController/raw.test.ts', () => 
         .httpRequest()
         .get(`/${pkg.name}/1.0.40000404/files/bin/foo/bar.js`)
         .expect(404);
-      assert(!res.headers.etag);
-      assert(!res.headers['cache-control']);
+      assert.ok(!res.headers.etag);
+      assert.ok(!res.headers['cache-control']);
       assert.equal(
         res.body.error,
         `[NOT_FOUND] ${pkg.name}@1.0.40000404 not found`

--- a/test/port/controller/ProxyCacheController/index.test.ts
+++ b/test/port/controller/ProxyCacheController/index.test.ts
@@ -49,7 +49,7 @@ describe('test/port/controller/PackageVersionFileController/listFiles.test.ts', 
       mock(app.config.cnpmcore, 'syncMode', SyncMode.proxy);
       mock(app.config.cnpmcore, 'redirectNotFound', false);
       const res = await app.httpRequest().get('/-/proxy-cache').expect(200);
-      assert(res.body.data.length === 4);
+      assert.ok(res.body.data.length === 4);
     });
 
     it('should pageSize work', async () => {
@@ -59,18 +59,18 @@ describe('test/port/controller/PackageVersionFileController/listFiles.test.ts', 
         .httpRequest()
         .get('/-/proxy-cache?pageSize=2&pageIndex=0')
         .expect(200);
-      assert(res0.body.data.length === 2);
+      assert.ok(res0.body.data.length === 2);
       const res1 = await app
         .httpRequest()
         .get('/-/proxy-cache?pageSize=2&pageIndex=1')
         .expect(200);
-      assert(res1.body.data.length === 2);
+      assert.ok(res1.body.data.length === 2);
       const res2 = await app
         .httpRequest()
         .get('/-/proxy-cache?pageSize=2&pageIndex=2')
         .expect(200);
-      assert(res2.body.data.length === 0);
-      assert(res2.body.count === 4);
+      assert.ok(res2.body.data.length === 0);
+      assert.ok(res2.body.count === 4);
     });
   });
 
@@ -86,7 +86,7 @@ describe('test/port/controller/PackageVersionFileController/listFiles.test.ts', 
         .httpRequest()
         .get('/-/proxy-cache/foo-bar')
         .expect(200);
-      assert(res.body.count === 2);
+      assert.ok(res.body.count === 2);
     });
 
     it('should 404 when not found', async () => {
@@ -96,7 +96,7 @@ describe('test/port/controller/PackageVersionFileController/listFiles.test.ts', 
         .httpRequest()
         .get('/-/proxy-cache/foo-bar-xxx')
         .expect(200);
-      assert(res.body.count === 0);
+      assert.ok(res.body.count === 0);
     });
   });
 
@@ -113,12 +113,12 @@ describe('test/port/controller/PackageVersionFileController/listFiles.test.ts', 
         .patch('/-/proxy-cache/foo-bar')
         .expect(200);
       // 仅需创建ABBREVIATED_MANIFESTS的更新任务
-      assert(res.body.tasks.length === 1);
+      assert.ok(res.body.tasks.length === 1);
       const taskRepository = await app.getEggObject(TaskRepository);
       const waitingTask = await taskRepository.findTask(
         res.body.tasks[0].taskId
       );
-      assert(waitingTask);
+      assert.ok(waitingTask);
     });
 
     it('should 404 when not found', async () => {
@@ -147,12 +147,12 @@ describe('test/port/controller/PackageVersionFileController/listFiles.test.ts', 
         .delete('/-/proxy-cache/foo-bar')
         .set('authorization', adminUser.authorization)
         .expect(200);
-      assert(res.body.ok === true);
+      assert.ok(res.body.ok === true);
       // foo-bar
-      assert(res.body.result.length === 2);
+      assert.ok(res.body.result.length === 2);
       const res1 = await app.httpRequest().get('/-/proxy-cache').expect(200);
       // foobar
-      assert(res1.body.data.length === 2);
+      assert.ok(res1.body.data.length === 2);
     });
 
     it('should 404 when not found', async () => {

--- a/test/port/controller/RegistryController/index.test.ts
+++ b/test/port/controller/RegistryController/index.test.ts
@@ -60,7 +60,7 @@ describe('test/port/controller/RegistryController/index.test.ts', () => {
           type: 'cnpmcore',
         });
 
-      assert(res.body.ok);
+      assert.ok(res.body.ok);
     });
 
     it('should verify params', async () => {
@@ -75,7 +75,7 @@ describe('test/port/controller/RegistryController/index.test.ts', () => {
         })
         .expect(422);
 
-      assert(
+      assert.ok(
         res.body.error === "[INVALID_PARAM] must have required property 'host'"
       );
     });
@@ -93,7 +93,7 @@ describe('test/port/controller/RegistryController/index.test.ts', () => {
         })
         .expect(403);
 
-      assert(res.body.error === '[FORBIDDEN] Not allow to access');
+      assert.ok(res.body.error === '[FORBIDDEN] Not allow to access');
     });
   });
 
@@ -115,8 +115,8 @@ describe('test/port/controller/RegistryController/index.test.ts', () => {
       // query success
       const res = await app.httpRequest().get('/-/registry').expect(200);
 
-      assert(res.body.count === 2);
-      assert(res.body.data[1].name === 'custom5');
+      assert.ok(res.body.count === 2);
+      assert.ok(res.body.data[1].name === 'custom5');
     });
   });
 
@@ -154,22 +154,22 @@ describe('test/port/controller/RegistryController/index.test.ts', () => {
         .httpRequest()
         .get(`/-/registry/${registry.registryId}/scopes`)
         .expect(200);
-      assert(scopRes.body.count === 4);
-      assert(scopRes.body.data.length === 4);
+      assert.ok(scopRes.body.count === 4);
+      assert.ok(scopRes.body.data.length === 4);
 
       scopRes = await app
         .httpRequest()
         .get(`/-/registry/${registry.registryId}/scopes?pageSize=1`)
         .expect(200);
-      assert(scopRes.body.count === 4);
-      assert(scopRes.body.data.length === 1);
+      assert.ok(scopRes.body.count === 4);
+      assert.ok(scopRes.body.data.length === 1);
 
       scopRes = await app
         .httpRequest()
         .get(`/-/registry/${registry.registryId}/scopes?pageSize=2&pageIndex=1`)
         .expect(200);
-      assert(scopRes.body.count === 4);
-      assert(scopRes.body.data.length === 2);
+      assert.ok(scopRes.body.count === 4);
+      assert.ok(scopRes.body.data.length === 2);
     });
     it('should error', async () => {
       await app
@@ -207,7 +207,7 @@ describe('test/port/controller/RegistryController/index.test.ts', () => {
         .set('authorization', adminUser.authorization)
         .expect(200);
 
-      assert(queryRes.body.count === 0);
+      assert.ok(queryRes.body.count === 0);
     });
   });
 
@@ -225,7 +225,7 @@ describe('test/port/controller/RegistryController/index.test.ts', () => {
         .post('/-/registry/in_valid/sync')
         .set('authorization', adminUser.authorization)
         .expect(404);
-      assert(res.body.error.includes('registry not found'));
+      assert.ok(res.body.error.includes('registry not found'));
     });
 
     it('should 200', async () => {
@@ -236,7 +236,7 @@ describe('test/port/controller/RegistryController/index.test.ts', () => {
         .expect(200);
 
       const task = await taskService.findExecuteTask(TaskType.ChangesStream);
-      assert(task?.targetName === 'CUSTOM3_WORKER');
+      assert.ok(task?.targetName === 'CUSTOM3_WORKER');
     });
 
     it('since params', async () => {
@@ -250,7 +250,7 @@ describe('test/port/controller/RegistryController/index.test.ts', () => {
         .expect(200);
 
       const task = await taskService.findExecuteTask(TaskType.ChangesStream);
-      assert(task);
+      assert.ok(task);
       assert.equal(task.targetName, 'CUSTOM3_WORKER');
       assert.equal((task.data as ChangesStreamTaskData).since, '9527');
     });

--- a/test/port/controller/ScopeController/index.test.ts
+++ b/test/port/controller/ScopeController/index.test.ts
@@ -38,7 +38,7 @@ describe('test/port/controller/ScopeController/index.test.ts', () => {
         })
         .expect(200);
 
-      assert(res.body.ok);
+      assert.ok(res.body.ok);
     });
 
     it('should 400', async () => {
@@ -52,7 +52,7 @@ describe('test/port/controller/ScopeController/index.test.ts', () => {
         })
         .expect(400);
 
-      assert(res.body.error === '[BAD_REQUEST] registry banana not found');
+      assert.ok(res.body.error === '[BAD_REQUEST] registry banana not found');
     });
 
     it('should 403', async () => {
@@ -65,7 +65,7 @@ describe('test/port/controller/ScopeController/index.test.ts', () => {
         })
         .expect(403);
 
-      assert(res.body.error === '[FORBIDDEN] Not allow to access');
+      assert.ok(res.body.error === '[FORBIDDEN] Not allow to access');
     });
   });
 
@@ -94,7 +94,7 @@ describe('test/port/controller/ScopeController/index.test.ts', () => {
         .delete(`/-/scope/${scope.scopeId}`)
         .set('authorization', adminUser.authorization)
         .expect(200);
-      assert(res.body.ok);
+      assert.ok(res.body.ok);
     });
   });
 });

--- a/test/port/controller/TokenController/createToken.test.ts
+++ b/test/port/controller/TokenController/createToken.test.ts
@@ -202,20 +202,20 @@ describe('test/port/controller/TokenController/createToken.test.ts', () => {
 
         const userRepository = await app.getEggObject(UserRepository);
         const user = await userRepository.findUserByName('banana');
-        assert(user);
+        assert.ok(user);
         const tokens = await userRepository.listTokens(user.userId);
 
         let granularToken = tokens.find(
           token => token.type === TokenType.granular
         );
 
-        assert(granularToken);
-        assert(granularToken.lastUsedAt === null);
+        assert.ok(granularToken);
+        assert.ok(granularToken.lastUsedAt === null);
         assert.equal(granularToken.name, 'apple');
         assert.deepEqual(granularToken.allowedScopes, ['@banana']);
         const expiredDate = dayjs(granularToken.expiredAt);
-        assert(expiredDate.isAfter(dayjs().add(29, 'days')));
-        assert(expiredDate.isBefore(dayjs().add(30, 'days')));
+        assert.ok(expiredDate.isAfter(dayjs().add(29, 'days')));
+        assert.ok(expiredDate.isBefore(dayjs().add(30, 'days')));
 
         // should ignore granularToken when use v1 query
         res = await app
@@ -223,8 +223,8 @@ describe('test/port/controller/TokenController/createToken.test.ts', () => {
           .get('/-/npm/v1/tokens')
           .set('authorization', 'Bearer ' + res.body.token);
 
-        assert(res.body.objects.length > 0);
-        assert(
+        assert.ok(res.body.objects.length > 0);
+        assert.ok(
           res.body.objects.every(
             (token: Token) => token.type !== TokenType.granular
           )
@@ -236,8 +236,8 @@ describe('test/port/controller/TokenController/createToken.test.ts', () => {
         granularToken = res.body.objects.find(
           (token: Token) => token.type === TokenType.granular
         );
-        assert(granularToken?.lastUsedAt);
-        assert(dayjs(granularToken?.lastUsedAt).isAfter(start));
+        assert.ok(granularToken?.lastUsedAt);
+        assert.ok(dayjs(granularToken?.lastUsedAt).isAfter(start));
       });
 
       it('should check for uniq name', async () => {

--- a/test/port/controller/TokenController/listTokens.test.ts
+++ b/test/port/controller/TokenController/listTokens.test.ts
@@ -33,8 +33,8 @@ describe('test/port/controller/TokenController/listTokens.test.ts', () => {
       assert.deepEqual(tokens[0].cidr_whitelist, []);
       assert.equal(tokens[0].readonly, false);
       assert.equal(tokens[0].automation, false);
-      assert(tokens[0].created);
-      assert(tokens[0].updated);
+      assert.ok(tokens[0].created);
+      assert.ok(tokens[0].updated);
     });
 
     it('should update lastUsedAt', async () => {
@@ -54,7 +54,7 @@ describe('test/port/controller/TokenController/listTokens.test.ts', () => {
         .expect(200);
 
       const lastUsedAt = res.body.objects[0].lastUsedAt;
-      assert(dayjs(lastUsedAt).isAfter(now));
+      assert.ok(dayjs(lastUsedAt).isAfter(now));
     });
 
     it('should 401 when readonly token access', async () => {
@@ -79,7 +79,7 @@ describe('test/port/controller/TokenController/listTokens.test.ts', () => {
       const { name, email } = await TestUtil.createUser();
       const userService = await app.getEggObject(UserService);
       const user = await userService.findUserByName(name);
-      assert(user);
+      assert.ok(user);
       await userService.createToken(user.userId, {
         name: 'good',
         type: TokenType.granular,

--- a/test/port/controller/TokenController/removeToken.test.ts
+++ b/test/port/controller/TokenController/removeToken.test.ts
@@ -168,7 +168,7 @@ describe('test/port/controller/TokenController/removeToken.test.ts', () => {
       const { name, email } = await TestUtil.createUser();
       const userService = await app.getEggObject(UserService);
       const user = await userService.findUserByName(name);
-      assert(user);
+      assert.ok(user);
       await TestUtil.createPackage({ name: '@cnpm/foo' }, { name: user.name });
       token = await userService.createToken(user.userId, {
         name: 'good',

--- a/test/port/controller/UserController/loginOrCreateUser.test.ts
+++ b/test/port/controller/UserController/loginOrCreateUser.test.ts
@@ -76,7 +76,7 @@ describe('test/port/controller/UserController/loginOrCreateUser.test.ts', () => 
         .expect(201);
       assert.equal(res.body.ok, true);
       assert.equal(res.body.id, 'org.couchdb.user:cnpmcore_admin');
-      assert(res.body.rev);
+      assert.ok(res.body.rev);
       assert.match(res.body.token, /^cnpm_\w+/);
     });
 
@@ -93,7 +93,7 @@ describe('test/port/controller/UserController/loginOrCreateUser.test.ts', () => 
         .expect(201);
       assert.equal(res.body.ok, true);
       assert.equal(res.body.id, 'org.couchdb.user:leo');
-      assert(res.body.rev);
+      assert.ok(res.body.rev);
       assert.match(res.body.token, /^cnpm_\w+/);
       const lastToken = res.body.token;
 
@@ -109,7 +109,7 @@ describe('test/port/controller/UserController/loginOrCreateUser.test.ts', () => 
         .expect(201);
       assert.equal(res.body.ok, true);
       assert.equal(res.body.id, 'org.couchdb.user:leo');
-      assert(res.body.rev);
+      assert.ok(res.body.rev);
       assert.match(res.body.token, /^cnpm_\w+/);
       assert.notEqual(res.body.token, lastToken);
 
@@ -143,7 +143,7 @@ describe('test/port/controller/UserController/loginOrCreateUser.test.ts', () => 
         .expect(201);
       assert.equal(res.body.ok, true);
       assert.equal(res.body.id, 'org.couchdb.user:leo');
-      assert(res.body.rev);
+      assert.ok(res.body.rev);
       assert.match(res.body.token, /^cnpm_\w+/);
       const lastToken = res.body.token;
 
@@ -159,7 +159,7 @@ describe('test/port/controller/UserController/loginOrCreateUser.test.ts', () => 
         .expect(201);
       assert.equal(res.body.ok, true);
       assert.equal(res.body.id, 'org.couchdb.user:leo');
-      assert(res.body.rev);
+      assert.ok(res.body.rev);
       assert.match(res.body.token, /^cnpm_\w+/);
       assert.notEqual(res.body.token, lastToken);
 

--- a/test/port/controller/UserController/saveProfile.test.ts
+++ b/test/port/controller/UserController/saveProfile.test.ts
@@ -11,12 +11,16 @@ describe('test/port/controller/UserController/saveProfile.test.ts', () => {
         .httpRequest()
         .post('/-/npm/v1/user')
         .set('authorization', authorization);
-      assert(res.status === 403);
-      assert(res.body.error === '[FORBIDDEN] npm profile set is not allowed');
+      assert.ok(res.status === 403);
+      assert.ok(
+        res.body.error === '[FORBIDDEN] npm profile set is not allowed'
+      );
 
       res = await app.httpRequest().post('/-/npm/v1/user');
-      assert(res.status === 403);
-      assert(res.body.error === '[FORBIDDEN] npm profile set is not allowed');
+      assert.ok(res.status === 403);
+      assert.ok(
+        res.body.error === '[FORBIDDEN] npm profile set is not allowed'
+      );
     });
   });
 });

--- a/test/port/controller/UserController/showProfile.test.ts
+++ b/test/port/controller/UserController/showProfile.test.ts
@@ -11,12 +11,12 @@ describe('test/port/controller/UserController/showProfile.test.ts', () => {
         .httpRequest()
         .get('/-/npm/v1/user')
         .set('authorization', authorization + 'wrong');
-      assert(res.status === 401);
-      assert(res.body.error === '[UNAUTHORIZED] Invalid token');
+      assert.ok(res.status === 401);
+      assert.ok(res.body.error === '[UNAUTHORIZED] Invalid token');
 
       res = await app.httpRequest().get('/-/npm/v1/user');
-      assert(res.status === 401);
-      assert(res.body.error === '[UNAUTHORIZED] Login first');
+      assert.ok(res.status === 401);
+      assert.ok(res.body.error === '[UNAUTHORIZED] Login first');
     });
 
     it('should 200', async () => {
@@ -25,8 +25,8 @@ describe('test/port/controller/UserController/showProfile.test.ts', () => {
         .httpRequest()
         .get('/-/npm/v1/user')
         .set('authorization', authorization);
-      assert(res.status === 200);
-      assert(res.body.name === name);
+      assert.ok(res.status === 200);
+      assert.ok(res.body.name === name);
     });
   });
 });

--- a/test/port/controller/UserController/starredByUser.test.ts
+++ b/test/port/controller/UserController/starredByUser.test.ts
@@ -11,14 +11,14 @@ describe('test/port/controller/UserController/starredByUser.test.ts', () => {
         .httpRequest()
         .get('/-/_view/starredByUser?key=%22cnpmcore_admin%22')
         .set('authorization', authorization);
-      assert(res.status === 403);
-      assert(res.body.error === '[FORBIDDEN] npm stars is not allowed');
+      assert.ok(res.status === 403);
+      assert.ok(res.body.error === '[FORBIDDEN] npm stars is not allowed');
 
       res = await app
         .httpRequest()
         .get('/-/_view/starredByUser?key=%22cnpmcore_admin%22');
-      assert(res.status === 403);
-      assert(res.body.error === '[FORBIDDEN] npm stars is not allowed');
+      assert.ok(res.status === 403);
+      assert.ok(res.body.error === '[FORBIDDEN] npm stars is not allowed');
     });
   });
 });

--- a/test/port/controller/UserController/whoami.test.ts
+++ b/test/port/controller/UserController/whoami.test.ts
@@ -61,7 +61,7 @@ describe('test/port/controller/UserController/whoami.test.ts', () => {
       assert.equal(res.body.description, 'lets play');
       assert.deepEqual(res.body.allowedPackages, ['@cnpm/banana']);
       assert.deepEqual(res.body.allowedScopes, ['@banana']);
-      assert(dayjs(res.body.expires).isBefore(dayjs().add(30, 'days')));
+      assert.ok(dayjs(res.body.expires).isBefore(dayjs().add(30, 'days')));
     });
   });
 });

--- a/test/port/controller/hook/HookController.test.ts
+++ b/test/port/controller/hook/HookController.test.ts
@@ -18,7 +18,7 @@ describe('test/port/controller/hook/HookController.test.ts', () => {
     hookManageService = await app.getEggObject(HookManageService);
     const userRepository = await app.getEggObject(UserRepository);
     const userEntity = await userRepository.findUserByName(user.name);
-    assert(userEntity);
+    assert.ok(userEntity);
     userId = userEntity.userId;
   });
 
@@ -36,19 +36,19 @@ describe('test/port/controller/hook/HookController.test.ts', () => {
           secret: 'this is certainly very secret',
         })
         .expect(200);
-      assert(res.body);
-      assert(res.body.id);
-      assert(res.body.username === user.name);
-      assert(res.body.name === '@cnpmcore');
-      assert(res.body.endpoint === 'https://example.com/webhook');
-      assert(res.body.secret === 'this is certainly very secret');
-      assert(res.body.type === HookType.Scope);
-      assert(res.body.created);
-      assert(res.body.updated);
-      assert(res.body.delivered === false);
-      assert(res.body.last_delivery === null);
-      assert(res.body.response_code === 0);
-      assert(res.body.status === 'active');
+      assert.ok(res.body);
+      assert.ok(res.body.id);
+      assert.ok(res.body.username === user.name);
+      assert.ok(res.body.name === '@cnpmcore');
+      assert.ok(res.body.endpoint === 'https://example.com/webhook');
+      assert.ok(res.body.secret === 'this is certainly very secret');
+      assert.ok(res.body.type === HookType.Scope);
+      assert.ok(res.body.created);
+      assert.ok(res.body.updated);
+      assert.ok(res.body.delivered === false);
+      assert.ok(res.body.last_delivery === null);
+      assert.ok(res.body.response_code === 0);
+      assert.ok(res.body.status === 'active');
     });
   });
 
@@ -75,8 +75,8 @@ describe('test/port/controller/hook/HookController.test.ts', () => {
           secret: 'new secret',
         })
         .expect(200);
-      assert(res.body.endpoint === 'https://new.com/webhook');
-      assert(res.body.secret === 'new secret');
+      assert.ok(res.body.endpoint === 'https://new.com/webhook');
+      assert.ok(res.body.secret === 'new secret');
     });
   });
 
@@ -99,7 +99,7 @@ describe('test/port/controller/hook/HookController.test.ts', () => {
         .set('authorization', user.authorization)
         .set('user-agent', user.ua)
         .expect(200);
-      assert(res.body.deleted === true);
+      assert.ok(res.body.deleted === true);
     });
   });
 
@@ -121,7 +121,7 @@ describe('test/port/controller/hook/HookController.test.ts', () => {
         .set('authorization', user.authorization)
         .set('user-agent', user.ua)
         .expect(200);
-      assert(res.body.objects.length === 1);
+      assert.ok(res.body.objects.length === 1);
     });
   });
 
@@ -144,19 +144,19 @@ describe('test/port/controller/hook/HookController.test.ts', () => {
         .set('authorization', user.authorization)
         .set('user-agent', user.ua)
         .expect(200);
-      assert(res.body);
-      assert(res.body.id === hook.hookId);
-      assert(res.body.username === user.name);
-      assert(res.body.name === 'foo_package');
-      assert(res.body.endpoint === 'http://foo.com');
-      assert(res.body.secret === 'mock_secret');
-      assert(res.body.type === HookType.Package);
-      assert(res.body.created);
-      assert(res.body.updated);
-      assert(res.body.delivered === false);
-      assert(res.body.last_delivery === null);
-      assert(res.body.response_code === 0);
-      assert(res.body.status === 'active');
+      assert.ok(res.body);
+      assert.ok(res.body.id === hook.hookId);
+      assert.ok(res.body.username === user.name);
+      assert.ok(res.body.name === 'foo_package');
+      assert.ok(res.body.endpoint === 'http://foo.com');
+      assert.ok(res.body.secret === 'mock_secret');
+      assert.ok(res.body.type === HookType.Package);
+      assert.ok(res.body.created);
+      assert.ok(res.body.updated);
+      assert.ok(res.body.delivered === false);
+      assert.ok(res.body.last_delivery === null);
+      assert.ok(res.body.response_code === 0);
+      assert.ok(res.body.status === 'active');
     });
   });
 });

--- a/test/port/controller/package/DownloadPackageVersionTarController.test.ts
+++ b/test/port/controller/package/DownloadPackageVersionTarController.test.ts
@@ -27,8 +27,8 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
       .set('user-agent', publisher.ua)
       .send(pkg)
       .expect(201);
-    assert(res.status === 201);
-    assert(res.body.ok === true);
+    assert.ok(res.status === 201);
+    assert.ok(res.body.ok === true);
     assert.match(res.body.rev, /^\d+-\w{24}$/);
 
     pkg = await TestUtil.getFullPackage({ name: scopedName, version: '1.0.0' });
@@ -38,8 +38,8 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
       .set('authorization', publisher.authorization)
       .set('user-agent', publisher.ua)
       .send(pkg);
-    assert(res.status === 201);
-    assert(res.body.ok === true);
+    assert.ok(res.status === 201);
+    assert.ok(res.body.ok === true);
     assert.match(res.body.rev, /^\d+-\w{24}$/);
   });
 
@@ -52,16 +52,16 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
       let res = await app
         .httpRequest()
         .get(`/${name}/-/testmodule-download-version-tar-1.0.0.tgz`);
-      assert(res.status === 302);
-      assert(
+      assert.ok(res.status === 302);
+      assert.ok(
         res.headers.location ===
           `https://cdn.mock.com/packages/${name}/1.0.0/${name}-1.0.0.tgz`
       );
       res = await app
         .httpRequest()
         .get(`/${scopedName}/-/testmodule-download-version-tar-1.0.0.tgz`);
-      assert(res.status === 302);
-      assert(
+      assert.ok(res.status === 302);
+      assert.ok(
         res.headers.location ===
           `https://cdn.mock.com/packages/${scopedName}/1.0.0/${name}-1.0.0.tgz`
       );
@@ -95,16 +95,16 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
         let res = await app
           .httpRequest()
           .get(`/${name}/-/testmodule-download-version-tar-1.0.0.tgz`);
-        assert(res.status === 302);
-        assert(
+        assert.ok(res.status === 302);
+        assert.ok(
           res.headers.location ===
             `https://cdn.mock.com/packages/${name}/1.0.0/${name}-1.0.0.tgz`
         );
         res = await app
           .httpRequest()
           .get(`/${scopedName}/-/testmodule-download-version-tar-1.0.0.tgz`);
-        assert(res.status === 302);
-        assert(
+        assert.ok(res.status === 302);
+        assert.ok(
           res.headers.location ===
             `https://cdn.mock.com/packages/${scopedName}/1.0.0/${name}-1.0.0.tgz`
         );
@@ -183,9 +183,11 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
       const res = await app
         .httpRequest()
         .get(`/${pkg.name}/-/${pkg.name}-1.0.0.tgz`);
-      assert(res.status === 404);
-      assert(res.headers['content-type'] === 'application/json; charset=utf-8');
-      assert(
+      assert.ok(res.status === 404);
+      assert.ok(
+        res.headers['content-type'] === 'application/json; charset=utf-8'
+      );
+      assert.ok(
         res.body.error ===
           '[NOT_FOUND] "testmodule-download-version-tar222-1.0.0.tgz" not found'
       );
@@ -224,8 +226,8 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
         .get(
           '/testmodule-download-version-tar-not-exists/-/testmodule-download-version-tar-not-exists-1.0.0.tgz'
         );
-      assert(res.status === 302);
-      assert(
+      assert.ok(res.status === 302);
+      assert.ok(
         res.headers.location ===
           'https://registry.npmjs.org/testmodule-download-version-tar-not-exists/-/testmodule-download-version-tar-not-exists-1.0.0.tgz'
       );
@@ -291,8 +293,8 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
 
       mock(app.config.cnpmcore, 'syncMode', 'all');
       const res = await app.httpRequest().get('/foo/-/foo-1.0.404404.tgz');
-      assert(res.status === 404);
-      assert(res.body.error === '[NOT_FOUND] foo not found');
+      assert.ok(res.status === 404);
+      assert.ok(res.body.error === '[NOT_FOUND] foo not found');
 
       // not redirect when package exists
       await app
@@ -368,7 +370,7 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
         .get('/lodash/-/lodash-1.404.404.tgz')
         .set('user-agent', publisher.ua + ' node/16.0.0')
         .set('Accept', 'application/vnd.npm.install-v1+json');
-      assert(res.status === 404);
+      assert.ok(res.status === 404);
       app.notExpectLog(
         '[middleware:ErrorHandler][syncPackage] create sync package'
       );
@@ -383,7 +385,7 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
         .get('/lodash/-/lodash-1.404.404.tgz')
         .set('user-agent', publisher.ua + ' node/16.0.0')
         .set('Accept', 'application/vnd.npm.install-v1+json');
-      assert(res.status === 404);
+      assert.ok(res.status === 404);
       app.expectLog(
         '[middleware:ErrorHandler][syncPackage] create sync package'
       );
@@ -407,7 +409,7 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
         .get('/foobar/-/foobar-1.0.0.tgz')
         .set('user-agent', publisher.ua + ' node/16.0.0')
         .set('Accept', 'application/vnd.npm.install-v1+json');
-      assert(res.status === 200);
+      assert.ok(res.status === 200);
       // run in background
       await setTimeout(500);
       app.expectLog(
@@ -445,9 +447,9 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
       const res = await app
         .httpRequest()
         .get(`/${name}/download/${name}-1.0.0.tgz`);
-      assert(res.status === 200);
-      assert(res.headers['content-type'] === 'application/octet-stream');
-      assert(
+      assert.ok(res.status === 200);
+      assert.ok(res.headers['content-type'] === 'application/octet-stream');
+      assert.ok(
         res.headers['content-disposition'] ===
           `attachment; filename="${name}-1.0.0.tgz"`
       );
@@ -455,9 +457,9 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
       await app
         .httpRequest()
         .get(`/${scopedName}/download/${scopedName}-1.0.0.tgz`);
-      assert(res.status === 200);
-      assert(res.headers['content-type'] === 'application/octet-stream');
-      assert(
+      assert.ok(res.status === 200);
+      assert.ok(res.headers['content-type'] === 'application/octet-stream');
+      assert.ok(
         res.headers['content-disposition'] ===
           `attachment; filename="${name}-1.0.0.tgz"`
       );
@@ -475,9 +477,11 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
       const res = await app
         .httpRequest()
         .get(`/${name}/download/${name}-1.0.0.tgz`);
-      assert(res.status === 404);
-      assert(res.headers['content-type'] === 'application/json; charset=utf-8');
-      assert(res.body.error === `[NOT_FOUND] "${name}-1.0.0.tgz" not found`);
+      assert.ok(res.status === 404);
+      assert.ok(
+        res.headers['content-type'] === 'application/json; charset=utf-8'
+      );
+      assert.ok(res.body.error === `[NOT_FOUND] "${name}-1.0.0.tgz" not found`);
     });
   });
 
@@ -490,16 +494,16 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
       let res = await app
         .httpRequest()
         .get(`/${name}/-/${scope}/${name}-1.0.0.tgz`);
-      assert(res.status === 302);
-      assert(
+      assert.ok(res.status === 302);
+      assert.ok(
         res.headers.location ===
           `https://cdn.mock.com/packages/${name}/1.0.0/${name}-1.0.0.tgz`
       );
       res = await app
         .httpRequest()
         .get(`/${scopedName}/-/${scope}/${name}-1.0.0.tgz`);
-      assert(res.status === 302);
-      assert(
+      assert.ok(res.status === 302);
+      assert.ok(
         res.headers.location ===
           `https://cdn.mock.com/packages/${scopedName}/1.0.0/${name}-1.0.0.tgz`
       );
@@ -510,9 +514,9 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
       const res = await app
         .httpRequest()
         .get(`/${name}/-/${scope}/${name}-1.0.0.tgz`);
-      assert(res.status === 200);
-      assert(res.headers['content-type'] === 'application/octet-stream');
-      assert(
+      assert.ok(res.status === 200);
+      assert.ok(res.headers['content-type'] === 'application/octet-stream');
+      assert.ok(
         res.headers['content-disposition'] ===
           `attachment; filename="${name}-1.0.0.tgz"`
       );
@@ -520,9 +524,9 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
       await app
         .httpRequest()
         .get(`/${scopedName}/-/${scope}/${name}-1.0.0.tgz`);
-      assert(res.status === 200);
-      assert(res.headers['content-type'] === 'application/octet-stream');
-      assert(
+      assert.ok(res.status === 200);
+      assert.ok(res.headers['content-type'] === 'application/octet-stream');
+      assert.ok(
         res.headers['content-disposition'] ===
           `attachment; filename="${name}-1.0.0.tgz"`
       );
@@ -540,9 +544,11 @@ describe('test/port/controller/package/DownloadPackageVersionTarController.test.
       const res = await app
         .httpRequest()
         .get(`/${name}/-/${scope}/${name}-1.0.0.tgz`);
-      assert(res.status === 404);
-      assert(res.headers['content-type'] === 'application/json; charset=utf-8');
-      assert(res.body.error === `[NOT_FOUND] "${name}-1.0.0.tgz" not found`);
+      assert.ok(res.status === 404);
+      assert.ok(
+        res.headers['content-type'] === 'application/json; charset=utf-8'
+      );
+      assert.ok(res.body.error === `[NOT_FOUND] "${name}-1.0.0.tgz" not found`);
     });
   });
 });

--- a/test/port/controller/package/RemovePackageVersionController.test.ts
+++ b/test/port/controller/package/RemovePackageVersionController.test.ts
@@ -22,7 +22,7 @@ describe('test/port/controller/package/RemovePackageVersionController.test.ts', 
         isPrivate: false,
       });
       let res = await app.httpRequest().get(`/${pkg.name}/1.0.0`);
-      assert(res.status === 200);
+      assert.ok(res.status === 200);
 
       const adminUser = await TestUtil.createUser({ name: 'cnpmcore_admin' });
       const pkgVersion = res.body;
@@ -33,11 +33,11 @@ describe('test/port/controller/package/RemovePackageVersionController.test.ts', 
         .set('authorization', adminUser.authorization)
         .set('npm-command', 'unpublish')
         .set('user-agent', adminUser.ua);
-      assert(res.status === 200);
-      assert(res.body.ok === true);
+      assert.ok(res.status === 200);
+      assert.ok(res.body.ok === true);
 
       res = await app.httpRequest().get(`/${pkg.name}/1.0.0`);
-      assert(res.status === 404);
+      assert.ok(res.status === 404);
     });
 
     it('should remove public package version over 72 hours success on admin action', async () => {
@@ -48,15 +48,15 @@ describe('test/port/controller/package/RemovePackageVersionController.test.ts', 
         isPrivate: false,
       });
       let res = await app.httpRequest().get(`/${pkg.name}/1.0.0`);
-      assert(res.status === 200);
+      assert.ok(res.status === 200);
 
       const pkgEntity = await packageRepository.findPackage('', 'foo');
-      assert(pkgEntity);
+      assert.ok(pkgEntity);
       const pkgVersionEntity = await packageRepository.findPackageVersion(
         pkgEntity.packageId,
         '1.0.0'
       );
-      assert(pkgVersionEntity);
+      assert.ok(pkgVersionEntity);
       pkgVersionEntity.publishTime = new Date(
         Date.now() - 72 * 3_600_000 - 100
       );
@@ -71,11 +71,11 @@ describe('test/port/controller/package/RemovePackageVersionController.test.ts', 
         .set('authorization', adminUser.authorization)
         .set('npm-command', 'unpublish')
         .set('user-agent', adminUser.ua);
-      assert(res.status === 200);
-      assert(res.body.ok === true);
+      assert.ok(res.status === 200);
+      assert.ok(res.body.ok === true);
 
       res = await app.httpRequest().get(`/${pkg.name}/1.0.0`);
-      assert(res.status === 404);
+      assert.ok(res.status === 404);
     });
 
     it('should remove public package version fobidden on non-admin action', async () => {
@@ -86,7 +86,7 @@ describe('test/port/controller/package/RemovePackageVersionController.test.ts', 
         isPrivate: false,
       });
       let res = await app.httpRequest().get(`/${pkg.name}/1.0.0`);
-      assert(res.status === 200);
+      assert.ok(res.status === 200);
 
       const normalUser = await TestUtil.createUser();
       const pkgVersion = res.body;
@@ -97,14 +97,14 @@ describe('test/port/controller/package/RemovePackageVersionController.test.ts', 
         .set('authorization', normalUser.authorization)
         .set('npm-command', 'unpublish')
         .set('user-agent', normalUser.ua);
-      assert(res.status === 403);
+      assert.ok(res.status === 403);
       // console.log(res.body);
-      assert(
+      assert.ok(
         res.body.error === '[FORBIDDEN] Can\'t modify npm public package "foo"'
       );
 
       res = await app.httpRequest().get(`/${pkg.name}/1.0.0`);
-      assert(res.status === 200);
+      assert.ok(res.status === 200);
     });
 
     it('should remove the latest version', async () => {
@@ -136,10 +136,10 @@ describe('test/port/controller/package/RemovePackageVersionController.test.ts', 
       let pkgVersion = res.body;
       let tarballUrl = new URL(pkgVersion.dist.tarball).pathname;
       res = await app.httpRequest().get(`${tarballUrl}`);
-      assert(res.status === 200 || res.status === 302);
+      assert.ok(res.status === 200 || res.status === 302);
 
       res = await app.httpRequest().get(`/${pkg.name}`).expect(200);
-      assert(res.body['dist-tags'].latest === '2.0.0');
+      assert.ok(res.body['dist-tags'].latest === '2.0.0');
 
       res = await app
         .httpRequest()
@@ -151,7 +151,7 @@ describe('test/port/controller/package/RemovePackageVersionController.test.ts', 
       assert.equal(res.body.ok, true);
 
       res = await app.httpRequest().get(`/${pkg.name}`).expect(200);
-      assert(res.body['dist-tags'].latest === '1.0.0');
+      assert.ok(res.body['dist-tags'].latest === '1.0.0');
 
       res = await app.httpRequest().get(`${tarballUrl}`);
       if (res.status === 404) {
@@ -164,8 +164,8 @@ describe('test/port/controller/package/RemovePackageVersionController.test.ts', 
       }
 
       res = await app.httpRequest().get(`/${pkg.name}`).expect(200);
-      assert(!res.body.versions['2.0.0']);
-      assert(res.body.versions['1.0.0']);
+      assert.ok(!res.body.versions['2.0.0']);
+      assert.ok(res.body.versions['1.0.0']);
       assert.equal(res.body['dist-tags'].latest, '1.0.0');
 
       // remove all versions
@@ -180,9 +180,9 @@ describe('test/port/controller/package/RemovePackageVersionController.test.ts', 
         .expect(200);
       assert.equal(res.body.ok, true);
       res = await app.httpRequest().get(`/${pkg.name}`).expect(200);
-      assert(!res.body.versions);
+      assert.ok(!res.body.versions);
       assert.equal(res.body.name, pkg.name);
-      assert(res.body.time.unpublished);
+      assert.ok(res.body.time.unpublished);
       assert.deepEqual(res.body['dist-tags'], {});
 
       // publish again work
@@ -202,10 +202,10 @@ describe('test/port/controller/package/RemovePackageVersionController.test.ts', 
       pkgVersion = res.body;
       tarballUrl = new URL(pkgVersion.dist.tarball).pathname;
       res = await app.httpRequest().get(`${tarballUrl}`);
-      assert(res.status === 200 || res.status === 302);
+      assert.ok(res.status === 200 || res.status === 302);
 
       res = await app.httpRequest().get(`/${pkg.name}`).expect(200);
-      assert(res.body['dist-tags'].latest === '2.0.0');
+      assert.ok(res.body['dist-tags'].latest === '2.0.0');
     });
 
     it('should 404 when version not exists', async () => {
@@ -278,12 +278,12 @@ describe('test/port/controller/package/RemovePackageVersionController.test.ts', 
       const tarballUrl = new URL(pkgVersion.dist.tarball).pathname;
 
       const pkgEntity = await packageRepository.findPackage('@cnpm', 'foo');
-      assert(pkgEntity);
+      assert.ok(pkgEntity);
       const pkgVersionEntity = await packageRepository.findPackageVersion(
         pkgEntity.packageId,
         '1.0.0'
       );
-      assert(pkgVersionEntity);
+      assert.ok(pkgVersionEntity);
       pkgVersionEntity.publishTime = new Date(
         Date.now() - 72 * 3_600_000 - 100
       );

--- a/test/port/controller/package/SavePackageVersionController.test.ts
+++ b/test/port/controller/package/SavePackageVersionController.test.ts
@@ -59,16 +59,16 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
       for (const manifest of [fullManifest, abbreviatedManifest]) {
         for (const v of Object.keys(manifest.versions)) {
           const version = manifest.versions[v];
-          assert(version);
+          assert.ok(version);
           assert.equal(version._source_registry_name, 'self');
-          assert(version.publish_time);
+          assert.ok(version.publish_time);
         }
       }
 
       for (const v of Object.keys(fullManifest.versions)) {
         const version = fullManifest.versions[v];
-        assert(version);
-        assert(version._cnpmcore_publish_time);
+        assert.ok(version);
+        assert.ok(version._cnpmcore_publish_time);
         assert.deepEqual(version._npmUser, {
           name: user.name,
           email: user.email,
@@ -102,7 +102,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
       );
       const selfRegistry = await registryManagerService.ensureSelfRegistry();
 
-      assert(pkgEntity);
+      assert.ok(pkgEntity);
       assert.equal(pkgEntity.registryId, selfRegistry.registryId);
     });
 
@@ -138,9 +138,9 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
             .send(pkg);
         })(),
       ]);
-      assert(errorRes.error, '[FORBIDDEN] mock error');
+      assert.ok(errorRes.error, '[FORBIDDEN] mock error');
       assert.equal(conflictRes.status, 409);
-      assert(
+      assert.ok(
         conflictRes.error,
         '[CONFLICT] Unable to create the publication lock, please try again later.'
       );
@@ -153,7 +153,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
         .set('authorization', user.authorization)
         .set('user-agent', user.ua)
         .send(pkg);
-      assert(nextErrorRes.error, '[FORBIDDEN] mock error');
+      assert.ok(nextErrorRes.error, '[FORBIDDEN] mock error');
     });
 
     it('should verify tgz and manifest', async () => {
@@ -228,10 +228,10 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
       assert.match(res.body.rev, /^\d+-\w{24}$/);
       res = await app.httpRequest().get(`/${pkg.name}/0.0.0`).expect(200);
       assert.equal(res.body.version, '0.0.0');
-      assert(res.body.description === 'init description');
+      assert.ok(res.body.description === 'init description');
       res = await app.httpRequest().get(`/${pkg.name}`).expect(200);
-      assert(res.body['dist-tags'].latest === '0.0.0');
-      assert(res.body.description === 'init description');
+      assert.ok(res.body['dist-tags'].latest === '0.0.0');
+      assert.ok(res.body.description === 'init description');
 
       // add other version
       const pkg2 = await TestUtil.getFullPackage({ name, version: '1.0.0' });
@@ -261,11 +261,11 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
       assert.match(res.body.rev, /^\d+-\w{24}$/);
 
       res = await app.httpRequest().get(`/${pkg.name}/2.0.0`).expect(200);
-      assert(res.body.version === '2.0.0');
-      assert(res.body.description === '2.0.0 description');
+      assert.ok(res.body.version === '2.0.0');
+      assert.ok(res.body.description === '2.0.0 description');
       res = await app.httpRequest().get(`/${pkg.name}`).expect(200);
-      assert(res.body['dist-tags'].latest === '2.0.0');
-      assert(res.body.description === '2.0.0 description');
+      assert.ok(res.body['dist-tags'].latest === '2.0.0');
+      assert.ok(res.body.description === '2.0.0 description');
     });
 
     it('should 403 on not allow scoped package', async () => {
@@ -307,13 +307,13 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
         .send(pkg)
         .expect(201);
 
-      assert(res);
+      assert.ok(res);
       const packageRepository = await app.getEggObject(PackageRepository);
       let pkgEntity = await packageRepository.findPackage(
         '@cnpm',
         'publish-package-test'
       );
-      assert(pkgEntity);
+      assert.ok(pkgEntity);
       pkgEntity.registryId = '';
       await packageRepository.savePackage(pkgEntity);
 
@@ -333,7 +333,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
         '@cnpm',
         'publish-package-test'
       );
-      assert(pkgEntity?.registryId);
+      assert.ok(pkgEntity?.registryId);
 
       res = await app.httpRequest().get(`/${pkg.name}`);
       assert.equal(res.body._source_registry_name, 'self');
@@ -342,7 +342,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
     it('should publish on user custom scopes', async () => {
       // add user.scopes
       const user = await userRepository.findUserByName(publisher.name);
-      assert(user);
+      assert.ok(user);
       user.scopes = ['@somescope'];
       await userRepository.saveUser(user);
       const name = '@somescope/publish-package-test';
@@ -361,7 +361,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
     it('should publish 102 chars length version', async () => {
       // https://github.com/cnpm/cnpmcore/issues/36
       const user = await userRepository.findUserByName(publisher.name);
-      assert(user);
+      assert.ok(user);
       user.scopes = ['@inrupt'];
       await userRepository.saveUser(user);
       const name = '@inrupt/solid-client';
@@ -385,7 +385,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
     it('should publish 100+ chars length name', async () => {
       // https://github.com/cnpm/cnpmcore/issues/36
       const user = await userRepository.findUserByName(publisher.name);
-      assert(user);
+      assert.ok(user);
       user.scopes = ['@inrupt'];
       await userRepository.saveUser(user);
       const name =
@@ -652,7 +652,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
       assert.equal(res.body.deprecated, deprecated);
       res = await app.httpRequest().get(`/${pkg.name}`).expect(200);
       assert.equal(res.body.versions['0.0.0'].deprecated, deprecated);
-      assert(!res.body.versions['1.0.0']);
+      assert.ok(!res.body.versions['1.0.0']);
 
       // remove deprecated message
       res = await app
@@ -681,7 +681,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
       assert.equal(res.body.deprecated, undefined);
       res = await app.httpRequest().get(`/${pkg.name}`).expect(200);
       assert.equal(res.body.versions['0.0.0'].deprecated, undefined);
-      assert(!res.body.versions['1.0.0']);
+      assert.ok(!res.body.versions['1.0.0']);
     });
 
     it('should add new version without dist success', async () => {
@@ -689,7 +689,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
         name: '@cnpm/without-dist',
         version: '0.0.0',
       });
-      assert(pkg.versions);
+      assert.ok(pkg.versions);
       const version = Object.keys(pkg.versions)[0];
       pkg.versions[version].dist = undefined;
       let res = await app
@@ -757,7 +757,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
         name: '@cnpm/with-readme-object',
         version: '0.0.0',
       });
-      assert(pkg.versions);
+      assert.ok(pkg.versions);
       const version = Object.keys(pkg.versions)[0];
       Reflect.set(pkg.versions[version], 'readme', { foo: 'bar' });
       let res = await app
@@ -883,8 +883,8 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
         .set('authorization', publisher.authorization)
         .set('user-agent', publisher.ua)
         .send(pkg);
-      assert(res.status === 422);
-      assert(
+      assert.ok(res.status === 422);
+      assert.ok(
         res.body.error ===
           '[UNPROCESSABLE_ENTITY] package.name invalid, errors: name can no longer contain special characters ("~\'!()*")'
       );
@@ -898,8 +898,8 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
         .set('authorization', publisher.authorization)
         .set('user-agent', publisher.ua)
         .send(pkg);
-      assert(res.status === 422);
-      assert(
+      assert.ok(res.status === 422);
+      assert.ok(
         res.body.error ===
           '[UNPROCESSABLE_ENTITY] package.name invalid, errors: name can only contain URL-friendly characters'
       );
@@ -913,8 +913,8 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
         .set('authorization', publisher.authorization)
         .set('user-agent', publisher.ua)
         .send(pkg);
-      assert(res.status === 422);
-      assert(
+      assert.ok(res.status === 422);
+      assert.ok(
         res.body.error ===
           '[UNPROCESSABLE_ENTITY] package.name invalid, errors: name can no longer contain more than 214 characters, name can no longer contain capital letters'
       );
@@ -929,7 +929,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
         name: '@cnpm/LegacyName',
       });
       const user = await userRepository.findUserByName(publisher.name);
-      assert(user);
+      assert.ok(user);
       await packageManagerService.publish(
         {
           scope: '@cnpm',
@@ -953,7 +953,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
         .set('authorization', publisher.authorization)
         .set('user-agent', publisher.ua)
         .send(pkg);
-      assert(res.status === 201);
+      assert.ok(res.status === 201);
     });
 
     it('should 422 when attachment data format invalid', async () => {
@@ -1120,7 +1120,9 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
           _attachments: {},
         })
         .expect(422);
-      assert(res.body.error === '[UNPROCESSABLE_ENTITY] _attachments is empty');
+      assert.ok(
+        res.body.error === '[UNPROCESSABLE_ENTITY] _attachments is empty'
+      );
 
       res = await app
         .httpRequest()
@@ -1137,7 +1139,9 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
           },
         })
         .expect(422);
-      assert(res.body.error === '[UNPROCESSABLE_ENTITY] _attachments is empty');
+      assert.ok(
+        res.body.error === '[UNPROCESSABLE_ENTITY] _attachments is empty'
+      );
 
       res = await app
         .httpRequest()
@@ -1155,7 +1159,9 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
           _attachments: null,
         })
         .expect(422);
-      assert(res.body.error === '[UNPROCESSABLE_ENTITY] _attachments is empty');
+      assert.ok(
+        res.body.error === '[UNPROCESSABLE_ENTITY] _attachments is empty'
+      );
     });
 
     it('should 422 versions is empty', async () => {
@@ -1232,7 +1238,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
           },
         })
         .expect(422);
-      assert(res.body.error === '[UNPROCESSABLE_ENTITY] dist-tags is empty');
+      assert.ok(res.body.error === '[UNPROCESSABLE_ENTITY] dist-tags is empty');
     });
 
     it('should 402 when star / unstar request', async () => {
@@ -1243,8 +1249,8 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
         .set('user-agent', publisher.ua)
         .set('npm-command', 'star')
         .send({});
-      assert(res.status === 403);
-      assert(res.body.error === '[FORBIDDEN] npm star is not allowed');
+      assert.ok(res.status === 403);
+      assert.ok(res.body.error === '[FORBIDDEN] npm star is not allowed');
 
       res = await app
         .httpRequest()
@@ -1253,8 +1259,8 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
         .set('user-agent', publisher.ua)
         .set('npm-command', 'unstar')
         .send({});
-      assert(res.status === 403);
-      assert(res.body.error === '[FORBIDDEN] npm unstar is not allowed');
+      assert.ok(res.status === 403);
+      assert.ok(res.body.error === '[FORBIDDEN] npm unstar is not allowed');
 
       res = await app
         .httpRequest()
@@ -1263,8 +1269,8 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
         .set('user-agent', publisher.ua)
         .set('referer', 'star [REDACTED]')
         .send({});
-      assert(res.status === 403);
-      assert(res.body.error === '[FORBIDDEN] npm star is not allowed');
+      assert.ok(res.status === 403);
+      assert.ok(res.body.error === '[FORBIDDEN] npm star is not allowed');
 
       res = await app
         .httpRequest()
@@ -1273,8 +1279,8 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
         .set('user-agent', publisher.ua)
         .set('referer', 'unstar [REDACTED]')
         .send({});
-      assert(res.status === 403);
-      assert(res.body.error === '[FORBIDDEN] npm unstar is not allowed');
+      assert.ok(res.status === 403);
+      assert.ok(res.body.error === '[FORBIDDEN] npm unstar is not allowed');
     });
 
     describe('granular token', async () => {
@@ -1286,7 +1292,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
         userService = await app.getEggObject(UserService);
 
         user = await userService.findUserByName(publisher.name);
-        assert(user);
+        assert.ok(user);
         token = await userService.createToken(user.userId, {
           name: publisher.name,
           type: TokenType.granular,
@@ -1315,7 +1321,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
           .set('user-agent', publisher.ua)
           .send(pkg);
 
-        assert(res.body.error, 'Token expired');
+        assert.ok(res.body.error, 'Token expired');
         assert.equal(res.status, 401);
       });
 
@@ -1337,7 +1343,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
       });
 
       it('should 200 when token has no limit', async () => {
-        assert(user);
+        assert.ok(user);
         token = await userService.createToken(user.userId, {
           name: 'new-token',
           type: TokenType.granular,
@@ -1357,7 +1363,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
       });
 
       it('should 200 when allowedScopes', async () => {
-        assert(user);
+        assert.ok(user);
         token = await userService.createToken(user.userId, {
           name: 'new-token',
           type: TokenType.granular,
@@ -1378,7 +1384,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
       });
 
       it('should 200 when allowedPackages', async () => {
-        assert(user);
+        assert.ok(user);
         await TestUtil.createPackage(
           { name: '@cnpm/other_new_pkg' },
           { name: user.name }
@@ -1404,7 +1410,7 @@ describe('test/port/controller/package/SavePackageVersionController.test.ts', ()
 
       it('should 200 add default latest tag', async () => {
         const name = '@cnpm/default_latest_tag';
-        assert(user);
+        assert.ok(user);
         token = await userService.createToken(user.userId, {
           name: 'new-token',
           type: TokenType.granular,

--- a/test/port/controller/package/ShowPackageController.test.ts
+++ b/test/port/controller/package/ShowPackageController.test.ts
@@ -112,17 +112,17 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .expect(200)
         .expect('content-type', 'application/json; charset=utf-8');
       const pkg = res.body;
-      assert(pkg.name === name);
-      assert(pkg.readme);
-      assert(Object.keys(pkg.versions).length === 2);
+      assert.ok(pkg.name === name);
+      assert.ok(pkg.readme);
+      assert.ok(Object.keys(pkg.versions).length === 2);
       // console.log(JSON.stringify(pkg, null, 2));
       const versionOne = pkg.versions['1.0.0'];
       assert.equal(versionOne.dist.unpackedSize, 6_497_043);
-      assert(versionOne._cnpmcore_publish_time);
-      assert(versionOne.publish_time);
+      assert.ok(versionOne._cnpmcore_publish_time);
+      assert.ok(versionOne.publish_time);
       assert.equal(pkg._id, name);
-      assert(pkg._rev);
-      assert(versionOne._id);
+      assert.ok(pkg._rev);
+      assert.ok(versionOne._id);
       assert.equal(
         versionOne.dist.tarball,
         `https://registry.example.com/${name}/-/${name}-1.0.0.tgz`
@@ -157,7 +157,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .set('If-None-Match', res.headers.etag)
         .expect('vary', 'Origin')
         .expect(200);
-      assert(res2.body.name);
+      assert.ok(res2.body.name);
       assert.equal(res2.headers.etag, res.headers.etag);
       res2 = await app
         .httpRequest()
@@ -166,7 +166,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .set('user-agent', 'npm_service.cnpmjs.org/1.0.0')
         .expect('vary', 'Origin')
         .expect(200);
-      assert(res2.body.name);
+      assert.ok(res2.body.name);
       assert.equal(res2.headers.etag, res.headers.etag);
 
       mock(app.config.cnpmcore, 'enableCDN', true);
@@ -184,9 +184,9 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .get(`/${name}`)
         .set('If-None-Match', res.headers.etag)
         .set('Accept', 'application/vnd.npm.install-v1+json');
-      assert(res2.status === 200);
-      assert(!res2.body.readme);
-      assert(res2.headers.vary === 'Origin');
+      assert.ok(res2.status === 200);
+      assert.ok(!res2.body.readme);
+      assert.ok(res2.headers.vary === 'Origin');
 
       mock(app.config.cnpmcore, 'enableCDN', true);
       res2 = await app
@@ -194,9 +194,9 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .get(`/${name}`)
         .set('If-None-Match', res.headers.etag)
         .set('Accept', 'application/vnd.npm.install-v1+json');
-      assert(res2.status === 200);
-      assert(!res2.body.readme);
-      assert(res2.headers.vary === 'Origin, Accept, Accept-Encoding');
+      assert.ok(res2.status === 200);
+      assert.ok(!res2.body.readme);
+      assert.ok(res2.headers.vary === 'Origin, Accept, Accept-Encoding');
 
       // remove W/ still work
       mock(app.config.cnpmcore, 'enableCDN', false);
@@ -206,7 +206,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .set('if-none-match', res.headers.etag.replace('W/', ''))
         .expect(304);
       assert.equal(resEmpty.text, '');
-      assert(resEmpty.headers.vary === 'Origin');
+      assert.ok(resEmpty.headers.vary === 'Origin');
 
       mock(app.config.cnpmcore, 'enableCDN', true);
       resEmpty = await app
@@ -215,7 +215,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .set('if-none-match', res.headers.etag.replace('W/', ''))
         .expect(304);
       assert.equal(resEmpty.text, '');
-      assert(resEmpty.headers.vary === 'Origin, Accept, Accept-Encoding');
+      assert.ok(resEmpty.headers.vary === 'Origin, Accept, Accept-Encoding');
 
       // etag not match
       const resNew = await app
@@ -223,15 +223,15 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .get(`/${name}`)
         .set('if-none-match', res.headers.etag.replace('"', '"change'))
         .expect(200);
-      assert(resNew.text);
-      assert(
+      assert.ok(resNew.text);
+      assert.ok(
         resNew.headers['content-type'] === 'application/json; charset=utf-8'
       );
-      assert(resNew.body.name === name);
+      assert.ok(resNew.body.name === name);
 
       // HEAD work
       const resHead = await app.httpRequest().head(`/${name}`).expect(200);
-      assert(!resHead.text);
+      assert.ok(!resHead.text);
       assert.match(resHead.headers.etag, /^W\/"\w{40}"$/);
 
       // new version, cache should update
@@ -260,24 +260,24 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .expect(200)
         .expect('content-type', 'application/json; charset=utf-8');
       const pkg = res.body;
-      assert(pkg.name === scopedName);
-      assert(Object.keys(pkg.versions).length === 2);
+      assert.ok(pkg.name === scopedName);
+      assert.ok(Object.keys(pkg.versions).length === 2);
       // console.log(JSON.stringify(pkg, null, 2));
       const versionOne = pkg.versions['1.0.0'];
-      assert(versionOne.dist.unpackedSize === 6_497_043);
-      assert(versionOne._cnpmcore_publish_time);
+      assert.ok(versionOne.dist.unpackedSize === 6_497_043);
+      assert.ok(versionOne._cnpmcore_publish_time);
       assert.equal(typeof versionOne._cnpmcore_publish_time, 'string');
-      assert(versionOne.publish_time);
+      assert.ok(versionOne.publish_time);
       assert.equal(typeof versionOne.publish_time, 'number');
-      assert(pkg._id === scopedName);
-      assert(pkg._rev);
-      assert(versionOne._id);
-      assert(
+      assert.ok(pkg._id === scopedName);
+      assert.ok(pkg._rev);
+      assert.ok(versionOne._id);
+      assert.ok(
         versionOne.dist.tarball ===
           `https://registry.example.com/${scopedName}/-/${name}-1.0.0.tgz`
       );
-      assert(!res.headers['cache-control']);
-      assert(res.headers.vary === 'Origin');
+      assert.ok(!res.headers['cache-control']);
+      assert.ok(res.headers.vary === 'Origin');
     });
 
     it('should show one scoped package with full manifests with CDN enable', async () => {
@@ -293,11 +293,11 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
       // console.log(JSON.stringify(pkg, null, 2));
       const versionOne = pkg.versions['1.0.0'];
       assert.equal(versionOne.dist.unpackedSize, 6_497_043);
-      assert(versionOne._cnpmcore_publish_time);
+      assert.ok(versionOne._cnpmcore_publish_time);
       assert.equal(pkg._id, scopedName);
-      assert(pkg._rev);
-      assert(versionOne._id);
-      assert(
+      assert.ok(pkg._rev);
+      assert.ok(versionOne._id);
+      assert.ok(
         versionOne.dist.tarball ===
           `https://registry.example.com/${scopedName}/-/${name}-1.0.0.tgz`
       );
@@ -320,12 +320,12 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
       // console.log(JSON.stringify(pkg, null, 2));
       const versionOne = pkg.versions['2.0.0'];
       assert.equal(versionOne.dist.unpackedSize, 6_497_043);
-      assert(!versionOne._cnpmcore_publish_time);
-      assert(versionOne.publish_time);
+      assert.ok(!versionOne._cnpmcore_publish_time);
+      assert.ok(versionOne.publish_time);
       assert.equal(typeof versionOne.publish_time, 'number');
-      assert(!pkg._rev);
-      assert(!pkg._id);
-      assert(!versionOne._id);
+      assert.ok(!pkg._rev);
+      assert.ok(!pkg._id);
+      assert.ok(!versionOne._id);
       assert.equal(
         versionOne.dist.tarball,
         `https://registry.example.com/${name}/-/${name}-2.0.0.tgz`
@@ -355,11 +355,11 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .set('Accept', 'application/vnd.npm.install-v1+json')
         .set('if-none-match', res.headers.etag.replace('"', '"change'))
         .expect(200);
-      assert(resNew.text);
-      assert(
+      assert.ok(resNew.text);
+      assert.ok(
         resNew.headers['content-type'] === 'application/json; charset=utf-8'
       );
-      assert(resNew.body.name === name);
+      assert.ok(resNew.body.name === name);
 
       // HEAD work
       const resHead = await app
@@ -367,7 +367,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .head(`/${name}`)
         .set('Accept', 'application/vnd.npm.install-v1+json')
         .expect(200);
-      assert(!resHead.text);
+      assert.ok(!resHead.text);
       assert.match(resHead.headers.etag, /^W\/"\w{40}"$/);
 
       // new version, cache should update
@@ -397,18 +397,18 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
       // console.log(JSON.stringify(pkg, null, 2));
       const versionOne = pkg.versions['2.0.0'];
       assert.equal(versionOne.dist.unpackedSize, 6_497_043);
-      assert(!versionOne._cnpmcore_publish_time);
-      assert(versionOne.publish_time);
+      assert.ok(!versionOne._cnpmcore_publish_time);
+      assert.ok(versionOne.publish_time);
       assert.equal(typeof versionOne.publish_time, 'number');
-      assert(!pkg._rev);
-      assert(!pkg._id);
-      assert(!versionOne._id);
-      assert(
+      assert.ok(!pkg._rev);
+      assert.ok(!pkg._id);
+      assert.ok(!versionOne._id);
+      assert.ok(
         versionOne.dist.tarball ===
           `https://registry.example.com/${scopedName}/-/${name}-2.0.0.tgz`
       );
-      assert(!res.headers['cache-control']);
-      assert(res.headers.vary === 'Origin');
+      assert.ok(!res.headers['cache-control']);
+      assert.ok(res.headers.vary === 'Origin');
     });
 
     it('should show one scoped package with abbreviated manifests with CDN enable', async () => {
@@ -420,18 +420,18 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .expect(200)
         .expect('content-type', 'application/json; charset=utf-8');
       const pkg = res.body;
-      assert(pkg.name === scopedName);
-      assert(Object.keys(pkg.versions).length === 2);
+      assert.ok(pkg.name === scopedName);
+      assert.ok(Object.keys(pkg.versions).length === 2);
       // console.log(JSON.stringify(pkg, null, 2));
       const versionOne = pkg.versions['2.0.0'];
-      assert(versionOne.dist.unpackedSize === 6_497_043);
-      assert(!versionOne._cnpmcore_publish_time);
-      assert(versionOne.publish_time);
+      assert.ok(versionOne.dist.unpackedSize === 6_497_043);
+      assert.ok(!versionOne._cnpmcore_publish_time);
+      assert.ok(versionOne.publish_time);
       assert.equal(typeof versionOne.publish_time, 'number');
-      assert(!pkg._rev);
-      assert(!pkg._id);
-      assert(!versionOne._id);
-      assert(
+      assert.ok(!pkg._rev);
+      assert.ok(!pkg._id);
+      assert.ok(!versionOne._id);
+      assert.ok(
         versionOne.dist.tarball ===
           `https://registry.example.com/${scopedName}/-/${name}-2.0.0.tgz`
       );
@@ -447,9 +447,9 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .expect(404)
         .expect('content-type', 'application/json; charset=utf-8');
       let data = res.body;
-      assert(!res.headers.etag);
-      assert(!res.headers['cache-control']);
-      assert(
+      assert.ok(!res.headers.etag);
+      assert.ok(!res.headers['cache-control']);
+      assert.ok(
         data.error ===
           '[NOT_FOUND] @cnpm/testmodule-show-package-not-exists not found'
       );
@@ -463,9 +463,9 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .expect(404)
         .expect('content-type', 'application/json; charset=utf-8');
       data = res.body;
-      assert(!res.headers.etag);
-      assert(!res.headers['cache-control']);
-      assert(
+      assert.ok(!res.headers.etag);
+      assert.ok(!res.headers['cache-control']);
+      assert.ok(
         data.error ===
           '[NOT_FOUND] @cnpm/testmodule-show-package-not-exists not found'
       );
@@ -479,9 +479,9 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .expect(404)
         .expect('content-type', 'application/json; charset=utf-8');
       let data = res.body;
-      assert(!res.headers.etag);
-      assert(!res.headers['cache-control']);
-      assert(
+      assert.ok(!res.headers.etag);
+      assert.ok(!res.headers['cache-control']);
+      assert.ok(
         data.error ===
           '[NOT_FOUND] @cnpm/testmodule-show-package-not-exists not found'
       );
@@ -495,9 +495,9 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .expect(404)
         .expect('content-type', 'application/json; charset=utf-8');
       data = res.body;
-      assert(!res.headers.etag);
-      assert(!res.headers['cache-control']);
-      assert(
+      assert.ok(!res.headers.etag);
+      assert.ok(!res.headers['cache-control']);
+      assert.ok(
         data.error ===
           '[NOT_FOUND] @cnpm/testmodule-show-package-not-exists not found'
       );
@@ -560,7 +560,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .expect('content-type', 'application/json; charset=utf-8');
       pkg = res.body;
       versionOne = pkg.versions[Object.keys(pkg.versions)[0]];
-      assert(versionOne.hasInstallScript === true);
+      assert.ok(versionOne.hasInstallScript === true);
 
       pkg = await TestUtil.getFullPackage({
         name: '@cnpm/test-module-postinstall-scripts',
@@ -589,7 +589,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .expect('content-type', 'application/json; charset=utf-8');
       pkg = res.body;
       versionOne = pkg.versions[Object.keys(pkg.versions)[0]];
-      assert(versionOne.hasInstallScript === true);
+      assert.ok(versionOne.hasInstallScript === true);
     });
 
     it('should abbreviated manifests work when dist not exists', async () => {
@@ -611,7 +611,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         '@cnpm',
         'test-module-mock-dist-not-exists'
       );
-      assert(pkgModel);
+      assert.ok(pkgModel);
       await packageRepository.removePackageDist(pkgModel, false);
 
       res = await app
@@ -622,7 +622,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .expect('content-type', 'application/json; charset=utf-8');
       pkg = res.body;
       const versionOne = pkg.versions[Object.keys(pkg.versions)[0]];
-      assert(!versionOne.hasInstallScript);
+      assert.ok(!versionOne.hasInstallScript);
       assert.equal(versionOne.version, '1.0.0');
     });
 
@@ -645,7 +645,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         '@cnpm',
         'test-module-mock-dist-not-exists-full-manifests'
       );
-      assert(pkgModel);
+      assert.ok(pkgModel);
       await packageRepository.removePackageDist(pkgModel, true);
 
       res = await app
@@ -656,7 +656,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .expect('content-type', 'application/json; charset=utf-8');
       pkg = res.body;
       const versionOne = pkg.versions[Object.keys(pkg.versions)[0]];
-      assert(!versionOne.hasInstallScript);
+      assert.ok(!versionOne.hasInstallScript);
       assert.equal(versionOne.version, '1.0.0');
     });
 
@@ -677,7 +677,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
       assert.match(res.body.rev, /^\d+-\w{24}$/);
 
       const pkgEntity = await packageRepository.findPackage('@cnpm', name);
-      assert(pkgEntity);
+      assert.ok(pkgEntity);
       await packageRepository.removePackageDist(pkgEntity, true);
       await packageRepository.removePackageVersions(pkgEntity.packageId);
 
@@ -686,8 +686,8 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .get(`/${pkg.name}`)
         .set('Accept', 'application/json')
         .expect('content-type', 'application/json; charset=utf-8');
-      assert(res.status === 404);
-      assert(res.body.error === `[NOT_FOUND] @cnpm/${name} not found`);
+      assert.ok(res.status === 404);
+      assert.ok(res.body.error === `[NOT_FOUND] @cnpm/${name} not found`);
     });
 
     it('should abbreviated manifests work when all versions not exists', async () => {
@@ -708,7 +708,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
       assert.match(res.body.rev, /^\d+-\w{24}$/);
 
       const pkgEntity = await packageRepository.findPackage('@cnpm', name);
-      assert(pkgEntity);
+      assert.ok(pkgEntity);
       await packageRepository.removePackageDist(pkgEntity, false);
       await packageRepository.removePackageVersions(pkgEntity.packageId);
 
@@ -717,8 +717,8 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .get(`/${pkg.name}`)
         .set('Accept', 'application/vnd.npm.install-v1+json')
         .expect('content-type', 'application/json; charset=utf-8');
-      assert(res.status === 404);
-      assert(res.body.error === `[NOT_FOUND] @cnpm/${name} not found`);
+      assert.ok(res.status === 404);
+      assert.ok(res.body.error === `[NOT_FOUND] @cnpm/${name} not found`);
     });
 
     it('should redirect to source registry if public package not exists when syncMode=none', async () => {
@@ -762,8 +762,8 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
     it('should not redirect to source registry if public package not exists when syncMode=all', async () => {
       mock(app.config.cnpmcore, 'syncMode', 'all');
       const res = await app.httpRequest().get('/123');
-      assert(res.status === 404);
-      assert(res.body.error === '[NOT_FOUND] 123 not found');
+      assert.ok(res.status === 404);
+      assert.ok(res.body.error === '[NOT_FOUND] 123 not found');
     });
 
     it('should not redirect private scope package to source registry if package not exists when syncMode=all', async () => {
@@ -773,8 +773,8 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .get('/@cnpm/cnpmcore')
         .set('Accept', 'application/vnd.npm.install-v1+json')
         .expect('content-type', 'application/json; charset=utf-8');
-      assert(res.status === 404);
-      assert(res.body.error === '[NOT_FOUND] @cnpm/cnpmcore not found');
+      assert.ok(res.status === 404);
+      assert.ok(res.body.error === '[NOT_FOUND] @cnpm/cnpmcore not found');
 
       res = await app
         .httpRequest()
@@ -783,7 +783,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .set('Accept', 'application/json')
         .expect(404)
         .expect('content-type', 'application/json; charset=utf-8');
-      assert(res.body.error === '[NOT_FOUND] @cnpm/cnpmcore not found');
+      assert.ok(res.body.error === '[NOT_FOUND] @cnpm/cnpmcore not found');
     });
 
     it('should not redirect private scope package to source registry if package not exists when syncMode=none', async () => {
@@ -794,7 +794,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .set('Accept', 'application/vnd.npm.install-v1+json')
         .expect(404)
         .expect('content-type', 'application/json; charset=utf-8');
-      assert(res.body.error === '[NOT_FOUND] @cnpm/cnpmcore not found');
+      assert.ok(res.body.error === '[NOT_FOUND] @cnpm/cnpmcore not found');
 
       res = await app
         .httpRequest()
@@ -803,7 +803,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .set('Accept', 'application/json')
         .expect(404)
         .expect('content-type', 'application/json; charset=utf-8');
-      assert(res.body.error === '[NOT_FOUND] @cnpm/cnpmcore not found');
+      assert.ok(res.body.error === '[NOT_FOUND] @cnpm/cnpmcore not found');
     });
 
     it('should redirect public scope package to source registry if package not exists when syncMode=none', async () => {
@@ -812,8 +812,8 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .httpRequest()
         .get('/@eggjs/tegg-metadata')
         .set('Accept', 'application/vnd.npm.install-v1+json');
-      assert(res.status === 302);
-      assert(
+      assert.ok(res.status === 302);
+      assert.ok(
         res.headers.location ===
           'https://registry.npmjs.org/@eggjs/tegg-metadata'
       );
@@ -823,8 +823,8 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .get('/@eggjs/tegg-metadata')
         .query({ t: '0123123', foo: 'bar' })
         .set('Accept', 'application/json');
-      assert(res.status === 302);
-      assert(
+      assert.ok(res.status === 302);
+      assert.ok(
         res.headers.location ===
           'https://registry.npmjs.org/@eggjs/tegg-metadata?t=0123123&foo=bar'
       );
@@ -837,7 +837,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .httpRequest()
         .get('/@eggjs/tegg-metadata')
         .set('Accept', 'application/vnd.npm.install-v1+json');
-      assert(res.status === 404);
+      assert.ok(res.status === 404);
     });
 
     it('should redirect public non-scope package to source registry if package not exists when syncMode=none', async () => {
@@ -846,16 +846,16 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .httpRequest()
         .get('/egg')
         .set('Accept', 'application/vnd.npm.install-v1+json');
-      assert(res.status === 302);
-      assert(res.headers.location === 'https://registry.npmjs.org/egg');
+      assert.ok(res.status === 302);
+      assert.ok(res.headers.location === 'https://registry.npmjs.org/egg');
 
       res = await app
         .httpRequest()
         .get('/egg')
         .query({ t: '0123123', foo: 'bar' })
         .set('Accept', 'application/json');
-      assert(res.status === 302);
-      assert(
+      assert.ok(res.status === 302);
+      assert.ok(
         res.headers.location ===
           'https://registry.npmjs.org/egg?t=0123123&foo=bar'
       );
@@ -882,16 +882,16 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .expect(200)
         .expect('content-type', 'application/json; charset=utf-8');
       const shouldFixVersion = res.body.versions['2.0.0'];
-      assert(
+      assert.ok(
         shouldFixVersion.dist.tarball ===
           'https://registry.example.com/testmodule-show-package/-/testmodule-show-package-1.0.0.tgz'
       );
-      assert(
+      assert.ok(
         shouldFixVersion.deprecated ===
           '[WARNING] Use 1.0.0 instead of 2.0.0, reason: mock reason'
       );
       // don't change version
-      assert(shouldFixVersion.version === '2.0.0');
+      assert.ok(shouldFixVersion.version === '2.0.0');
 
       // sync worker request should not effect
       res = await app
@@ -900,12 +900,12 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .expect(200)
         .expect('content-type', 'application/json; charset=utf-8');
       const orginalVersion = res.body.versions['2.0.0'];
-      assert(
+      assert.ok(
         orginalVersion.dist.tarball ===
           'https://registry.example.com/testmodule-show-package/-/testmodule-show-package-2.0.0.tgz'
       );
-      assert(!orginalVersion.deprecated);
-      assert(orginalVersion.version === '2.0.0');
+      assert.ok(!orginalVersion.deprecated);
+      assert.ok(orginalVersion.version === '2.0.0');
     });
 
     it('should show _source_registry_name', async () => {
@@ -919,8 +919,8 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .expect('content-type', 'application/json; charset=utf-8');
 
       const data = res.body as PackageManifestType;
-      assert(data._source_registry_name === 'self');
-      assert(
+      assert.ok(data._source_registry_name === 'self');
+      assert.ok(
         Object.values(data.versions).every(
           v => v && v._source_registry_name === 'self'
         )
@@ -939,7 +939,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .expect('content-type', 'application/json; charset=utf-8');
 
       const data = res.body as PackageManifestType;
-      assert(
+      assert.ok(
         Object.values(data.versions).every(
           v => v && v._source_registry_name === 'self'
         )
@@ -993,7 +993,7 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .get('/lodash')
         .set('user-agent', publisher.ua + ' node/16.0.0')
         .set('Accept', 'application/vnd.npm.install-v1+json');
-      assert(res.status === 404);
+      assert.ok(res.status === 404);
       // app.expectLog('[middleware:ErrorHandler][syncPackage] create sync package');
     });
 
@@ -1006,8 +1006,8 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .get('/egg')
         .set('user-agent', publisher.ua + ' node/16.0.0')
         .set('Accept', 'application/vnd.npm.install-v1+json');
-      assert(res.status === 302);
-      assert(res.headers.location === 'https://registry.npmjs.org/egg');
+      assert.ok(res.status === 302);
+      assert.ok(res.headers.location === 'https://registry.npmjs.org/egg');
     });
 
     it('should read manifest from source in proxy mode', async () => {
@@ -1025,9 +1025,9 @@ describe('test/port/controller/package/ShowPackageController.test.ts', () => {
         .get('/foobar')
         .set('user-agent', publisher.ua + ' node/16.0.0')
         .set('Accept', 'application/vnd.npm.install-v1+json');
-      assert(res.status === 200);
-      assert(res.body.description === 'cnpmcore mock json');
-      assert(
+      assert.ok(res.status === 200);
+      assert.ok(res.body.description === 'cnpmcore mock json');
+      assert.ok(
         res.body.versions['1.0.0'].dist.tarball.includes(
           app.config.cnpmcore.registry
         )

--- a/test/port/controller/package/ShowPackageVersionController.test.ts
+++ b/test/port/controller/package/ShowPackageVersionController.test.ts
@@ -37,7 +37,7 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
         .expect('content-type', 'application/json; charset=utf-8');
       assert.equal(res.body.name, 'foo');
       assert.match(res.body.dist.tarball, /^http:\/\//);
-      assert(res.body.dist.tarball.endsWith('/foo/-/foo-1.0.0.tgz'));
+      assert.ok(res.body.dist.tarball.endsWith('/foo/-/foo-1.0.0.tgz'));
       assert.equal(
         res.body.dist.shasum,
         'fa475605f88bab9b1127833633ca3ae0a477224c'
@@ -131,15 +131,15 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
         .expect(200)
         .expect('content-type', 'application/json; charset=utf-8');
 
-      assert(
+      assert.ok(
         new URL(res.body.dist.tarball).pathname === '/foo/-/foo-1.0.0.tgz'
       );
-      assert(
+      assert.ok(
         res.body.deprecated ===
           '[WARNING] Use 1.0.0 instead of 2.0.0, reason: mock reason'
       );
       // don't change version
-      assert(res.body.version === '2.0.0');
+      assert.ok(res.body.version === '2.0.0');
 
       // same version not fix bug version
       res = await app
@@ -148,11 +148,11 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
         .expect(200)
         .expect('content-type', 'application/json; charset=utf-8');
 
-      assert(
+      assert.ok(
         new URL(res.body.dist.tarball).pathname === '/foo/-/foo-3.0.0.tgz'
       );
-      assert(!res.body.deprecated);
-      assert(res.body.version === '3.0.0');
+      assert.ok(!res.body.deprecated);
+      assert.ok(res.body.version === '3.0.0');
 
       // sync worker request should not effect
       res = await app
@@ -160,11 +160,11 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
         .get(`/${pkgV1.name}/2.0.0?cache=0`)
         .expect(200)
         .expect('content-type', 'application/json; charset=utf-8');
-      assert(
+      assert.ok(
         new URL(res.body.dist.tarball).pathname === '/foo/-/foo-2.0.0.tgz'
       );
-      assert(!res.body.deprecated);
-      assert(res.body.version === '2.0.0');
+      assert.ok(!res.body.deprecated);
+      assert.ok(res.body.version === '2.0.0');
     });
 
     it('should 422 with invalid spec', async () => {
@@ -173,7 +173,7 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
         .get('/foo/@invalid-spec')
         .expect(422)
         .expect('content-type', 'application/json; charset=utf-8');
-      assert(res.error, '[INVALID_PARAM] must match format "semver-spec"');
+      assert.ok(res.error, '[INVALID_PARAM] must match format "semver-spec"');
     });
 
     it('should work with scoped package', async () => {
@@ -197,7 +197,7 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
         .get('/@cnpm/foo/1.0.0')
         .expect(200)
         .expect(res => {
-          assert(res.body);
+          assert.ok(res.body);
         });
     });
 
@@ -215,17 +215,17 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
         .set('authorization', publisher.authorization)
         .set('user-agent', publisher.ua)
         .send(pkg);
-      assert(res.status === 201);
+      assert.ok(res.status === 201);
       res = await app.httpRequest().get(`/${pkg.name}/latest`);
-      assert(res.status === 200);
-      assert(res.body.version === '1.0.0');
-      assert(!res.headers['cache-control']);
-      assert(res.headers.vary === 'Origin');
+      assert.ok(res.status === 200);
+      assert.ok(res.body.version === '1.0.0');
+      assert.ok(!res.headers['cache-control']);
+      assert.ok(res.headers.vary === 'Origin');
 
       mock(app.config.cnpmcore, 'enableCDN', true);
       res = await app.httpRequest().get(`/${pkg.name}/latest`);
-      assert(res.status === 200);
-      assert(res.body.version === '1.0.0');
+      assert.ok(res.status === 200);
+      assert.ok(res.body.version === '1.0.0');
       assert.equal(res.headers['cache-control'], 'public, max-age=300');
       assert.equal(res.headers.vary, 'Origin, Accept, Accept-Encoding');
     });
@@ -270,7 +270,7 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
       // 404 when tag not exists
       res = await app.httpRequest().get(`/${pkg.name}/beta-not-exists`);
       assert.equal(res.status, 404);
-      assert(!res.headers.etag);
+      assert.ok(!res.headers.etag);
       assert.equal(
         res.body.error,
         `[NOT_FOUND] ${pkg.name}@beta-not-exists not found`
@@ -297,7 +297,7 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
         .httpRequest()
         .get(`/${pkg.name}/1.0.40000404`)
         .expect(404);
-      assert(!res.headers.etag);
+      assert.ok(!res.headers.etag);
       assert.equal(
         res.body.error,
         `[NOT_FOUND] ${pkg.name}@1.0.40000404 not found`
@@ -309,8 +309,8 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
         .httpRequest()
         .get(`/${pkg.name}/1.0.40000404`)
         .expect(404);
-      assert(!res.headers.etag);
-      assert(
+      assert.ok(!res.headers.etag);
+      assert.ok(
         res.body.error === `[NOT_FOUND] ${pkg.name}@1.0.40000404 not found`
       );
     });
@@ -320,7 +320,7 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
         .httpRequest()
         .get('/@cnpm/foonot-exists/1.0.40000404')
         .expect(404);
-      assert(!res.headers.etag);
+      assert.ok(!res.headers.etag);
       assert.equal(res.body.error, '[NOT_FOUND] @cnpm/foonot-exists not found');
     });
 
@@ -330,7 +330,7 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
         .httpRequest()
         .get('/foonot-not-exists/1.0.40000404')
         .expect(404);
-      assert(res.body.error === '[NOT_FOUND] foonot-not-exists not found');
+      assert.ok(res.body.error === '[NOT_FOUND] foonot-not-exists not found');
 
       mock(app.config.cnpmcore, 'allowPublishNonScopePackage', true);
       await TestUtil.createPackage({ name: 'foo-exists', isPrivate: false });
@@ -365,9 +365,9 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
     it('should redirect public scope package to source registry when syncMode=none', async () => {
       mock(app.config.cnpmcore, 'syncMode', 'none');
       let res = await app.httpRequest().get('/@egg/foonot-exists/1.0.40000404');
-      assert(res.status === 302);
-      assert(!res.headers.etag);
-      assert(
+      assert.ok(res.status === 302);
+      assert.ok(!res.headers.etag);
+      assert.ok(
         res.headers.location ===
           'https://registry.npmjs.org/@egg/foonot-exists/1.0.40000404'
       );
@@ -375,9 +375,9 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
       res = await app
         .httpRequest()
         .get('/@egg/foonot-exists/1.0.40000404?t=123');
-      assert(res.status === 302);
-      assert(!res.headers.etag);
-      assert(
+      assert.ok(res.status === 302);
+      assert.ok(!res.headers.etag);
+      assert.ok(
         res.headers.location ===
           'https://registry.npmjs.org/@egg/foonot-exists/1.0.40000404?t=123'
       );
@@ -407,7 +407,7 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
     it('should show _source_registry_name in version manifest', async () => {
       await TestUtil.createPackage({ name: '@cnpm/foo', version: '1.0.0' });
       const res = await app.httpRequest().get('/@cnpm/foo/1.0.0').expect(200);
-      assert(res.body._source_registry_name === 'self');
+      assert.ok(res.body._source_registry_name === 'self');
     });
 
     it('should show _source_registry_name in version manifest for abbreviated', async () => {
@@ -417,7 +417,7 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
         .get('/@cnpm/foo/1.0.0')
         .set('accept', 'application/vnd.npm.install-v1+json')
         .expect(200);
-      assert(res.body._source_registry_name === 'self');
+      assert.ok(res.body._source_registry_name === 'self');
     });
 
     it('should read package version manifest from source in proxy mode', async () => {
@@ -435,8 +435,8 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
         .get('/foobar/1.0.0')
         .set('user-agent', publisher.ua + ' node/16.0.0')
         .set('Accept', 'application/vnd.npm.install-v1+json');
-      assert(res.status === 200);
-      assert(res.body.dist.tarball.includes(app.config.cnpmcore.registry));
+      assert.ok(res.status === 200);
+      assert.ok(res.body.dist.tarball.includes(app.config.cnpmcore.registry));
     });
   });
 });

--- a/test/port/middleware/Tracing.test.ts
+++ b/test/port/middleware/Tracing.test.ts
@@ -4,6 +4,6 @@ import { app } from '@eggjs/mock/bootstrap';
 describe('test/port/middleware/Tracing.test.ts', () => {
   it('should set request-id header', async () => {
     const res = await app.httpRequest().get('/').expect(200);
-    assert(res.headers['request-id']);
+    assert.ok(res.headers['request-id']);
   });
 });

--- a/test/port/webauth/webauthController.test.ts
+++ b/test/port/webauth/webauthController.test.ts
@@ -17,8 +17,8 @@ describe('test/port/webauth/webauthController.test.ts', () => {
       });
 
       assert.equal(res.status, 200);
-      assert(res.body.loginUrl);
-      assert(res.body.doneUrl);
+      assert.ok(res.body.loginUrl);
+      assert.ok(res.body.doneUrl);
       const loginSessionId = basename(res.body.loginUrl);
       const doneSessionId = basename(res.body.doneUrl);
       assert.equal(loginSessionId, doneSessionId);
@@ -60,7 +60,7 @@ describe('test/port/webauth/webauthController.test.ts', () => {
         .get(`/-/v1/login/request/session/${crypto.randomUUID()}`);
 
       assert.equal(res.status, 404);
-      assert(/Session not found/.test(res.text));
+      assert.ok(/Session not found/.test(res.text));
       assert.equal(res.headers['content-type'], 'text/html; charset=utf-8');
     });
 
@@ -70,7 +70,7 @@ describe('test/port/webauth/webauthController.test.ts', () => {
         .get(`/-/v1/login/request/session/${sessionId}`);
 
       assert.equal(res.status, 200);
-      assert(/<title>Sign in to CNPM<\/title>/.test(res.text));
+      assert.ok(/<title>Sign in to CNPM<\/title>/.test(res.text));
     });
   });
 
@@ -102,7 +102,7 @@ describe('test/port/webauth/webauthController.test.ts', () => {
         .post(`/-/v1/login/request/session/${crypto.randomUUID()}`);
 
       assert.equal(res.status, 200);
-      assert(/Session not found/.test(res.text));
+      assert.ok(/Session not found/.test(res.text));
       assert.equal(
         res.headers['content-type'],
         'application/json; charset=utf-8'
@@ -149,7 +149,7 @@ describe('test/port/webauth/webauthController.test.ts', () => {
           });
 
         assert.equal(res.status, 200);
-        assert(
+        assert.ok(
           /Please check your login name and password/.test(res.body.message)
         );
       });
@@ -167,7 +167,7 @@ describe('test/port/webauth/webauthController.test.ts', () => {
           });
 
         assert.equal(res.status, 200);
-        assert(/Unauthorized, Validation Failed/.test(res.body.message));
+        assert.ok(/Unauthorized, Validation Failed/.test(res.body.message));
       });
 
       it('should check authentication user (unbound webauthn) when enableWebauthn', async () => {
@@ -186,7 +186,7 @@ describe('test/port/webauth/webauthController.test.ts', () => {
           });
 
         assert.equal(res.status, 200);
-        assert(
+        assert.ok(
           /Unauthorized, Please check your login name/.test(res.body.message)
         );
       });
@@ -208,7 +208,7 @@ describe('test/port/webauth/webauthController.test.ts', () => {
         assert.equal(res.body.ok, true);
 
         const user = await userRepository.findUserByName('orange');
-        assert(user);
+        assert.ok(user);
       });
 
       it('only support admin when not allowPublicRegistration', async () => {
@@ -225,7 +225,7 @@ describe('test/port/webauth/webauthController.test.ts', () => {
           });
 
         assert.equal(res.status, 200);
-        assert(/Public registration is not allowed/.test(res.body.message));
+        assert.ok(/Public registration is not allowed/.test(res.body.message));
       });
     });
   });
@@ -269,7 +269,7 @@ describe('test/port/webauth/webauthController.test.ts', () => {
         .get(`/-/v1/login/request/prepare/${crypto.randomUUID()}?name=banana`);
 
       assert.equal(res.status, 200);
-      assert(/Session not found/.test(res.text));
+      assert.ok(/Session not found/.test(res.text));
       assert.equal(
         res.headers['content-type'],
         'application/json; charset=utf-8'
@@ -282,7 +282,7 @@ describe('test/port/webauth/webauthController.test.ts', () => {
         .get(`/-/v1/login/request/prepare/${sessionId}?name=banana`);
 
       assert.equal(res.status, 200);
-      assert(typeof res.body.wanCredentialAuthOption === 'object');
+      assert.ok(typeof res.body.wanCredentialAuthOption === 'object');
     });
 
     it('should get prepare with registration options', async () => {
@@ -291,7 +291,7 @@ describe('test/port/webauth/webauthController.test.ts', () => {
         .get(`/-/v1/login/request/prepare/${sessionId}?name=apple`);
 
       assert.equal(res.status, 200);
-      assert(typeof res.body.wanCredentialRegiOption === 'object');
+      assert.ok(typeof res.body.wanCredentialRegiOption === 'object');
     });
   });
 
@@ -351,7 +351,7 @@ describe('test/port/webauth/webauthController.test.ts', () => {
 
       assert.equal(res.status, 200);
       assert.equal(res.headers['content-type'], 'text/html; charset=utf-8');
-      assert(/Authorization Successful/.test(res.text));
+      assert.ok(/Authorization Successful/.test(res.text));
     });
   });
 

--- a/test/repository/PackageRepository.test.ts
+++ b/test/repository/PackageRepository.test.ts
@@ -45,8 +45,8 @@ describe('test/repository/PackageRepository.test.ts', () => {
       );
       await setTimeout(1000);
       const res = await packageRepository.queryTotal();
-      assert(res.packageCount >= packageCount);
-      assert(res.packageVersionCount > packageVersionCount);
+      assert.ok(res.packageCount >= packageCount);
+      assert.ok(res.packageVersionCount > packageVersionCount);
     });
   });
 });

--- a/test/repository/ProxyCachePepository.test.ts
+++ b/test/repository/ProxyCachePepository.test.ts
@@ -11,57 +11,74 @@ describe('test/repository/ProxyCacheRepository.test.ts', () => {
 
   beforeEach(async () => {
     proxyCacheRepository = await app.getEggObject(ProxyCacheRepository);
-    proxyCacheModel = await proxyCacheRepository.saveProxyCache(ProxyCache.create({
-      fullname: 'foo-bar',
-      fileType: DIST_NAMES.FULL_MANIFESTS,
-    }));
+    proxyCacheModel = await proxyCacheRepository.saveProxyCache(
+      ProxyCache.create({
+        fullname: 'foo-bar',
+        fileType: DIST_NAMES.FULL_MANIFESTS,
+      })
+    );
   });
 
   describe('ProxyCacheRepository', () => {
     it('create work', async () => {
-      const newProxyCache = await proxyCacheRepository.saveProxyCache(ProxyCache.create({
-        fullname: 'foo-bar-new',
-        fileType: DIST_NAMES.FULL_MANIFESTS,
-      }));
-      assert(newProxyCache);
+      const newProxyCache = await proxyCacheRepository.saveProxyCache(
+        ProxyCache.create({
+          fullname: 'foo-bar-new',
+          fileType: DIST_NAMES.FULL_MANIFESTS,
+        })
+      );
+      assert.ok(newProxyCache);
       assert.equal(newProxyCache.fullname, 'foo-bar-new');
     });
 
     it('update work', async () => {
       const beforeUpdateTime = proxyCacheModel.updatedAt.getTime();
-      const updatedProxyCache = await proxyCacheRepository.saveProxyCache(ProxyCache.update(proxyCacheModel));
-      assert(updatedProxyCache);
+      const updatedProxyCache = await proxyCacheRepository.saveProxyCache(
+        ProxyCache.update(proxyCacheModel)
+      );
+      assert.ok(updatedProxyCache);
       assert.equal(updatedProxyCache.fullname, 'foo-bar');
       const afterUpdateTime = updatedProxyCache.updatedAt.getTime();
-      assert(afterUpdateTime >= beforeUpdateTime);
+      assert.ok(afterUpdateTime >= beforeUpdateTime);
     });
 
     it('list work', async () => {
       const proxyCaches = await proxyCacheRepository.listCachedFiles({});
-      assert(proxyCaches.count === 1);
+      assert.ok(proxyCaches.count === 1);
     });
 
     it('query null', async () => {
-      const queryRes = await proxyCacheRepository.findProxyCache('not-exists', DIST_NAMES.FULL_MANIFESTS);
-      assert(queryRes === null);
+      const queryRes = await proxyCacheRepository.findProxyCache(
+        'not-exists',
+        DIST_NAMES.FULL_MANIFESTS
+      );
+      assert.ok(queryRes === null);
     });
 
     it('query work', async () => {
-      const queryRes = await proxyCacheRepository.findProxyCache('foo-bar', DIST_NAMES.FULL_MANIFESTS);
-      assert(queryRes?.fullname === 'foo-bar');
+      const queryRes = await proxyCacheRepository.findProxyCache(
+        'foo-bar',
+        DIST_NAMES.FULL_MANIFESTS
+      );
+      assert.ok(queryRes?.fullname === 'foo-bar');
     });
 
     it('remove work', async () => {
-      await proxyCacheRepository.removeProxyCache('foo-bar', DIST_NAMES.FULL_MANIFESTS);
+      await proxyCacheRepository.removeProxyCache(
+        'foo-bar',
+        DIST_NAMES.FULL_MANIFESTS
+      );
       const { count } = await proxyCacheRepository.listCachedFiles({});
       assert.equal(count, 0);
     });
 
     it('truncate work', async () => {
-      await proxyCacheRepository.saveProxyCache(ProxyCache.create({
-        fullname: 'foo-bar-new',
-        fileType: DIST_NAMES.FULL_MANIFESTS,
-      }));
+      await proxyCacheRepository.saveProxyCache(
+        ProxyCache.create({
+          fullname: 'foo-bar-new',
+          fileType: DIST_NAMES.FULL_MANIFESTS,
+        })
+      );
       await proxyCacheRepository.truncateProxyCache();
       const { count } = await proxyCacheRepository.listCachedFiles({});
       assert.equal(count, 0);

--- a/test/repository/RegistryRepository.test.ts
+++ b/test/repository/RegistryRepository.test.ts
@@ -35,8 +35,8 @@ describe('test/repository/RegistryRepository.test.ts', () => {
           authToken: '',
         })
       )) as Registry;
-      assert(newRegistry);
-      assert(newRegistry.type === 'cnpmcore');
+      assert.ok(newRegistry);
+      assert.ok(newRegistry.type === 'cnpmcore');
     });
     it('update work', async () => {
       const updatedRegistry = await registryRepository.saveRegistry({
@@ -49,22 +49,22 @@ describe('test/repository/RegistryRepository.test.ts', () => {
         type: 'cnpmcore' as RegistryType,
         changeStream: 'https://replicate.npmjs.com/_changes',
       });
-      assert(updatedRegistry);
-      assert(updatedRegistry.name === 'banana');
+      assert.ok(updatedRegistry);
+      assert.ok(updatedRegistry.name === 'banana');
     });
     it('list work', async () => {
       const registries = await registryRepository.listRegistries({});
-      assert(registries.count === 1);
+      assert.ok(registries.count === 1);
     });
 
     it('query null', async () => {
       const queryRes = await registryRepository.findRegistry('orange');
-      assert(queryRes === null);
+      assert.ok(queryRes === null);
     });
 
     it('query work', async () => {
       const queryRes = await registryRepository.findRegistry('cnpmcore');
-      assert(queryRes?.name === 'cnpmcore');
+      assert.ok(queryRes?.name === 'cnpmcore');
     });
     it('remove work', async () => {
       await registryRepository.removeRegistry(registryModel.registryId);

--- a/test/repository/ScopeRepository.test.ts
+++ b/test/repository/ScopeRepository.test.ts
@@ -26,8 +26,8 @@ describe('test/repository/ScopeRepository.test.ts', () => {
           registryId: '1',
         })
       );
-      assert(cnpmScope);
-      assert(cnpmjsScope);
+      assert.ok(cnpmScope);
+      assert.ok(cnpmjsScope);
     });
 
     it('list work', async () => {
@@ -54,8 +54,8 @@ describe('test/repository/ScopeRepository.test.ts', () => {
         registryId: '1',
       });
       const scopeRes = await scopeRepository.listScopes({});
-      assert(scopeRes.count === 1);
-      assert(scopeRes.data[0].name === '@anpm');
+      assert.ok(scopeRes.count === 1);
+      assert.ok(scopeRes.data[0].name === '@anpm');
     });
 
     it('remove work', async () => {

--- a/test/repository/TaskRepository.test.ts
+++ b/test/repository/TaskRepository.test.ts
@@ -47,12 +47,12 @@ describe('test/repository/TaskRepository.test.ts', () => {
         taskRepository.saveTask(task1),
         taskRepository.saveTask(task2),
       ]);
-      assert(task1.id);
-      assert(task2.id);
-      assert(task1.id === task2.id);
-      assert(task1.taskId);
-      assert(task2.taskId);
-      assert(task1.taskId === task2.taskId);
+      assert.ok(task1.id);
+      assert.ok(task2.id);
+      assert.ok(task1.id === task2.id);
+      assert.ok(task1.taskId);
+      assert.ok(task2.taskId);
+      assert.ok(task1.taskId === task2.taskId);
     });
 
     it('should update updatedAt', async () => {
@@ -88,7 +88,9 @@ describe('test/repository/TaskRepository.test.ts', () => {
       // 由于已经被 task1 更新，所以会导致 asyncTask.updatedAd 会覆盖 model
       await taskRepository.saveTask(asyncTask);
 
-      assert(asyncTask.updatedAt.getTime() !== asyncTask.createdAt.getTime());
+      assert.ok(
+        asyncTask.updatedAt.getTime() !== asyncTask.createdAt.getTime()
+      );
     });
 
     it('cant modify updatedAt', async () => {
@@ -114,7 +116,7 @@ describe('test/repository/TaskRepository.test.ts', () => {
       task1.updatedAt = lastSince;
       await taskRepository.saveTask(task1);
 
-      assert(task1.updatedAt.getTime() >= lastSince.getTime());
+      assert.ok(task1.updatedAt.getTime() >= lastSince.getTime());
     });
   });
 
@@ -147,7 +149,7 @@ describe('test/repository/TaskRepository.test.ts', () => {
         taskRepository.idempotentSaveTask(task, condition),
         taskRepository.idempotentSaveTask(task, condition),
       ]);
-      assert(firstSave !== secondSave);
+      assert.ok(firstSave !== secondSave);
     });
   });
 });

--- a/test/schedule/ChangesStreamWorker.test.ts
+++ b/test/schedule/ChangesStreamWorker.test.ts
@@ -48,18 +48,18 @@ describe('test/schedule/ChangesStreamWorker.test.ts', () => {
     app.expectLog('[ChangesStreamWorker:start]');
     app.expectLog('[ChangesStreamService.executeTask:changes] since: ');
     const task = await changesStreamService.findExecuteTask();
-    assert(!task, 'task should not exists');
+    assert.ok(!task, 'task should not exists');
 
     // mock no changed after 10 mins
     const existsTask = await Task.findOne({ type: 'changes_stream' });
-    assert(existsTask);
+    assert.ok(existsTask);
     existsTask.updatedAt = new Date(
       existsTask.updatedAt.getTime() - 60_000 * 10 - 1
     );
     await existsTask.save();
     const result = await taskService.retryExecuteTimeoutTasks();
-    assert(result.processing === 1);
-    assert(result.waiting === 0);
+    assert.ok(result.processing === 1);
+    assert.ok(result.waiting === 0);
   });
 
   it('should work on replicate: r.cnpmjs.org', async () => {
@@ -93,18 +93,18 @@ describe('test/schedule/ChangesStreamWorker.test.ts', () => {
     app.expectLog('[ChangesStreamService.executeTask:changes] since:');
     app.expectLog(/, \d+ new tasks,/);
     const task = await changesStreamService.findExecuteTask();
-    assert(!task);
+    assert.ok(!task);
 
     // mock no changed after 10 mins
     const existsTask = await Task.findOne({ type: 'changes_stream' });
-    assert(existsTask);
+    assert.ok(existsTask);
     existsTask.updatedAt = new Date(
       existsTask.updatedAt.getTime() - 60_000 * 10 - 1
     );
     await existsTask.save();
     const result = await taskService.retryExecuteTimeoutTasks();
-    assert(result.processing === 1);
-    assert(result.waiting === 0);
+    assert.ok(result.processing === 1);
+    assert.ok(result.waiting === 0);
     // mock request https://r.cnpmjs.org/_changes error
     app.mockHttpclient('https://r.cnpmjs.org/_changes', 'GET', {
       status: 500,

--- a/test/schedule/CheckProxyCacheUpdateWorker.test.ts
+++ b/test/schedule/CheckProxyCacheUpdateWorker.test.ts
@@ -12,7 +12,10 @@ import { TaskType } from '../../app/common/enum/Task.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const CheckProxyCacheUpdateWorkerPath = path.join(__dirname, '../../app/port/schedule/CheckProxyCacheUpdateWorker.ts');
+const CheckProxyCacheUpdateWorkerPath = path.join(
+  __dirname,
+  '../../app/port/schedule/CheckProxyCacheUpdateWorker.ts'
+);
 
 describe('test/schedule/CheckProxyCacheUpdateWorker.test.ts', () => {
   it('should create update task by repo', async () => {
@@ -20,14 +23,15 @@ describe('test/schedule/CheckProxyCacheUpdateWorker.test.ts', () => {
     mock(app.config.cnpmcore, 'redirectNotFound', false);
     const proxyCacheRepository = await app.getEggObject(ProxyCacheRepository);
     const taskService = await app.getEggObject(TaskService);
-    await proxyCacheRepository.saveProxyCache(ProxyCache.create({
-      fullname: 'foo-bar',
-      fileType: DIST_NAMES.FULL_MANIFESTS,
-    }));
+    await proxyCacheRepository.saveProxyCache(
+      ProxyCache.create({
+        fullname: 'foo-bar',
+        fileType: DIST_NAMES.FULL_MANIFESTS,
+      })
+    );
     await app.runSchedule(CheckProxyCacheUpdateWorkerPath);
     const task = await taskService.findExecuteTask(TaskType.UpdateProxyCache);
-    assert(task);
+    assert.ok(task);
     assert.equal(task.targetName, `foo-bar/${DIST_NAMES.FULL_MANIFESTS}`);
   });
-
 });

--- a/test/schedule/CheckRecentlyUpdatedPackages.test.ts
+++ b/test/schedule/CheckRecentlyUpdatedPackages.test.ts
@@ -67,7 +67,7 @@ describe('test/schedule/CheckRecentlyUpdatedPackages.test.ts', () => {
     app.expectLog('[CheckRecentlyUpdatedPackages.subscribe][0] request');
     app.expectLog('[CheckRecentlyUpdatedPackages.subscribe][0] parse');
     const executeTask = await packageSyncerService.findExecuteTask();
-    assert(!executeTask);
+    assert.ok(!executeTask);
 
     // syncMode=all
     mock(app.config.cnpmcore, 'syncMode', 'all');
@@ -76,7 +76,7 @@ describe('test/schedule/CheckRecentlyUpdatedPackages.test.ts', () => {
     app.expectLog('[CheckRecentlyUpdatedPackages.subscribe][0] parse');
     app.expectLog('[CheckRecentlyUpdatedPackages.subscribe:createTask]');
     const task = await packageSyncerService.findExecuteTask();
-    assert(task);
+    assert.ok(task);
     app.mockAgent().assertNoPendingInterceptors();
   });
 
@@ -107,10 +107,10 @@ describe('test/schedule/CheckRecentlyUpdatedPackages.test.ts', () => {
     mock(app.config.cnpmcore, 'syncMode', 'exist');
     await app.runSchedule(CheckRecentlyUpdatedPackagesPath);
     let task = await packageSyncerService.findExecuteTask();
-    assert(task);
-    assert(task.targetName === '@cnpm/foo');
+    assert.ok(task);
+    assert.ok(task.targetName === '@cnpm/foo');
     task = await packageSyncerService.findExecuteTask();
-    assert(!task);
+    assert.ok(!task);
   });
 
   it('should handle pageUrl request error', async () => {
@@ -122,7 +122,7 @@ describe('test/schedule/CheckRecentlyUpdatedPackages.test.ts', () => {
     await app.runSchedule(CheckRecentlyUpdatedPackagesPath);
     app.expectLog('[CheckRecentlyUpdatedPackages.subscribe:error][0] request');
     const task = await packageSyncerService.findExecuteTask();
-    assert(!task);
+    assert.ok(!task);
   });
 
   it('should handle PackageSyncerService.createTask error', async () => {
@@ -164,7 +164,7 @@ describe('test/schedule/CheckRecentlyUpdatedPackages.test.ts', () => {
     await app.runSchedule(CheckRecentlyUpdatedPackagesPath);
     app.expectLog('[CheckRecentlyUpdatedPackages.subscribe:error][0] parse');
     const task = await packageSyncerService.findExecuteTask();
-    assert(!task);
+    assert.ok(!task);
     app.mockAgent().assertNoPendingInterceptors();
   });
 });

--- a/test/schedule/SyncPackageWorker.test.ts
+++ b/test/schedule/SyncPackageWorker.test.ts
@@ -55,7 +55,7 @@ describe('test/schedule/SyncPackageWorker.test.ts', () => {
       .set('Accept', 'application/json')
       .expect(200);
     // make sure npm user name not contain 'npm:'
-    assert(res.body.maintainers[0].name === 'fengmk2');
+    assert.ok(res.body.maintainers[0].name === 'fengmk2');
     app.mockAgent().assertNoPendingInterceptors();
   });
 
@@ -95,8 +95,8 @@ describe('test/schedule/SyncPackageWorker.test.ts', () => {
       .httpRequest()
       .get(`/${name}`)
       .set('Accept', 'application/json');
-    assert(res.status === 200);
-    assert(res.body.name === name);
+    assert.ok(res.status === 200);
+    assert.ok(res.body.name === name);
     app.mockAgent().assertNoPendingInterceptors();
   });
 


### PR DESCRIPTION
should be `https://replicate.npmjs.com/registry` not `https://replicate.npmjs.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the changes stream registry endpoint configuration.
  - Standardized assertion methods in tests to use `assert.ok()` for improved clarity and consistency across the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->