### PR TITLE
feat: add ffmpeg-builds binary mirror

### DIFF
--- a/config/binaries.ts
+++ b/config/binaries.ts
@@ -959,8 +959,8 @@ const binaries = {
     category: 'ffmpeg-builds',
     description: 'Static Windows (x86_64) and Linux (x86_64) Builds of ffmpeg master and latest release branch.',
     type: BinaryType.GitHub,
-    repo: 'BtbN/FFmpeg-Builds',
-    distUrl: 'https://github.com/BtbN/FFmpeg-Builds/releases',
+    repo: 'KarinJS/FFmpeg-Builds',
+    distUrl: 'https://github.com/KarinJS/FFmpeg-Builds/releases',
   },
 } as const;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FFmpeg builds are now available as a supported binary source, offering static builds for Windows and Linux platforms (x86_64). Both master branch and latest release versions are accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->