### PR TITLE
feat: add package/limit/offset query filters to list hooks API

### DIFF
--- a/app/port/controller/HookController.ts
+++ b/app/port/controller/HookController.ts
@@ -1,11 +1,21 @@
-import { HTTPContext, Context, HTTPBody, HTTPController, HTTPMethod, HTTPMethodEnum, HTTPParam, HTTPQuery, Inject } from 'egg';
 import type { Static } from '@eggjs/typebox-validate/typebox';
+import {
+  HTTPContext,
+  Context,
+  HTTPBody,
+  HTTPController,
+  HTTPMethod,
+  HTTPMethodEnum,
+  HTTPParam,
+  HTTPQuery,
+  Inject,
+} from 'egg';
 
 import type { HookType } from '../../common/enum/Hook.ts';
 import type { TriggerHookTask } from '../../core/entity/Task.ts';
 import type { HookManageService } from '../../core/service/HookManageService.ts';
 import type { TaskService } from '../../core/service/TaskService.ts';
-import { CreateHookRequestRule, UpdateHookRequestRule, type ListHookQueryOptions } from '../typebox.ts';
+import { CreateHookRequestRule, UpdateHookRequestRule, ListHookQueryOptions } from '../typebox.ts';
 import type { UserRoleManager } from '../UserRoleManager.ts';
 import { HookConvertor } from './convertor/HookConvertor.ts';
 
@@ -103,7 +113,7 @@ export class HookController {
 
     // Filter by package name (npm spec: ?package=lodash)
     if (packageName) {
-      hooks = hooks.filter(hook => hook.name === packageName);
+      hooks = hooks.filter((hook) => hook.name === packageName);
     }
 
     // Pagination (npm spec: ?limit=N&offset=N)

--- a/app/port/typebox.ts
+++ b/app/port/typebox.ts
@@ -187,14 +187,14 @@ export const ListHookQueryOptions = Type.Object({
     }),
   ),
   offset: Type.Optional(
-    Type.Number({
+    Type.Integer({
       transform: ['trim'],
       minimum: 0,
       default: 0,
     }),
   ),
   limit: Type.Optional(
-    Type.Number({
+    Type.Integer({
       transform: ['trim'],
       minimum: 1,
       maximum: 100,

--- a/test/port/controller/hook/HookController.test.ts
+++ b/test/port/controller/hook/HookController.test.ts
@@ -196,6 +196,15 @@ describe('test/port/controller/hook/HookController.test.ts', () => {
         .set('user-agent', user.ua)
         .expect(200);
       assert.equal(res.body.objects.length, 0);
+
+      // Combined offset and limit
+      res = await app
+        .httpRequest()
+        .get('/-/npm/v1/hooks?offset=1&limit=1')
+        .set('authorization', user.authorization)
+        .set('user-agent', user.ua)
+        .expect(200);
+      assert.equal(res.body.objects.length, 1);
     });
   });
 


### PR DESCRIPTION
## Summary

The Hooks API was already implemented but the `GET /-/npm/v1/hooks` endpoint was missing the query parameter filters specified in the [npm registry spec](https://github.com/npm/registry/blob/master/docs/hooks/endpoints.md#get-v1hooks).

## Changes

Added support for three query parameters on `GET /-/npm/v1/hooks`:

- `package`: filter hooks by exact package name
- `limit`: return at most N hooks
- `offset`: skip the first N hooks (for pagination)

Example:
```
GET /-/npm/v1/hooks?package=lodash&limit=10&offset=0
```

## Tests

Added tests for:
- Filtering by package name (match, no match)
- Limit pagination
- Offset pagination
- Offset beyond total (returns empty)

Closes #518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter hooks by package name via a query parameter.
  * Paginate hook results with offset and limit query parameters (offset defaults to 0; offset ≥ 0; limit between 1–100).
  * Query parameters validated and normalized (trimmed/validated; offset/limit treated as integers).

* **Tests**
  * Added tests covering package-name filtering and offset/limit pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->