### PR TITLE
feat: require package maintainer permission when granting team package access

### DIFF
--- a/app/common/adapter/binary/EdgedriverBinary.ts
+++ b/app/common/adapter/binary/EdgedriverBinary.ts
@@ -110,13 +110,13 @@ export class EdgedriverBinary extends AbstractBinary {
     // specific version is skipped cleanly via `ignoreDownloadStatuses`.
     // /126.0.2578.0/ => 126.0.2578.0/
     const subDir = dir.substring(1);
-    const items: BinaryItem[] = EDGEDRIVER_PLATFORM_FILES.map((name) => ({
+    const items: BinaryItem[] = EDGEDRIVER_PLATFORM_FILES.map(name => ({
       name,
       isDir: false,
       url: `${EDGEDRIVER_DOWNLOAD_BASE}${subDir}${name}`,
       size: '-',
       date: '-',
-      ignoreDownloadStatuses: [404],
+      ignoreDownloadStatuses: [ 404 ],
     }));
     return { items, nextParams: null };
   }

--- a/app/common/adapter/binary/EdgedriverBinary.ts
+++ b/app/common/adapter/binary/EdgedriverBinary.ts
@@ -1,9 +1,35 @@
-import path from 'node:path';
 import { SingletonProto } from '@eggjs/tegg';
 import {
   AbstractBinary, FetchResult, BinaryItem, BinaryAdapter,
 } from './AbstractBinary';
 import { BinaryType } from '../../enum/Binary';
+
+// Microsoft moved Edge WebDriver binaries to https://msedgedriver.microsoft.com/
+// in July 2025 after `msedgedriver.azureedge.net` was retired, and around
+// 2026-04-07 also disabled public access on the legacy Azure Blob container
+// that used to host the XML file listing. There is still no paginated/filtered
+// listing API — the only "listing" endpoint on the new host is a ~1.2MB static
+// JSON dump (`/listing.json`, ~9000 entries covering every version since
+// 112.0.1722.39).
+//
+// To avoid hammering that 1.2MB dump for every version subdirectory during a
+// sync, we mirror the approach used by `FirefoxBinary` / `ChromeForTestingBinary`
+// and generate the per-version download URLs from a static list of known
+// platform filenames. cnpmcore's sync pipeline honors the per-item
+// `ignoreDownloadStatuses` field, so any version that doesn't ship a given
+// platform (e.g. older builds without `edgedriver_mac64_m1.zip`) gets a clean
+// 404 and is skipped rather than failing the sync.
+const EDGEDRIVER_DOWNLOAD_BASE = 'https://msedgedriver.microsoft.com/';
+// Platform filenames observed in Microsoft's current `listing.json` dump.
+// Every version since 112.0.1722.39 ships some subset of these six files.
+const EDGEDRIVER_PLATFORM_FILES = [
+  'edgedriver_arm64.zip',
+  'edgedriver_linux64.zip',
+  'edgedriver_mac64.zip',
+  'edgedriver_mac64_m1.zip',
+  'edgedriver_win32.zip',
+  'edgedriver_win64.zip',
+] as const;
 
 @SingletonProto()
 @BinaryAdapter(BinaryType.Edgedriver)
@@ -32,91 +58,6 @@ export class EdgedriverBinary extends AbstractBinary {
       return;
     }
     this.logger.info('[EdgedriverBinary] remote data length: %s', data.length);
-    // [
-    //   {
-    //     "Product": "Stable",
-    //     "Releases": [
-    //       {
-    //         "ReleaseId": 73376,
-    //         "Platform": "iOS",
-    //         "Architecture": "arm64",
-    //         "CVEs": [],
-    //         "ProductVersion": "124.0.2478.89",
-    //         "Artifacts": [],
-    //         "PublishedTime": "2024-05-07T02:57:00",
-    //         "ExpectedExpiryDate": "2025-05-07T02:57:00"
-    //       },
-    //       {
-    //         "ReleaseId": 73629,
-    //         "Platform": "Windows",
-    //         "Architecture": "x86",
-    //         "CVEs": [
-    //           "CVE-2024-4559",
-    //           "CVE-2024-4671"
-    //         ],
-    //         "ProductVersion": "124.0.2478.97",
-    //         "Artifacts": [
-    //           {
-    //             "ArtifactName": "msi",
-    //             "Location": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/aa1c9fe3-bb9c-4a80-9ff7-5c109701fbfe/MicrosoftEdgeEnterpriseX86.msi",
-    //             "Hash": "4CEF7B907D3E2371E953C41190E32C3560CEE7D3F16D7550CA156DC976EBCB80",
-    //             "HashAlgorithm": "SHA256",
-    //             "SizeInBytes": 162029568
-    //           }
-    //         ],
-    //         "PublishedTime": "2024-05-11T06:47:00",
-    //         "ExpectedExpiryDate": "2025-05-10T16:59:00"
-    //       },
-    //       {
-    //         "ReleaseId": 73630,
-    //         "Platform": "Linux",
-    //         "Architecture": "x64",
-    //         "CVEs": [
-    //           "CVE-2024-4559"
-    //         ],
-    //         "ProductVersion": "124.0.2478.97",
-    //         "Artifacts": [
-    //           {
-    //             "ArtifactName": "rpm",
-    //             "Location": "https://packages.microsoft.com/yumrepos/edge/microsoft-edge-stable-124.0.2478.97-1.x86_64.rpm",
-    //             "Hash": "32D9C333544DDD9C56FED54844E89EF00F3E5620942C07B9B68D214016687895",
-    //             "HashAlgorithm": "SHA256",
-    //             "SizeInBytes": 169877932
-    //           },
-    //           {
-    //             "ArtifactName": "deb",
-    //             "Location": "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_124.0.2478.97-1_amd64.deb",
-    //             "Hash": "85D0AD1D63847B3DD54F0F214D18A2B54462BB43291536E773AD1B8B29BBF799",
-    //             "HashAlgorithm": "SHA256",
-    //             "SizeInBytes": 167546042
-    //           }
-    //         ],
-    //         "PublishedTime": "2024-05-10T17:01:00",
-    //         "ExpectedExpiryDate": "2025-05-10T17:01:00"
-    //       },
-    // {
-    //   "Product": "EdgeUpdate",
-    //   "Releases": [
-    //     {
-    //       "ReleaseId": 73493,
-    //       "Platform": "Windows",
-    //       "Architecture": "x86",
-    //       "CVEs": [],
-    //       "ProductVersion": "1.3.187.37",
-    //       "Artifacts": [
-    //         {
-    //           "ArtifactName": "exe",
-    //           "Location": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/a2fa84fe-796b-4f80-b1cd-f4d1f5731aa8/MicrosoftEdgeUpdateSetup_X86_1.3.187.37.exe",
-    //           "Hash": "503088D22461FEE5D7B6B011609D73FFD5869D3ACE1DBB0F00F8F3B9D122C514",
-    //           "HashAlgorithm": "SHA256",
-    //           "SizeInBytes": 1622072
-    //         }
-    //       ],
-    //       "PublishedTime": "2024-05-08T05:44:00",
-    //       "ExpectedExpiryDate": "2025-05-08T05:44:00"
-    //     }
-    //   ]
-    // }
     const products = data as {
       Product: string;
       Releases: {
@@ -163,51 +104,20 @@ export class EdgedriverBinary extends AbstractBinary {
       return { items: this.dirItems![dir], nextParams: null };
     }
 
-    // fetch sub dir
-    // /foo/ => foo/
+    // fetch sub dir: generate the known platform filenames for this version.
+    // We intentionally don't call any listing API — see the file-level
+    // comment for the rationale. Any platform that doesn't exist for a
+    // specific version is skipped cleanly via `ignoreDownloadStatuses`.
+    // /126.0.2578.0/ => 126.0.2578.0/
     const subDir = dir.substring(1);
-    // https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver?prefix=124.0.2478.97/&delimiter=/&maxresults=100&restype=container&comp=list
-    const url = `https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver?prefix=${encodeURIComponent(subDir)}&delimiter=/&maxresults=100&restype=container&comp=list`;
-    const xml = await this.requestXml(url);
-    return { items: this.#parseItems(xml), nextParams: null };
-  }
-
-  #parseItems(xml: string): BinaryItem[] {
-    const items: BinaryItem[] = [];
-    // <Blob><Name>124.0.2478.97/edgedriver_arm64.zip</Name><Url>https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/124.0.2478.97/edgedriver_arm64.zip</Url><Properties><Last-Modified>Fri, 10 May 2024 18:35:44 GMT</Last-Modified><Etag>0x8DC712000713C13</Etag><Content-Length>9191362</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-MD5>1tjPTf5JU6KKB06Qf1JOGw==</Content-MD5><Cache-Control /><BlobType>BlockBlob</BlobType><LeaseStatus>unlocked</LeaseStatus></Properties></Blob>
-    const fileRe = /<Blob><Name>([^<]+?)<\/Name><Url>([^<]+?)<\/Url><Properties><Last\-Modified>([^<]+?)<\/Last\-Modified><Etag>(?:[^<]+?)<\/Etag><Content\-Length>(\d+)<\/Content\-Length>/g;
-    const matchItems = xml.matchAll(fileRe);
-    for (const m of matchItems) {
-      const fullname = m[1].trim();
-      // <Blob>
-      //   <Name>124.0.2478.97/edgedriver_arm64.zip</Name>
-      //   <Url>https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/124.0.2478.97/edgedriver_arm64.zip</Url>
-      //   <Properties>
-      //     <Last-Modified>Fri, 10 May 2024 18:35:44 GMT</Last-Modified>
-      //     <Etag>0x8DC712000713C13</Etag>
-      //     <Content-Length>9191362</Content-Length>
-      //     <Content-Type>application/octet-stream</Content-Type>
-      //     <Content-Encoding/>
-      //     <Content-Language/>
-      //     <Content-MD5>1tjPTf5JU6KKB06Qf1JOGw==</Content-MD5>
-      //     <Cache-Control/>
-      //     <BlobType>BlockBlob</BlobType>
-      //     <LeaseStatus>unlocked</LeaseStatus>
-      //   </Properties>
-      // </Blob>
-      // ignore size = 0 dir
-      const name = path.basename(fullname);
-      const url = m[2].trim();
-      const date = m[3].trim();
-      const size = parseInt(m[4].trim());
-      items.push({
-        name,
-        isDir: false,
-        url,
-        size,
-        date,
-      });
-    }
-    return items;
+    const items: BinaryItem[] = EDGEDRIVER_PLATFORM_FILES.map((name) => ({
+      name,
+      isDir: false,
+      url: `${EDGEDRIVER_DOWNLOAD_BASE}${subDir}${name}`,
+      size: '-',
+      date: '-',
+      ignoreDownloadStatuses: [404],
+    }));
+    return { items, nextParams: null };
   }
 }

--- a/app/port/controller/TeamController.ts
+++ b/app/port/controller/TeamController.ts
@@ -82,21 +82,21 @@ export class TeamController extends AbstractController {
 
     // Admin always has access
     if (isAdmin) {
-      return { org, team, authorizedUser };
+      return { org, team, authorizedUser, isAdmin };
     }
 
     // Org owner has access
     if (!this.isAllowScopeOrg(orgName)) {
       const orgMember = await this.orgRepository.findMember(org.orgId, authorizedUser.userId);
       if (orgMember && orgMember.role === 'owner') {
-        return { org, team, authorizedUser };
+        return { org, team, authorizedUser, isAdmin };
       }
     }
 
     // Team owner has access
     const teamMember = await this.teamRepository.findMember(team.teamId, authorizedUser.userId);
     if (teamMember && teamMember.role === 'owner') {
-      return { org, team, authorizedUser };
+      return { org, team, authorizedUser, isAdmin };
     }
 
     throw new ForbiddenError('Only team owner or admin can perform this action');
@@ -318,7 +318,7 @@ export class TeamController extends AbstractController {
   })
   async grantPackageAccess(@Context() ctx: EggContext, @HTTPParam() orgName: string,
     @HTTPParam() teamName: string, @HTTPBody() body: { package: string }) {
-    const { team } = await this.requireTeamWriteAccess(ctx, orgName, teamName);
+    const { team, authorizedUser, isAdmin } = await this.requireTeamWriteAccess(ctx, orgName, teamName);
     if (!body.package) {
       throw new UnprocessableEntityError('package is required');
     }
@@ -326,6 +326,10 @@ export class TeamController extends AbstractController {
     const pkg = await this.packageRepository.findPackage(scope, name);
     if (!pkg) {
       throw new NotFoundError(`Package "${body.package}" not found`);
+    }
+    // Non-admin users can only add packages they are a maintainer of
+    if (!isAdmin) {
+      await this.userRoleManager.requiredPackageMaintainer(pkg, authorizedUser);
     }
     await this.teamService.grantPackageAccess(team.teamId, pkg.packageId);
     return { ok: true };

--- a/docs/org-team.en.md
+++ b/docs/org-team.en.md
@@ -43,6 +43,7 @@ cnpmcore adds a `role` field to Team members while maintaining full npm CLI comp
 1. When a **Team is created**, the creator is automatically added as Team Owner
 2. **Team write operations** (add/remove members, manage packages, delete Team) require the operator to be a Team Owner, Org Owner, or Admin
 3. Regular Org members **cannot directly manage other people's Teams**
+4. When **granting package access**, non-Admin users can only add packages they are a maintainer of (Admins can add any package)
 
 #### npm CLI Compatibility
 
@@ -269,6 +270,8 @@ curl -X DELETE http://localhost:7001/-/team/mycompany/frontend/user \
 
 ### Team Package Access
 
+> **Note**: When granting package access, the operator must be a maintainer of the package (Admins are exempt from this check). This ensures Team Owners can only add packages they have permission over.
+
 ```bash
 # Grant access (npm CLI compatible)
 npm access grant read-only @mycompany:frontend @mycompany/ui-lib \
@@ -294,7 +297,8 @@ npm access revoke @mycompany:frontend @mycompany/ui-lib \
 | Delete Team | Admin, Org Owner, or **Team Owner** |
 | View Teams / Team info / Team members | Logged-in user |
 | Add / Remove Team member | Admin, Org Owner, or **Team Owner** |
-| Grant / Revoke package access | Admin, Org Owner, or **Team Owner** |
+| Grant package access | Admin, Org Owner, or **Team Owner** (must be package maintainer, except Admin) |
+| Revoke package access | Admin, Org Owner, or **Team Owner** |
 | View Team packages | Logged-in user |
 
 > **Team Owner** is a cnpmcore extension role. When a team is created, the creator is automatically added as the team owner. Team owners can manage their own team without needing org-level owner permissions.

--- a/docs/org-team.md
+++ b/docs/org-team.md
@@ -43,6 +43,7 @@ cnpmcore 在保持 npm CLI 完全兼容的前提下，为 Team 成员增加了 `
 1. **创建 Team 时**，创建者自动成为 Team Owner
 2. **Team 的写操作**（增删成员、管理包、删除 Team）要求操作者是 Team Owner、Org Owner 或 Admin
 3. 普通 Org 成员**无法直接管理其他人的 Team**
+4. **授权包访问时**，非 Admin 用户只能添加自己是 maintainer 的包（Admin 可以添加任意包）
 
 #### npm CLI 兼容性
 
@@ -269,6 +270,8 @@ curl -X DELETE http://localhost:7001/-/team/mycompany/frontend/user \
 
 ### Team 包授权
 
+> **注意**：授权包访问时，操作者必须是该包的 maintainer（Admin 不受此限制）。这确保了 Team Owner 只能将自己有权限的包添加到团队中。
+
 ```bash
 # 授权（npm CLI 兼容）
 npm access grant read-only @mycompany:frontend @mycompany/ui-lib \
@@ -294,7 +297,8 @@ npm access revoke @mycompany:frontend @mycompany/ui-lib \
 | 删除 Team | Admin、Org Owner 或 **Team Owner** |
 | 查看 Team / Team 信息 / Team 成员 | 登录用户 |
 | 添加 / 移除 Team 成员 | Admin、Org Owner 或 **Team Owner** |
-| 授权 / 撤销包访问 | Admin、Org Owner 或 **Team Owner** |
+| 授权包访问 | Admin、Org Owner 或 **Team Owner**（且必须是包的 maintainer，Admin 除外） |
+| 撤销包访问 | Admin、Org Owner 或 **Team Owner** |
 | 查看 Team 包列表 | 登录用户 |
 
 > **Team Owner** 是 cnpmcore 的扩展角色。创建 Team 时，创建者自动成为 Team Owner。Team Owner 可以管理自己的团队，无需 Org 级别的 Owner 权限。

--- a/test/common/adapter/binary/EdgedriverBinary.test.ts
+++ b/test/common/adapter/binary/EdgedriverBinary.test.ts
@@ -73,7 +73,7 @@ describe('test/common/adapter/binary/EdgedriverBinary.test.ts', () => {
           url: 'https://msedgedriver.microsoft.com/126.0.2578.0/edgedriver_arm64.zip',
           size: '-',
           date: '-',
-          ignoreDownloadStatuses: [404],
+          ignoreDownloadStatuses: [ 404 ],
         },
         {
           name: 'edgedriver_linux64.zip',
@@ -81,7 +81,7 @@ describe('test/common/adapter/binary/EdgedriverBinary.test.ts', () => {
           url: 'https://msedgedriver.microsoft.com/126.0.2578.0/edgedriver_linux64.zip',
           size: '-',
           date: '-',
-          ignoreDownloadStatuses: [404],
+          ignoreDownloadStatuses: [ 404 ],
         },
         {
           name: 'edgedriver_mac64.zip',
@@ -89,7 +89,7 @@ describe('test/common/adapter/binary/EdgedriverBinary.test.ts', () => {
           url: 'https://msedgedriver.microsoft.com/126.0.2578.0/edgedriver_mac64.zip',
           size: '-',
           date: '-',
-          ignoreDownloadStatuses: [404],
+          ignoreDownloadStatuses: [ 404 ],
         },
         {
           name: 'edgedriver_mac64_m1.zip',
@@ -97,7 +97,7 @@ describe('test/common/adapter/binary/EdgedriverBinary.test.ts', () => {
           url: 'https://msedgedriver.microsoft.com/126.0.2578.0/edgedriver_mac64_m1.zip',
           size: '-',
           date: '-',
-          ignoreDownloadStatuses: [404],
+          ignoreDownloadStatuses: [ 404 ],
         },
         {
           name: 'edgedriver_win32.zip',
@@ -105,7 +105,7 @@ describe('test/common/adapter/binary/EdgedriverBinary.test.ts', () => {
           url: 'https://msedgedriver.microsoft.com/126.0.2578.0/edgedriver_win32.zip',
           size: '-',
           date: '-',
-          ignoreDownloadStatuses: [404],
+          ignoreDownloadStatuses: [ 404 ],
         },
         {
           name: 'edgedriver_win64.zip',
@@ -113,7 +113,7 @@ describe('test/common/adapter/binary/EdgedriverBinary.test.ts', () => {
           url: 'https://msedgedriver.microsoft.com/126.0.2578.0/edgedriver_win64.zip',
           size: '-',
           date: '-',
-          ignoreDownloadStatuses: [404],
+          ignoreDownloadStatuses: [ 404 ],
         },
       ]);
     });

--- a/test/common/adapter/binary/EdgedriverBinary.test.ts
+++ b/test/common/adapter/binary/EdgedriverBinary.test.ts
@@ -7,15 +7,19 @@ describe('test/common/adapter/binary/EdgedriverBinary.test.ts', () => {
   let binary: EdgedriverBinary;
   beforeEach(async () => {
     binary = await app.getEggObject(EdgedriverBinary);
+    // EdgedriverBinary is a @SingletonProto — reset its per-sync cache so
+    // each test sees a fresh state (the first `fetch('/')` call populates
+    // `dirItems` which would otherwise persist across tests).
+    await binary.initFetch();
   });
 
   describe('fetch()', () => {
-    it('should work', async () => {
+    it('should list recent stable versions from edgeupdates.microsoft.com', async () => {
       app.mockHttpclient('https://edgeupdates.microsoft.com/api/products', 'GET', {
         data: await TestUtil.readFixturesFile('edgeupdates.json'),
         persist: false,
       });
-      let result = await binary.fetch('/');
+      const result = await binary.fetch('/');
       assert.deepEqual(result, {
         items: [
           {
@@ -49,28 +53,69 @@ describe('test/common/adapter/binary/EdgedriverBinary.test.ts', () => {
         ],
         nextParams: null,
       });
+    });
 
-      const latestVersion = result!.items![result!.items.length - 1].name;
-      assert(latestVersion);
-      assert.equal(latestVersion, '126.0.2578.0/');
-      result = await binary.fetch(`/${latestVersion}`);
-      const items = result!.items;
-      assert(items.length >= 3);
-      for (const item of items) {
-        // {
-        //   name: 'edgedriver_win64.zip',
-        //   isDir: false,
-        //   url: 'https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/126.0.2578.0/edgedriver_win64.zip',
-        //   size: 9564395,
-        //   date: 'Fri, 10 May 2024 17:04:10 GMT'
-        // }
-        assert.equal(item.isDir, false);
-        assert.match(item.name, /^edgedriver_\w+.zip$/);
-        assert.match(item.url, /^https:\/\//);
-        assert(typeof item.size === 'number');
-        assert(item.size > 0);
-        assert(item.date);
-      }
+    it('should generate all known platform driver URLs for a version', async () => {
+      app.mockHttpclient('https://edgeupdates.microsoft.com/api/products', 'GET', {
+        data: await TestUtil.readFixturesFile('edgeupdates.json'),
+        persist: false,
+      });
+      const result = await binary.fetch('/126.0.2578.0/');
+      assert.ok(result);
+      assert.equal(result.nextParams, null);
+      // Expect all six known platform filenames, pointing at the new CDN,
+      // with `ignoreDownloadStatuses: [404]` so older versions that don't
+      // ship every platform get skipped cleanly instead of failing the sync.
+      assert.deepEqual(result.items, [
+        {
+          name: 'edgedriver_arm64.zip',
+          isDir: false,
+          url: 'https://msedgedriver.microsoft.com/126.0.2578.0/edgedriver_arm64.zip',
+          size: '-',
+          date: '-',
+          ignoreDownloadStatuses: [404],
+        },
+        {
+          name: 'edgedriver_linux64.zip',
+          isDir: false,
+          url: 'https://msedgedriver.microsoft.com/126.0.2578.0/edgedriver_linux64.zip',
+          size: '-',
+          date: '-',
+          ignoreDownloadStatuses: [404],
+        },
+        {
+          name: 'edgedriver_mac64.zip',
+          isDir: false,
+          url: 'https://msedgedriver.microsoft.com/126.0.2578.0/edgedriver_mac64.zip',
+          size: '-',
+          date: '-',
+          ignoreDownloadStatuses: [404],
+        },
+        {
+          name: 'edgedriver_mac64_m1.zip',
+          isDir: false,
+          url: 'https://msedgedriver.microsoft.com/126.0.2578.0/edgedriver_mac64_m1.zip',
+          size: '-',
+          date: '-',
+          ignoreDownloadStatuses: [404],
+        },
+        {
+          name: 'edgedriver_win32.zip',
+          isDir: false,
+          url: 'https://msedgedriver.microsoft.com/126.0.2578.0/edgedriver_win32.zip',
+          size: '-',
+          date: '-',
+          ignoreDownloadStatuses: [404],
+        },
+        {
+          name: 'edgedriver_win64.zip',
+          isDir: false,
+          url: 'https://msedgedriver.microsoft.com/126.0.2578.0/edgedriver_win64.zip',
+          size: '-',
+          date: '-',
+          ignoreDownloadStatuses: [404],
+        },
+      ]);
     });
   });
 });

--- a/test/port/controller/TeamController/index.test.ts
+++ b/test/port/controller/TeamController/index.test.ts
@@ -751,6 +751,72 @@ describe('test/port/controller/TeamController/index.test.ts', () => {
         .send({ package: '@cnpm/foo' })
         .expect(403);
     });
+
+    it('should allow admin to grant any package', async () => {
+      // Create a package by another user
+      const { pkg } = await TestUtil.createPackage({
+        name: '@cnpm/admin-grant-pkg',
+        version: '1.0.0',
+      });
+
+      const res = await app.httpRequest()
+        .put('/-/team/teamorg/developers/package')
+        .set('authorization', adminUser.authorization)
+        .send({ package: pkg.name })
+        .expect(200);
+      assert(res.body.ok);
+    });
+
+    it('should allow team owner to grant package they maintain', async () => {
+      // Create team in allowScopes org — normalUser becomes team owner
+      await app.httpRequest()
+        .put('/-/org/cnpm/team')
+        .set('authorization', normalUser.authorization)
+        .send({ name: 'pkg-owner-team' })
+        .expect(200);
+
+      // Publish package as normalUser (becomes maintainer)
+      const pkg = await TestUtil.getFullPackage({
+        name: '@cnpm/my-owned-pkg',
+        version: '1.0.0',
+      });
+      await app.httpRequest()
+        .put(`/${pkg.name}`)
+        .set('authorization', normalUser.authorization)
+        .set('user-agent', normalUser.ua)
+        .send(pkg)
+        .expect(201);
+
+      // Grant package — should succeed because normalUser is the maintainer
+      const res = await app.httpRequest()
+        .put('/-/team/cnpm/pkg-owner-team/package')
+        .set('authorization', normalUser.authorization)
+        .send({ package: pkg.name })
+        .expect(200);
+      assert(res.body.ok);
+    });
+
+    it('should 403 when team owner tries to grant package they do not maintain', async () => {
+      // Create team in allowScopes org — normalUser becomes team owner
+      await app.httpRequest()
+        .put('/-/org/cnpm/team')
+        .set('authorization', normalUser.authorization)
+        .send({ name: 'pkg-no-maintain-team' })
+        .expect(200);
+
+      // Create a package by another user
+      const { pkg } = await TestUtil.createPackage({
+        name: '@cnpm/not-my-pkg',
+        version: '1.0.0',
+      });
+
+      // normalUser is team owner but NOT a maintainer of this package
+      await app.httpRequest()
+        .put('/-/team/cnpm/pkg-no-maintain-team/package')
+        .set('authorization', normalUser.authorization)
+        .send({ package: pkg.name })
+        .expect(403);
+    });
   });
 
   // ==================== requireTeamWriteAccess permission paths ====================


### PR DESCRIPTION
## Summary
- Non-admin users must be a maintainer of the package before granting team package access
- Admin users are exempt from this check and can grant any package
- Updated docs (zh/en) with the new permission rule in core behavior, team package access, and permission summary sections

## Test plan
- [ ] Admin can grant any package to a team (bypass maintainer check)
- [ ] Team owner can grant a package they maintain
- [ ] Team owner gets 403 when granting a package they do not maintain

🤖 Generated with [Claude Code](https://claude.com/claude-code)