### PR TITLE
feat: add since for api sync binary

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -136,7 +136,14 @@
 
     // jsdoc
     "jsdoc/require-returns": "allow",
-    "jsdoc/require-param": "allow"
+    "jsdoc/require-param": "allow",
+
+    // import
+    "consistent-type-specifier-style": "allow",
+    "no-unassigned-import": "allow",
+
+    // for-loop
+    "no-for-loop": "allow"
   },
   "ignorePatterns": ["index.d.ts"]
 }

--- a/app/common/adapter/binary/ApiBinary.ts
+++ b/app/common/adapter/binary/ApiBinary.ts
@@ -21,12 +21,17 @@ export class ApiBinary extends AbstractBinary {
 
   async fetch(
     dir: string,
-    binaryName: string
+    binaryName: string,
+    lastData?: Record<string, unknown>
   ): Promise<FetchResult | undefined> {
     const apiUrl =
       this.config.cnpmcore.syncBinaryFromAPISource ||
       `${this.config.cnpmcore.sourceRegistry}/-/binary`;
-    const url = `${apiUrl}/${binaryName}${dir}`;
+    let url = `${apiUrl}/${binaryName}${dir}`;
+    if (lastData && lastData.lastSyncTime) {
+      url += `?since=${(lastData.lastSyncTime as Date).toISOString()}&limit=100`;
+    }
+
     const data = await this.requestJSON(url);
     if (!Array.isArray(data)) {
       this.logger.warn(

--- a/app/core/service/BinarySyncerService.ts
+++ b/app/core/service/BinarySyncerService.ts
@@ -63,7 +63,7 @@ export class BinarySyncerService extends AbstractService {
     binary: Binary,
     options?: {
       limit: number;
-      since: Date;
+      since: string;
     }
   ) {
     return await this.binaryRepository.listBinaries(
@@ -125,7 +125,7 @@ export class BinarySyncerService extends AbstractService {
         'chromium-browser-snapshots'
       );
       if (latestBinary) {
-        lastData.lastSyncTime = latestBinary.createdAt;
+        lastData.lastSyncTime = latestBinary.date;
       }
     }
     try {

--- a/app/core/service/BinarySyncerService.ts
+++ b/app/core/service/BinarySyncerService.ts
@@ -59,10 +59,17 @@ export class BinarySyncerService extends AbstractService {
     return await this.binaryRepository.findBinary(targetName, parent, name);
   }
 
-  public async listDirBinaries(binary: Binary) {
+  public async listDirBinaries(
+    binary: Binary,
+    options?: {
+      limit: number;
+      since: Date;
+    }
+  ) {
     return await this.binaryRepository.listBinaries(
       binary.category,
-      `${binary.parent}${binary.name}`
+      `${binary.parent}${binary.name}`,
+      options
     );
   }
 
@@ -113,6 +120,12 @@ export class BinarySyncerService extends AbstractService {
         if (binaryDir) {
           lastData[platform] = binaryDir.name.slice(0, -1);
         }
+      }
+      const latestBinary = await this.binaryRepository.findLatestBinary(
+        'chromium-browser-snapshots'
+      );
+      if (latestBinary) {
+        lastData.lastSyncTime = latestBinary.createdAt;
       }
     }
     try {

--- a/app/port/controller/BinarySyncController.ts
+++ b/app/port/controller/BinarySyncController.ts
@@ -83,15 +83,6 @@ export class BinarySyncController extends AbstractController {
         );
       }
     }
-    let sinceTime: Date | undefined;
-    if (since) {
-      sinceTime = new Date(since);
-      try {
-        sinceTime.toISOString();
-      } catch {
-        throw new NotFoundError(`invalidate since "${limit}"`);
-      }
-    }
     subpath = subpath || '/';
     if (subpath === '/') {
       const items = await this.binarySyncerService.listRootBinaries(binaryName);
@@ -131,10 +122,10 @@ export class BinarySyncController extends AbstractController {
     }
     if (binary.isDir) {
       let options;
-      if (limitCount && sinceTime) {
+      if (limitCount && since) {
         options = {
           limit: limitCount,
-          since: sinceTime,
+          since,
         };
       }
       const items = await this.binarySyncerService.listDirBinaries(

--- a/app/repository/BinaryRepository.ts
+++ b/app/repository/BinaryRepository.ts
@@ -44,7 +44,7 @@ export class BinaryRepository extends AbstractRepository {
     parent: string,
     options?: {
       limit: number;
-      since: Date;
+      since: string;
     }
   ): Promise<BinaryEntity[]> {
     let models;
@@ -52,9 +52,9 @@ export class BinaryRepository extends AbstractRepository {
       models = await this.Binary.find({
         category,
         parent,
-        createdAt: { $gte: options.since },
+        date: { $gte: options.since },
       })
-        .order('gmt_create', 'asc')
+        .order('date', 'asc')
         .limit(options.limit);
     } else {
       models = await this.Binary.find({ category, parent });

--- a/sql/ddl_mysql.sql
+++ b/sql/ddl_mysql.sql
@@ -12,7 +12,8 @@ CREATE TABLE `binaries` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `uk_binary_id` (`binary_id`),
   UNIQUE KEY `uk_category_parent_name` (`category`,`parent`,`name`),
-  KEY `idx_category_parent_gmt_create` (`category`, `parent`, `gmt_create`)
+  KEY `idx_category_parent_gmt_create` (`category`, `parent`, `gmt_create`),
+  KEY `idx_category_parent_date` (`category`, `parent`, `date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci COMMENT='binary info'
 ;
 

--- a/sql/ddl_postgresql.sql
+++ b/sql/ddl_postgresql.sql
@@ -14,6 +14,7 @@ CREATE TABLE binaries (
 CREATE UNIQUE INDEX binaries_uk_binary_id ON binaries (binary_id);
 CREATE UNIQUE INDEX binaries_uk_category_parent_name ON binaries (category, parent, name);
 CREATE INDEX binaries_idx_category_parent_gmt_create ON binaries (category, parent, gmt_create);
+CREATE INDEX binaries_idx_category_parent_date ON binaries (category, parent, date);
 
 COMMENT ON TABLE binaries IS 'binary info';
 COMMENT ON COLUMN binaries.id IS 'primary key';

--- a/test/port/controller/BinarySyncController/showBinary.test.ts
+++ b/test/port/controller/BinarySyncController/showBinary.test.ts
@@ -8,7 +8,6 @@ import { BinaryRepository } from '../../../../app/repository/BinaryRepository.js
 import { Binary } from '../../../../app/core/entity/Binary.js';
 import { NFSClientAdapter } from '../../../../app/infra/NFSClientAdapter.js';
 import { TestUtil } from '../../../../test/TestUtil.js';
-import { setTimeout } from 'node:timers/promises';
 
 describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
   let binarySyncerService: BinarySyncerService;
@@ -760,7 +759,6 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
     });
 
     it('since and limit should show valid files', async () => {
-      const now = new Date();
       await binaryRepository.saveBinary(
         Binary.create({
           category: 'node-canvas-prebuilt',
@@ -781,7 +779,6 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
           date: '2021-12-15T13:12:31.587Z',
         })
       );
-      await setTimeout(100);
       await binaryRepository.saveBinary(
         Binary.create({
           category: 'node-canvas-prebuilt',
@@ -792,7 +789,6 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
           date: '2021-12-16T13:12:31.587Z',
         })
       );
-      await setTimeout(100);
       await binaryRepository.saveBinary(
         Binary.create({
           category: 'node-canvas-prebuilt',
@@ -806,7 +802,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
       const res = await app
         .httpRequest()
         .get(
-          `/-/binary/node-canvas-prebuilt/v2.6.1/?since=${now.toISOString()}&limit=1`
+          `/-/binary/node-canvas-prebuilt/v2.6.1/?since=2021-12-15T13:12:31.587Z&limit=1`
         );
       assert.ok(res.status === 200);
       assert.ok(
@@ -834,7 +830,7 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
       const res2 = await app
         .httpRequest()
         .get(
-          `/-/binary/node-canvas-prebuilt/v2.6.1/?since=${new Date(now.getTime() + 50).toISOString()}&limit=1`
+          `/-/binary/node-canvas-prebuilt/v2.6.1/?since=2021-12-16T13:12:31.587Z&limit=1`
         );
       assert.ok(res2.status === 200);
       assert.ok(

--- a/test/port/controller/BinarySyncController/showBinary.test.ts
+++ b/test/port/controller/BinarySyncController/showBinary.test.ts
@@ -808,8 +808,10 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
         .get(
           `/-/binary/node-canvas-prebuilt/v2.6.1/?since=${now.toISOString()}&limit=1`
         );
-      assert(res.status === 200);
-      assert(res.headers['content-type'] === 'application/json; charset=utf-8');
+      assert.ok(res.status === 200);
+      assert.ok(
+        res.headers['content-type'] === 'application/json; charset=utf-8'
+      );
       const items = TestUtil.pickKeys(res.body, [
         'category',
         'name',
@@ -834,8 +836,8 @@ describe('test/port/controller/BinarySyncController/showBinary.test.ts', () => {
         .get(
           `/-/binary/node-canvas-prebuilt/v2.6.1/?since=${new Date(now.getTime() + 50).toISOString()}&limit=1`
         );
-      assert(res2.status === 200);
-      assert(
+      assert.ok(res2.status === 200);
+      assert.ok(
         res2.headers['content-type'] === 'application/json; charset=utf-8'
       );
       const items2 = TestUtil.pickKeys(res2.body, [

--- a/test/port/controller/HomeController/showTotal.test.ts
+++ b/test/port/controller/HomeController/showTotal.test.ts
@@ -331,7 +331,7 @@ describe('test/port/controller/HomeController/showTotal.test.ts', () => {
           .expect('content-type', 'application/json; charset=utf-8');
         const data = res.body;
         assert.ok(data.upstream_registries.length === 2);
-        const [defaultRegistry] = data.upstream_registries.filter(
+        const defaultRegistry = data.upstream_registries.find(
           (item: UpstreamRegistryInfo) => item.registry_name === 'default'
         );
         assert.ok(defaultRegistry.registry_name === 'default');
@@ -343,7 +343,7 @@ describe('test/port/controller/HomeController/showTotal.test.ts', () => {
           defaultRegistry.source_registry === 'https://registry.npmjs.org'
         );
 
-        const [customRegistry] = data.upstream_registries.filter(
+        const customRegistry = data.upstream_registries.find(
           (item: UpstreamRegistryInfo) => item.registry_name === 'custom'
         );
         assert.ok(customRegistry.registry_name === 'custom');


### PR DESCRIPTION
Puppeteer has over a million binaries, and synchronizing all of them at once can lead to OOM. By sync them in batches of 100, the memory pressure can be reduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for filtering and limiting binary file listings using optional "since" and "limit" query parameters in the API.
  - Introduced metadata synchronization enhancements for improved binary update tracking.
- **Bug Fixes**
  - Improved validation and error handling for "since" and "limit" query parameters in binary listing endpoints.
- **Tests**
  - Added tests to verify correct filtering and limiting of binary files based on "since" and "limit" parameters.
- **Chores**
  - Added new database indexes to optimize queries filtering binaries by category, parent, and date.
  - Updated linting configuration to allow specific import and loop styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->