### PR TITLE
feat: add search filters for deprecated packages and newly published …

### DIFF
--- a/app/port/config.ts
+++ b/app/port/config.ts
@@ -187,4 +187,18 @@ export interface CnpmcoreConfig {
   database: {
     type: DATABASE_TYPE | string;
   };
+
+  /**
+   * search package minimum age filter
+   * packages published within this time range will be excluded from search results
+   * support format: '2w' (weeks), '14d' (days), '336h' (hours)
+   * default is empty string (no filter)
+   */
+  searchPackageMinAge?: string;
+
+  /**
+   * exclude deprecated packages from search results
+   * default is true
+   */
+  searchExcludeDeprecated?: boolean;
 }

--- a/app/repository/SearchRepository.ts
+++ b/app/repository/SearchRepository.ts
@@ -16,7 +16,8 @@ export type SearchJSONPickKey =
   | 'license'
   | 'maintainers'
   | 'dist-tags'
-  | '_source_registry_name';
+  | '_source_registry_name'
+  | 'deprecated';
 
 export type SearchMappingType = Pick<PackageManifestType, SearchJSONPickKey> &
   CnpmcorePatchInfo & {

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -77,6 +77,8 @@ export const cnpmcoreConfig: CnpmcoreConfig = {
   database: {
     type: database.type,
   },
+  searchPackageMinAge: env('CNPMCORE_CONFIG_SEARCH_PACKAGE_MIN_AGE', 'string', ''),
+  searchExcludeDeprecated: env('CNPMCORE_CONFIG_SEARCH_EXCLUDE_DEPRECATED', 'boolean', true),
 };
 
 export interface NFSConfig {


### PR DESCRIPTION
…packages

Implemented two new search filter configurations:

1. `searchExcludeDeprecated` - Filter deprecated packages from search results
   - Default: true (deprecated packages are excluded by default)
   - Can be disabled by setting to false
   - Controlled by env: CNPMCORE_CONFIG_SEARCH_EXCLUDE_DEPRECATED

2. `searchPackageMinAge` - Filter newly published packages
   - Default: empty string (no filter applied)
   - Supports time format: '2w' (weeks), '14d' (days), '336h' (hours)
   - Controlled by env: CNPMCORE_CONFIG_SEARCH_PACKAGE_MIN_AGE

Changes:
- Added `deprecated` field to SearchMappingType and sync it to Elasticsearch
- Added `_buildFilterQueries()` method to build Elasticsearch filter conditions
- Added `_parseTimeString()` helper to parse time strings (h/d/w format)
- Added comprehensive unit tests for the new filter functionality

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)