### PR TITLE
fix: should refresh package manifests to dists to avoid missing versions

### DIFF
--- a/app/core/service/PackageSyncerService.ts
+++ b/app/core/service/PackageSyncerService.ts
@@ -1461,7 +1461,8 @@ ${diff.addedVersions.length} added, ${diff.removedVersions.length} removed, calc
         },
         isPrivate: false,
         publishTime,
-        skipRefreshPackageManifests: true,
+        // should refresh package manifests to dists to avoid missing versions
+        skipRefreshPackageManifests: false,
       };
       try {
         // if version record already exists, need to check if pkg.manifests exists


### PR DESCRIPTION
close https://github.com/cnpm/cnpmcore/issues/943

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package manifest refresh behavior after publishing to help prevent missing versions during synchronization.

* **Tests**
  * Added test coverage for package size constraint handling during version synchronization scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->