### PR TITLE
fix: support allow large check from scopes level

### DIFF
--- a/app/core/service/PackageVersionFileService.ts
+++ b/app/core/service/PackageVersionFileService.ts
@@ -58,6 +58,8 @@ export class PackageVersionFileService extends AbstractService {
       version: string;
     }
   > = {};
+  // allow large package scopes, e.g. ['@foo', '@bar']
+  #unpkgWhiteListAllowLargeScopes: string[] = [];
 
   async listPackageVersionFiles(pkgVersion: PackageVersion, directory: string) {
     await this.#ensurePackageVersionFilesSync(pkgVersion);
@@ -116,6 +118,7 @@ export class PackageVersionFileService extends AbstractService {
     this.#unpkgWhiteListAllowPackages = manifest.allowPackages ?? ({} as any);
     this.#unpkgWhiteListAllowScopes = manifest.allowScopes ?? ([] as any);
     this.#unpkgWhiteListAllowLargePackages = manifest.allowLargePackages ?? ({} as any);
+    this.#unpkgWhiteListAllowLargeScopes = manifest.allowLargeScopes ?? ([] as any);
     this.logger.info(
       '[PackageVersionFileService.updateUnpkgWhiteList] version:%s, total %s packages, %s scopes, %s large packages',
       whiteListPackageVersion,
@@ -128,6 +131,9 @@ export class PackageVersionFileService extends AbstractService {
   async isAllowLargePackageVersion(pkgScope: string, pkgName: string, pkgVersion: string) {
     if (!this.config.cnpmcore.enableSyncUnpkgFilesWhiteList) return false;
     await this.#updateUnpkgWhiteList();
+
+    // check allow large scopes
+    if (this.#unpkgWhiteListAllowLargeScopes.includes(pkgScope)) return true;
 
     const fullname = getFullname(pkgScope, pkgName);
     const pkgConfig = this.#unpkgWhiteListAllowLargePackages[fullname];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scope-level whitelisting for large packages. Scopes can now be designated as permitted for accessing and fetching large packages and files, streamlining permission management for repositories that handle large-scale packages without requiring individual package-level configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->