### PR TITLE
fix: zero copy to create a new Buffer

### DIFF
--- a/app/repository/DistRepository.ts
+++ b/app/repository/DistRepository.ts
@@ -92,7 +92,7 @@ export class DistRepository {
     if (!bytes) return undefined;
     // if bytes is Uint8Array, should use zero copy to create a new Buffer
     // https://nodejs.org/docs/latest-v24.x/api/buffer.html#static-method-bufferfromarraybuffer-byteoffset-length
-    return Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   }
 
   async readDistBytesToJSONBuilder(dist: Dist): Promise<JSONBuilder | undefined> {


### PR DESCRIPTION
https://nodejs.org/docs/latest-v24.x/api/buffer.html#static-method-bufferfromarraybuffer-byteoffset-length

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized binary data handling to reduce memory copies and improve performance.
  * Preserves identical visible content while changing internal buffer object identity — callers that rely on object identity (rather than content) may observe differences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->