### PR TITLE
fix: lastSyncTime is string should not stringify again

### DIFF
--- a/app/common/adapter/binary/ApiBinary.ts
+++ b/app/common/adapter/binary/ApiBinary.ts
@@ -29,7 +29,7 @@ export class ApiBinary extends AbstractBinary {
       `${this.config.cnpmcore.sourceRegistry}/-/binary`;
     let url = `${apiUrl}/${binaryName}${dir}`;
     if (lastData && lastData.lastSyncTime) {
-      url += `?since=${(lastData.lastSyncTime as Date).toISOString()}&limit=100`;
+      url += `?since=${lastData.lastSyncTime}&limit=100`;
     }
 
     const data = await this.requestJSON(url);

--- a/test/common/adapter/binary/ApiBinary.test.ts
+++ b/test/common/adapter/binary/ApiBinary.test.ts
@@ -97,5 +97,24 @@ describe('test/common/adapter/binary/ApiBinary.test.ts', () => {
       assert.ok(matchDir);
       assert.ok(matchFile);
     });
+
+    it('should fetch with lastData', async () => {
+      mock(
+        app.config.cnpmcore,
+        'syncBinaryFromAPISource',
+        'https://cnpmjs.org/mirrors/apis'
+      );
+      app.mockHttpclient('https://cnpmjs.org/mirrors/apis/node/', 'GET', {
+        data: await TestUtil.readFixturesFile(
+          'cnpmjs.org/mirrors/apis/node.json'
+        ),
+        persist: false,
+      });
+      const result = await binary.fetch('/', 'node', {
+        lastSyncTime: '2025-03-11T15:43:56.748Z',
+      });
+      assert.ok(result);
+      assert.ok(result.items.length > 0);
+    });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the `lastSyncTime` parameter when fetching binary data to ensure more accurate synchronization.

- **Tests**
  - Added a new test case to verify fetching binary data with a provided `lastSyncTime`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->