### PR TITLE
fix: only set lastSyncTime if lastData.lastSyncTime is undefined

### DIFF
--- a/app/core/service/BinarySyncerService.ts
+++ b/app/core/service/BinarySyncerService.ts
@@ -124,7 +124,7 @@ export class BinarySyncerService extends AbstractService {
       const latestBinary = await this.binaryRepository.findLatestBinary(
         'chromium-browser-snapshots'
       );
-      if (latestBinary) {
+      if (latestBinary && !lastData.lastSyncTime) {
         lastData.lastSyncTime = latestBinary.date;
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved synchronization logic to prevent overwriting the last sync time for Chromium browser snapshots if it is already set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->