### PR TITLE
chore: upgrade oxfmt to ^0.35.0

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -3,15 +3,8 @@
   "printWidth": 120,
   "singleQuote": true,
   "ignorePatterns": ["__snapshots__", "test/fixtures", "CHANGELOG.md"],
-  "experimentalSortImports": {
-    "groups": [
-      ["type-import"],
-      ["type-builtin", "value-builtin"],
-      ["type-external", "value-external", "type-internal", "value-internal"],
-      ["type-parent", "type-sibling", "type-index", "value-parent", "value-sibling", "value-index"],
-      ["ts-equals-import"],
-      ["unknown"]
-    ],
+  "sortImports": {
+    "groups": [["type-import"], ["builtin"], ["external", "internal"], ["parent", "sibling", "index"], ["unknown"]],
     "newlinesBetween": true,
     "order": "asc"
   }

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "coffee": "^5.5.1",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
-    "oxfmt": "^0.28.0",
+    "oxfmt": "^0.35.0",
     "oxlint": "^1.32.0",
     "oxlint-tsgolint": "^0.14.2",
     "typescript": "^5.9.3"


### PR DESCRIPTION
- Upgrade oxfmt from ^0.28.0 to ^0.35.0
- Update `.oxfmtrc.json`: `experimentalSortImports` → `sortImports`, remove deprecated `ts-equals-import` group, use new group name format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the code formatting tool from version 0.28.0 to 0.35.0, incorporating performance improvements, enhanced reliability, and new features for a better development experience
  * Refined the import organization configuration by streamlining the grouping structure to reduce unnecessary complexity while maintaining all existing functionality and ensuring consistent code organization standards throughout the project

<!-- end of auto-generated comment: release notes by coderabbit.ai -->