### PR TITLE
chore: use oxlint 0.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "coffee": "^5.4.0",
     "husky": "^9.1.7",
     "lint-staged": "^15.5.0",
-    "oxlint": "^0.16.0",
+    "oxlint": "^0.18.1",
     "prettier": "^3.5.3",
     "typescript": "5"
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the development dependency "oxlint" to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->