### PR TITLE
fix: set puppeteer loop only once

### DIFF
--- a/app/common/adapter/binary/PuppeteerBinary.ts
+++ b/app/common/adapter/binary/PuppeteerBinary.ts
@@ -11,7 +11,7 @@ import {
 
 export const platforms = ['Linux_x64', 'Mac', 'Mac_Arm', 'Win', 'Win_x64'];
 
-const MAX_DEPTH = 100;
+const MAX_DEPTH = 1;
 
 @SingletonProto()
 @BinaryAdapter(BinaryType.Puppeteer)


### PR DESCRIPTION
s3 return 1000 items, 100x1000 is too large.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Reduced the number of paginated results fetched from remote sources, now limiting retrieval to a single page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->