### PR TITLE
fix(DownloadController): crop /downloads/range to requested day boundaries

### DIFF
--- a/app/port/controller/DownloadController.ts
+++ b/app/port/controller/DownloadController.ts
@@ -100,14 +100,13 @@ export class DownloadController extends AbstractController {
     const month = yearMonth % 100;
     const startYM = startDate.year() * 100 + startDate.month() + 1;
     const endYM = endDate.year() * 100 + endDate.month() + 1;
-    const entityYM = year * 100 + month;
     const daysInMonth = dayjs(`${year}-${String(month).padStart(2, '0')}-01`).daysInMonth();
     let fromDay = 1;
     let toDay = daysInMonth;
-    if (entityYM === startYM) {
+    if (yearMonth === startYM) {
       fromDay = startDate.date();
     }
-    if (entityYM === endYM) {
+    if (yearMonth === endYM) {
       toDay = endDate.date();
     }
     return [ fromDay, toDay ];

--- a/app/port/controller/DownloadController.ts
+++ b/app/port/controller/DownloadController.ts
@@ -31,9 +31,11 @@ export class DownloadController extends AbstractController {
     const days: Record<string, number> = {};
     const versions: Record<string, { day: string, downloads: number }[]> = {};
     for (const entity of entities) {
-      const yearMonth = String(entity.yearMonth);
-      const prefix = yearMonth.substring(0, 4) + '-' + yearMonth.substring(4, 6);
-      for (let i = 1; i <= 31; i++) {
+      const yearMonth = entity.yearMonth as number;
+      const yearMonthStr = String(yearMonth);
+      const prefix = yearMonthStr.substring(0, 4) + '-' + yearMonthStr.substring(4, 6);
+      const [ fromDay, toDay ] = this.getDayRange(yearMonth, startDate, endDate);
+      for (let i = fromDay; i <= toDay; i++) {
         const day = String(i).padStart(2, '0');
         const field = `d${day}` as keyof typeof entity;
         const counter = entity[field] as number;
@@ -68,9 +70,11 @@ export class DownloadController extends AbstractController {
     const entities = await this.packageVersionDownloadRepository.query(scope, startDate.toDate(), endDate.toDate());
     const days: Record<string, number> = {};
     for (const entity of entities) {
-      const yearMonth = String(entity.yearMonth);
-      const prefix = yearMonth.substring(0, 4) + '-' + yearMonth.substring(4, 6);
-      for (let i = 1; i <= 31; i++) {
+      const yearMonth = entity.yearMonth as number;
+      const yearMonthStr = String(yearMonth);
+      const prefix = yearMonthStr.substring(0, 4) + '-' + yearMonthStr.substring(4, 6);
+      const [ fromDay, toDay ] = this.getDayRange(yearMonth, startDate, endDate);
+      for (let i = fromDay; i <= toDay; i++) {
         const day = String(i).padStart(2, '0');
         const field = `d${day}` as keyof typeof entity;
         const counter = entity[field] as number;
@@ -87,6 +91,26 @@ export class DownloadController extends AbstractController {
     return {
       downloads,
     };
+  }
+
+  // Get the valid day range [startDay, endDay] for a given entity's yearMonth
+  // considering the requested date range boundaries
+  private getDayRange(yearMonth: number, startDate: dayjs.Dayjs, endDate: dayjs.Dayjs): [number, number] {
+    const year = Math.floor(yearMonth / 100);
+    const month = yearMonth % 100;
+    const startYM = startDate.year() * 100 + startDate.month() + 1;
+    const endYM = endDate.year() * 100 + endDate.month() + 1;
+    const entityYM = year * 100 + month;
+    const daysInMonth = dayjs(`${year}-${String(month).padStart(2, '0')}-01`).daysInMonth();
+    let fromDay = 1;
+    let toDay = daysInMonth;
+    if (entityYM === startYM) {
+      fromDay = startDate.date();
+    }
+    if (entityYM === endYM) {
+      toDay = endDate.date();
+    }
+    return [ fromDay, toDay ];
   }
 
   private checkAndGetRange(range: string) {

--- a/test/port/controller/DownloadController/showPackageDownloads.test.ts
+++ b/test/port/controller/DownloadController/showPackageDownloads.test.ts
@@ -1,6 +1,9 @@
 import { strict as assert } from 'node:assert';
 import { app, mock } from 'egg-mock/bootstrap';
 import dayjs from '../../../../app/common/dayjs';
+import { getScopeAndName } from '../../../../app/common/PackageUtil';
+import { PackageRepository } from '../../../../app/repository/PackageRepository';
+import { PackageVersionDownloadRepository } from '../../../../app/repository/PackageVersionDownloadRepository';
 import { TestUtil } from '../../../../test/TestUtil';
 
 const SavePackageVersionDownloadCounterPath = require.resolve('../../../../app/port/schedule/SavePackageVersionDownloadCounter');
@@ -236,6 +239,61 @@ describe('test/port/controller/DownloadController/showPackageDownloads.test.ts',
         .expect('content-type', 'application/json; charset=utf-8');
       const data = res.body;
       assert.match(data.error, /beyond the processable range/);
+    });
+
+    it('should crop downloads to the requested day range, not return the whole month', async () => {
+      const { pkg } = await TestUtil.createPackage({ name: '@cnpm/range-crop', version: '1.0.0' });
+      const [ scope, name ] = getScopeAndName(pkg.name);
+      const packageRepository = await app.getEggObject(PackageRepository);
+      const pkgEntity = await packageRepository.findPackage(scope, name);
+      assert(pkgEntity);
+
+      const downloadRepository = await app.getEggObject(PackageVersionDownloadRepository);
+      // seed download counts at days 5, 15, 28 of 2023-03 directly
+      await downloadRepository.saveSyncDataByMonth(pkgEntity.packageId, 202303, [
+        [ '05', 100 ],
+        [ '15', 200 ],
+        [ '28', 300 ],
+      ]);
+
+      // 2-day range covering only day 5 — must NOT leak day 15 or 28
+      let res = await app.httpRequest()
+        .get(`/downloads/range/2023-03-05:2023-03-06/${pkg.name}`)
+        .expect(200);
+      assert.deepEqual(res.body.downloads, [
+        { day: '2023-03-05', downloads: 100 },
+      ]);
+
+      // mid-month range covering only day 15
+      res = await app.httpRequest()
+        .get(`/downloads/range/2023-03-10:2023-03-20/${pkg.name}`)
+        .expect(200);
+      assert.deepEqual(res.body.downloads, [
+        { day: '2023-03-15', downloads: 200 },
+      ]);
+
+      // full-month range returns every seeded day
+      res = await app.httpRequest()
+        .get(`/downloads/range/2023-03-01:2023-03-31/${pkg.name}`)
+        .expect(200);
+      assert.deepEqual(res.body.downloads, [
+        { day: '2023-03-05', downloads: 100 },
+        { day: '2023-03-15', downloads: 200 },
+        { day: '2023-03-28', downloads: 300 },
+      ]);
+
+      // cross-month range — middle months are NOT cropped, boundaries are
+      await downloadRepository.saveSyncDataByMonth(pkgEntity.packageId, 202304, [
+        [ '01', 10 ],
+        [ '20', 20 ],
+      ]);
+      res = await app.httpRequest()
+        .get(`/downloads/range/2023-03-28:2023-04-15/${pkg.name}`)
+        .expect(200);
+      assert.deepEqual(res.body.downloads, [
+        { day: '2023-03-28', downloads: 300 },
+        { day: '2023-04-01', downloads: 10 },
+      ]);
     });
 
     it('should 422 when range format invalid', async () => {


### PR DESCRIPTION
## Summary

Backport of the day-range cropping logic from #986 to the 3.x branch. The `/downloads/range/:from:to/:pkg` endpoint currently ignores the day part of `from` / `to` and returns the entire month.

## Why

`PackageVersionDownloadRepository.query` filters only by `yearMonth` (records are stored as one row per month with `d01..d31` columns), so any in-range month returns the full row. The controller was iterating `1..31` unconditionally and emitting every non-zero day, so:

```
GET /downloads/range/2026-03-05:2026-03-06/@some/pkg
GET /downloads/range/2026-03-25:2026-03-26/@some/pkg
GET /downloads/range/2026-03-01:2026-03-02/@some/pkg
```

all return the same data — every day of March that has downloads.

## Fix

Add `getDayRange(yearMonth, startDate, endDate)` that clamps `fromDay` / `toDay` against the request boundaries when the entity's `yearMonth` matches the start or end month. Middle months stay full. Logic mirrors master's `de5f074`.

## Test plan

- [x] New test seeds `d05`, `d15`, `d28` via `saveSyncDataByMonth` and asserts:
  - `2023-03-05:2023-03-06` → only day 05
  - `2023-03-10:2023-03-20` → only day 15
  - `2023-03-01:2023-03-31` → all three
  - `2023-03-28:2023-04-15` (cross-month) → boundary days only
- [ ] CI green

## Notes

Filed as **draft** so reviewers can confirm:
1. Backport scope is the right call (vs. cherry-picking the whole #986 — see commit message).
2. Test placement in the existing `showPackageDownloads.test.ts` is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)