### PR TITLE
chore(deps): update dependency oxlint-tsgolint to ^0.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "lint-staged": "^16.2.7",
     "oxfmt": "^0.28.0",
     "oxlint": "^1.32.0",
-    "oxlint-tsgolint": "^0.11.0",
+    "oxlint-tsgolint": "^0.14.2",
     "typescript": "^5.9.3"
   },
   "optionalDependencies": {


### PR DESCRIPTION
## Summary

- Update `oxlint-tsgolint` from `^0.11.0` to `^0.14.2`
- `oxlint@1.50.0` (resolved from `^1.32.0`) now requires `oxlint-tsgolint@>=0.14.1` as a peer dependency
- This fixes `ERESOLVE` errors when running `npm install` in environments that resolve oxlint to `1.50.0`

## Test plan

- [ ] CI passes with updated dependency versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to latest versions, including linting tools for improved code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->