### PR TITLE
fix: fallback to unpackedSize to limit tgz size

### DIFF
--- a/app/core/service/PackageSyncerService.ts
+++ b/app/core/service/PackageSyncerService.ts
@@ -867,7 +867,7 @@ data sample: ${remoteData.subarray(0, 200).toString()}`;
         logs = [];
         continue;
       }
-      const size = dist.size;
+      const size = dist.size ?? dist.unpackedSize;
       if (size && size > this.config.cnpmcore.largePackageVersionSize) {
         const isAllowLargePackageVersion = await this.packageVersionFileService.isAllowLargePackageVersion(
           scope,
@@ -1365,7 +1365,7 @@ ${diff.addedVersions.length} added, ${diff.removedVersions.length} removed, calc
         continue;
       }
 
-      const size = dist.size;
+      const size = dist.size ?? dist.unpackedSize;
       if (size && size > this.config.cnpmcore.largePackageVersionSize) {
         const isAllowLargePackageVersion = await this.packageVersionFileService.isAllowLargePackageVersion(
           scope,

--- a/test/core/service/PackageSyncerService/executeTask.test.ts
+++ b/test/core/service/PackageSyncerService/executeTask.test.ts
@@ -2214,6 +2214,42 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       );
     });
 
+    it('should mock large package version size block by unpackedSize', async () => {
+      mock.error(NPMRegistry.prototype, 'downloadTarball');
+      mock.data(NPMRegistry.prototype, 'getFullManifestsBuffer', {
+        data: Buffer.from(
+          JSON.stringify({
+            maintainers: [{ name: 'fengmk2', email: 'fengmk2@gmai.com' }],
+            versions: {
+              '2.0.0': {
+                version: '2.0.0',
+                dist: { tarball: 'http://foo.com/a.tgz', unpackedSize: 100 * 1024 * 1024 + 1 },
+              },
+            },
+          }),
+        ),
+        res: {},
+        headers: {},
+      });
+      mock(app.config.cnpmcore, 'enableSyncUnpkgFilesWhiteList', true);
+      mock(app.config.cnpmcore, 'largePackageVersionSize', 100 * 1024 * 1024);
+      const name = 'cnpmcore-test-sync-deprecated';
+      await packageSyncerService.createTask(name);
+      const task = await packageSyncerService.findExecuteTask();
+      assert.ok(task);
+      assert.equal(task.targetName, name);
+      await packageSyncerService.executeTask(task);
+      const stream = await packageSyncerService.findTaskLog(task);
+      assert.ok(stream);
+      const log = await TestUtil.readStreamToLog(stream);
+      // console.log(log);
+      assert.match(log, /❌❌❌❌❌ cnpmcore-test-sync-deprecated ❌❌❌❌❌/);
+      assert.match(
+        log,
+        /Synced version 2.0.0 fail, large package version size: 104857601, allow size: 104857600, see https:\/\/github\.com\/cnpm\/unpkg-white-list/,
+      );
+    });
+
     it('should mock large package version size allow', async () => {
       app.mockHttpclient('https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz', 'GET', {
         data: await TestUtil.readFixturesFile('registry.npmjs.org/foobar/-/foobar-1.0.0.tgz'),

--- a/test/core/service/PackageSyncerService/executeTaskWithPackument.test.ts
+++ b/test/core/service/PackageSyncerService/executeTaskWithPackument.test.ts
@@ -2190,6 +2190,42 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
       );
     });
 
+    it('should mock large package version size block by unpackedSize', async () => {
+      mock.error(NPMRegistry.prototype, 'downloadTarball');
+      mock.data(NPMRegistry.prototype, 'getFullManifestsBuffer', {
+        data: Buffer.from(
+          JSON.stringify({
+            maintainers: [{ name: 'fengmk2', email: 'fengmk2@gmai.com' }],
+            versions: {
+              '2.0.0': {
+                version: '2.0.0',
+                dist: { tarball: 'http://foo.com/a.tgz', unpackedSize: 100 * 1024 * 1024 + 1 },
+              },
+            },
+          }),
+        ),
+        res: {},
+        headers: {},
+      });
+      mock(app.config.cnpmcore, 'enableSyncUnpkgFilesWhiteList', true);
+      mock(app.config.cnpmcore, 'largePackageVersionSize', 100 * 1024 * 1024);
+      const name = 'cnpmcore-test-sync-deprecated';
+      await packageSyncerService.createTask(name);
+      const task = await packageSyncerService.findExecuteTask();
+      assert.ok(task);
+      assert.equal(task.targetName, name);
+      await packageSyncerService.executeTask(task);
+      const stream = await packageSyncerService.findTaskLog(task);
+      assert.ok(stream);
+      const log = await TestUtil.readStreamToLog(stream);
+      // console.log(log);
+      assert.match(log, /❌❌❌❌❌ cnpmcore-test-sync-deprecated ❌❌❌❌❌/);
+      assert.match(
+        log,
+        /Synced version 2.0.0 fail, large package version size: 104857601, allow size: 104857600, see https:\/\/github\.com\/cnpm\/unpkg-white-list/,
+      );
+    });
+
     it('should mock large package version size allow', async () => {
       app.mockHttpclient('https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz', 'GET', {
         data: await TestUtil.readFixturesFile('registry.npmjs.org/foobar/-/foobar-1.0.0.tgz'),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved large package detection by implementing a fallback mechanism for determining package size when standard size information is unavailable, ensuring consistent handling of package version limits.

* **Tests**
  * Added test coverage for the fallback size detection mechanism to verify proper behavior across different package data scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->