### PR TITLE
fix: use npm truster publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
 jobs:
   release:
     name: NPM
-    uses: cnpm/github-actions/.github/workflows/node-release.yml@master
+    uses: cnpm/github-actions/.github/workflows/npm-release.yml@master
     secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GIT_TOKEN: ${{ secrets.GIT_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "coffee": "^5.4.0",
     "husky": "^9.1.7",
     "lint-staged": "^15.5.0",
-    "oxlint": "^1.10.0",
+    "oxlint": "^1.11.0",
     "prettier": "^3.5.3",
     "typescript": "5"
   },


### PR DESCRIPTION
https://github.com/node-modules/github-actions/issues/14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow configuration for improved automation.
  * Upgraded the "oxlint" development dependency to version ^1.11.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->