### PR TITLE
feat: add shouldNotMerge for task data for skip task merge

### DIFF
--- a/app/common/adapter/binary/PuppeteerBinary.ts
+++ b/app/common/adapter/binary/PuppeteerBinary.ts
@@ -56,7 +56,7 @@ export class PuppeteerBinary extends AbstractBinary {
         this.dirItems[`/${platform}/`] = [];
         let i = 0;
         do {
-          let requestUrl = s3Url + '?prefix=' + platform;
+          let requestUrl = s3Url + '?prefix=' + platform + '&max-keys=100';
           if (marker) {
             requestUrl += '&marker=' + marker;
           }

--- a/app/core/entity/Task.ts
+++ b/app/core/entity/Task.ts
@@ -16,6 +16,7 @@ export const PID = process.pid;
 
 export interface TaskBaseData {
   taskWorker: string;
+  shouldNotMerge?: boolean;
 }
 
 export interface TaskData<T = TaskBaseData> extends EntityData {
@@ -268,8 +269,14 @@ export class Task<T extends TaskBaseData = TaskBaseData> extends Entity {
     return task;
   }
 
-  public static needMergeWhenWaiting(type: TaskType) {
-    return [TaskType.SyncBinary, TaskType.SyncPackage].includes(type);
+  needMergeWhenWaiting(): boolean {
+    // 历史任务补偿时，将 shouldNotMerge 设置为 true，避免合并
+    // 补偿任务单独执行
+    if (this.data.shouldNotMerge === true) {
+      return false;
+    }
+    // 仅合并二进制镜像与 npm 包
+    return [TaskType.SyncBinary, TaskType.SyncPackage].includes(this.type);
   }
 
   public static createUpdateProxyCache(

--- a/app/core/service/TaskService.ts
+++ b/app/core/service/TaskService.ts
@@ -4,7 +4,8 @@ import type { NFSAdapter } from '../../common/adapter/NFSAdapter.js';
 import { TaskState, TaskType } from '../../common/enum/Task.js';
 import { AbstractService } from '../../common/AbstractService.js';
 import type { TaskRepository } from '../../repository/TaskRepository.js';
-import { Task, type CreateSyncPackageTaskData } from '../entity/Task.js';
+import type { Task} from '../entity/Task.js';
+import { type CreateSyncPackageTaskData } from '../entity/Task.js';
 import type { QueueAdapter } from '../../common/typing.js';
 
 @SingletonProto({
@@ -29,7 +30,7 @@ export class TaskService extends AbstractService {
     );
 
     // 只在包同步场景下做任务合并，其余场景通过 bizId 来进行任务幂等
-    if (existsTask && Task.needMergeWhenWaiting(task.type)) {
+    if (existsTask && task.needMergeWhenWaiting()) {
       // 在包同步场景，如果任务还未被触发，就不继续重复创建
       // 如果任务正在执行，可能任务状态已更新，这种情况需要继续创建
       if (existsTask.state === TaskState.Waiting) {

--- a/app/core/service/TaskService.ts
+++ b/app/core/service/TaskService.ts
@@ -4,8 +4,7 @@ import type { NFSAdapter } from '../../common/adapter/NFSAdapter.js';
 import { TaskState, TaskType } from '../../common/enum/Task.js';
 import { AbstractService } from '../../common/AbstractService.js';
 import type { TaskRepository } from '../../repository/TaskRepository.js';
-import type { Task} from '../entity/Task.js';
-import { type CreateSyncPackageTaskData } from '../entity/Task.js';
+import type { Task, CreateSyncPackageTaskData } from '../entity/Task.js';
 import type { QueueAdapter } from '../../common/typing.js';
 
 @SingletonProto({

--- a/test/core/entity/Task.test.ts
+++ b/test/core/entity/Task.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { Task } from '../../../app/core/entity/Task.js';
+
+describe('test/core/entity/Task.js', () => {
+  describe('needMergeWhenWaiting', () => {
+    it('should not merge if data.shouldNotMerge is true', () => {
+      const task = Task.createSyncBinary('foo', {
+        shouldNotMerge: true,
+      });
+      assert.equal(task.needMergeWhenWaiting(), false);
+    });
+
+    it('should merge sync binary task', () => {
+      const task = Task.createSyncBinary('foo');
+      assert.equal(task.needMergeWhenWaiting(), true);
+    });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for a new task property to prevent certain tasks from being merged when waiting, providing more granular control over task handling.
- **Bug Fixes**
  - Improved logic for task merging to consider both task type and a new optional flag, ensuring correct behavior for historical task compensation scenarios.
- **Tests**
  - Introduced new tests to verify the updated task merging logic and the effect of the new property.
- **Chores**
  - Limited the number of items returned per request when fetching platform-specific binaries to improve data retrieval efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->