### PR TITLE
feat(binaries): 添加 ffmpeg-builds 二进制配置

### DIFF
--- a/config/binaries.ts
+++ b/config/binaries.ts
@@ -955,6 +955,13 @@ const binaries = {
     repo: 'microsoft/ripgrep-prebuilt',
     distUrl: 'https://github.com/microsoft/ripgrep-prebuilt/releases',
   },
+  'ffmpeg-builds': {
+    category: 'ffmpeg-builds',
+    description: 'Static Windows (x86_64) and Linux (x86_64) Builds of ffmpeg master and latest release branch.',
+    type: BinaryType.GitHub,
+    repo: 'BtbN/FFmpeg-Builds',
+    distUrl: 'https://github.com/BtbN/FFmpeg-Builds/releases',
+  },
 } as const;
 
 export interface BinaryTaskConfig {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FFmpeg-Builds as a new binary source, providing static Windows (x86_64) and Linux (x86_64) builds from FFmpeg master and latest release branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->