### PR TITLE
fix: clean up related data when unpublishing a package version

### DIFF
--- a/app/repository/PackageRepository.ts
+++ b/app/repository/PackageRepository.ts
@@ -489,6 +489,16 @@ export class PackageRepository extends AbstractRepository {
     return ModelConvertor.convertModelToEntity(model, this.PackageVersionManifest);
   }
 
+  async removePackageVersionManifest(packageVersionId: string): Promise<number> {
+    const removeCount = await this.PackageVersionManifest.remove({ packageVersionId });
+    this.logger.info(
+      '[PackageRepository:removePackageVersionManifest:remove] %d rows, packageVersionId: %s',
+      removeCount,
+      packageVersionId,
+    );
+    return removeCount;
+  }
+
   public async queryTotal() {
     const { packageCount, packageVersionCount } = await this.totalRepository.getAll();
 
@@ -573,6 +583,15 @@ export class PackageRepository extends AbstractRepository {
 
   async listPackageTags(packageId: string): Promise<PackageTagEntity[]> {
     const models = await this.PackageTag.find({ packageId });
+    const entities: PackageTagEntity[] = [];
+    for (const model of models) {
+      entities.push(ModelConvertor.convertModelToEntity(model, PackageTagEntity));
+    }
+    return entities;
+  }
+
+  async findPackageTagsByVersion(packageId: string, version: string): Promise<PackageTagEntity[]> {
+    const models = await this.PackageTag.find({ packageId, version });
     const entities: PackageTagEntity[] = [];
     for (const model of models) {
       entities.push(ModelConvertor.convertModelToEntity(model, PackageTagEntity));


### PR DESCRIPTION
## Summary

- Fix npm unpublish to properly clean up all related data when removing a package version
- Previously only PackageVersion and core Dist records were deleted, leaving orphaned data
- Add repository methods for cleaning up PackageVersionFile, PackageVersionManifest, and PackageTag records

## Changes

**Data now properly cleaned up during unpublish:**

| Data | Before | After |
|------|--------|-------|
| PackageVersionFile records | Orphaned | Deleted |
| PackageVersionFile NFS files | Orphaned | Deleted |
| PackageVersionManifest | Orphaned | Deleted |
| Non-latest tags pointing to version | Orphaned | Deleted |
| PackageVersionBlock | Orphaned | Deleted |

**Files modified:**
- `app/repository/PackageVersionFileRepository.ts` - Add `removePackageVersionFiles()`
- `app/repository/PackageRepository.ts` - Add `removePackageVersionManifest()` and `findPackageTagsByVersion()`
- `app/core/service/PackageManagerService.ts` - Update cleanup logic in `_removePackageVersionAndDist()` and `removePackageVersion()`

## Test plan

- [x] Added test for PackageVersionManifest cleanup on unpublish
- [x] Added test for PackageTag cleanup verification
- [x] Added test for PackageVersionFiles cleanup on unpublish
- [x] All existing unpublish tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unpublishing a package version now removes its version manifest, stored version files and distribution artifacts from storage, deletes non-latest tags pointing to the removed version, and logs removal counts.
* **Tests**
  * Added tests covering manifest, file, artifact, and tag cleanup during package version unpublish.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->