### PR TITLE
fix(PlaywrightBinary): mirror builds/cft/{browserVersion}/ chromium paths

### DIFF
--- a/app/common/adapter/binary/PlaywrightBinary.ts
+++ b/app/common/adapter/binary/PlaywrightBinary.ts
@@ -12,123 +12,134 @@ const DOWNLOAD_HOST = 'https://playwright.azureedge.net/';
 const PLAYWRIGHT_DRIVER_ARCHS = ['win32_x64', 'mac-arm64', 'mac', 'linux-arm64', 'linux'];
 
 // https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/registry/index.ts
+// CFT entries use Chrome for Testing URLs: builds/cft/{browserVersion}/{suffix}
+// (introduced in playwright 1.58.1, see https://github.com/cnpm/cnpmcore/issues/1033)
+const cft = (suffix: string) => ({ cft: suffix }) as const;
 /* eslint-disable quote-props */
 const DOWNLOAD_PATHS = {
   chromium: {
     '<unknown>': undefined,
     'ubuntu18.04-x64': undefined,
-    'ubuntu20.04-x64': 'builds/chromium/%s/chromium-linux.zip',
-    'ubuntu22.04-x64': 'builds/chromium/%s/chromium-linux.zip',
-    'ubuntu24.04-x64': 'builds/chromium/%s/chromium-linux.zip',
+    'ubuntu20.04-x64': cft('linux64/chrome-linux64.zip'),
+    'ubuntu22.04-x64': cft('linux64/chrome-linux64.zip'),
+    'ubuntu24.04-x64': cft('linux64/chrome-linux64.zip'),
     'ubuntu18.04-arm64': undefined,
     'ubuntu20.04-arm64': 'builds/chromium/%s/chromium-linux-arm64.zip',
     'ubuntu22.04-arm64': 'builds/chromium/%s/chromium-linux-arm64.zip',
     'ubuntu24.04-arm64': 'builds/chromium/%s/chromium-linux-arm64.zip',
-    'debian11-x64': 'builds/chromium/%s/chromium-linux.zip',
+    'debian11-x64': cft('linux64/chrome-linux64.zip'),
     'debian11-arm64': 'builds/chromium/%s/chromium-linux-arm64.zip',
-    'debian12-x64': 'builds/chromium/%s/chromium-linux.zip',
+    'debian12-x64': cft('linux64/chrome-linux64.zip'),
     'debian12-arm64': 'builds/chromium/%s/chromium-linux-arm64.zip',
-    'mac10.13': 'builds/chromium/%s/chromium-mac.zip',
-    'mac10.14': 'builds/chromium/%s/chromium-mac.zip',
-    'mac10.15': 'builds/chromium/%s/chromium-mac.zip',
-    mac11: 'builds/chromium/%s/chromium-mac.zip',
-    'mac11-arm64': 'builds/chromium/%s/chromium-mac-arm64.zip',
-    mac12: 'builds/chromium/%s/chromium-mac.zip',
-    'mac12-arm64': 'builds/chromium/%s/chromium-mac-arm64.zip',
-    mac13: 'builds/chromium/%s/chromium-mac.zip',
-    'mac13-arm64': 'builds/chromium/%s/chromium-mac-arm64.zip',
-    mac14: 'builds/chromium/%s/chromium-mac.zip',
-    'mac14-arm64': 'builds/chromium/%s/chromium-mac-arm64.zip',
-    mac15: 'builds/chromium/%s/chromium-mac.zip',
-    'mac15-arm64': 'builds/chromium/%s/chromium-mac-arm64.zip',
-    win64: 'builds/chromium/%s/chromium-win64.zip',
+    'debian13-x64': cft('linux64/chrome-linux64.zip'),
+    'debian13-arm64': 'builds/chromium/%s/chromium-linux-arm64.zip',
+    'mac10.13': cft('mac-x64/chrome-mac-x64.zip'),
+    'mac10.14': cft('mac-x64/chrome-mac-x64.zip'),
+    'mac10.15': cft('mac-x64/chrome-mac-x64.zip'),
+    mac11: cft('mac-x64/chrome-mac-x64.zip'),
+    'mac11-arm64': cft('mac-arm64/chrome-mac-arm64.zip'),
+    mac12: cft('mac-x64/chrome-mac-x64.zip'),
+    'mac12-arm64': cft('mac-arm64/chrome-mac-arm64.zip'),
+    mac13: cft('mac-x64/chrome-mac-x64.zip'),
+    'mac13-arm64': cft('mac-arm64/chrome-mac-arm64.zip'),
+    mac14: cft('mac-x64/chrome-mac-x64.zip'),
+    'mac14-arm64': cft('mac-arm64/chrome-mac-arm64.zip'),
+    mac15: cft('mac-x64/chrome-mac-x64.zip'),
+    'mac15-arm64': cft('mac-arm64/chrome-mac-arm64.zip'),
+    win64: cft('win64/chrome-win64.zip'),
   },
   'chromium-headless-shell': {
     '<unknown>': undefined,
     'ubuntu18.04-x64': undefined,
-    'ubuntu20.04-x64': 'builds/chromium/%s/chromium-headless-shell-linux.zip',
-    'ubuntu22.04-x64': 'builds/chromium/%s/chromium-headless-shell-linux.zip',
-    'ubuntu24.04-x64': 'builds/chromium/%s/chromium-headless-shell-linux.zip',
+    'ubuntu20.04-x64': cft('linux64/chrome-headless-shell-linux64.zip'),
+    'ubuntu22.04-x64': cft('linux64/chrome-headless-shell-linux64.zip'),
+    'ubuntu24.04-x64': cft('linux64/chrome-headless-shell-linux64.zip'),
     'ubuntu18.04-arm64': undefined,
     'ubuntu20.04-arm64': 'builds/chromium/%s/chromium-headless-shell-linux-arm64.zip',
     'ubuntu22.04-arm64': 'builds/chromium/%s/chromium-headless-shell-linux-arm64.zip',
     'ubuntu24.04-arm64': 'builds/chromium/%s/chromium-headless-shell-linux-arm64.zip',
-    'debian11-x64': 'builds/chromium/%s/chromium-headless-shell-linux.zip',
+    'debian11-x64': cft('linux64/chrome-headless-shell-linux64.zip'),
     'debian11-arm64': 'builds/chromium/%s/chromium-headless-shell-linux-arm64.zip',
-    'debian12-x64': 'builds/chromium/%s/chromium-headless-shell-linux.zip',
+    'debian12-x64': cft('linux64/chrome-headless-shell-linux64.zip'),
     'debian12-arm64': 'builds/chromium/%s/chromium-headless-shell-linux-arm64.zip',
+    'debian13-x64': cft('linux64/chrome-headless-shell-linux64.zip'),
+    'debian13-arm64': 'builds/chromium/%s/chromium-headless-shell-linux-arm64.zip',
     'mac10.13': undefined,
     'mac10.14': undefined,
     'mac10.15': undefined,
-    mac11: 'builds/chromium/%s/chromium-headless-shell-mac.zip',
-    'mac11-arm64': 'builds/chromium/%s/chromium-headless-shell-mac-arm64.zip',
-    mac12: 'builds/chromium/%s/chromium-headless-shell-mac.zip',
-    'mac12-arm64': 'builds/chromium/%s/chromium-headless-shell-mac-arm64.zip',
-    mac13: 'builds/chromium/%s/chromium-headless-shell-mac.zip',
-    'mac13-arm64': 'builds/chromium/%s/chromium-headless-shell-mac-arm64.zip',
-    mac14: 'builds/chromium/%s/chromium-headless-shell-mac.zip',
-    'mac14-arm64': 'builds/chromium/%s/chromium-headless-shell-mac-arm64.zip',
-    mac15: 'builds/chromium/%s/chromium-headless-shell-mac.zip',
-    'mac15-arm64': 'builds/chromium/%s/chromium-headless-shell-mac-arm64.zip',
-    win64: 'builds/chromium/%s/chromium-headless-shell-win64.zip',
+    mac11: cft('mac-x64/chrome-headless-shell-mac-x64.zip'),
+    'mac11-arm64': cft('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
+    mac12: cft('mac-x64/chrome-headless-shell-mac-x64.zip'),
+    'mac12-arm64': cft('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
+    mac13: cft('mac-x64/chrome-headless-shell-mac-x64.zip'),
+    'mac13-arm64': cft('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
+    mac14: cft('mac-x64/chrome-headless-shell-mac-x64.zip'),
+    'mac14-arm64': cft('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
+    mac15: cft('mac-x64/chrome-headless-shell-mac-x64.zip'),
+    'mac15-arm64': cft('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
+    win64: cft('win64/chrome-headless-shell-win64.zip'),
   },
   'chromium-tip-of-tree': {
     '<unknown>': undefined,
     'ubuntu18.04-x64': undefined,
-    'ubuntu20.04-x64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-linux.zip',
-    'ubuntu22.04-x64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-linux.zip',
-    'ubuntu24.04-x64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-linux.zip',
+    'ubuntu20.04-x64': cft('linux64/chrome-linux64.zip'),
+    'ubuntu22.04-x64': cft('linux64/chrome-linux64.zip'),
+    'ubuntu24.04-x64': cft('linux64/chrome-linux64.zip'),
     'ubuntu18.04-arm64': undefined,
     'ubuntu20.04-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-linux-arm64.zip',
     'ubuntu22.04-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-linux-arm64.zip',
     'ubuntu24.04-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-linux-arm64.zip',
-    'debian11-x64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-linux.zip',
+    'debian11-x64': cft('linux64/chrome-linux64.zip'),
     'debian11-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-linux-arm64.zip',
-    'debian12-x64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-linux.zip',
+    'debian12-x64': cft('linux64/chrome-linux64.zip'),
     'debian12-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-linux-arm64.zip',
-    'mac10.13': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-mac.zip',
-    'mac10.14': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-mac.zip',
-    'mac10.15': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-mac.zip',
-    mac11: 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-mac.zip',
-    'mac11-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-mac-arm64.zip',
-    mac12: 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-mac.zip',
-    'mac12-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-mac-arm64.zip',
-    mac13: 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-mac.zip',
-    'mac13-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-mac-arm64.zip',
-    mac14: 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-mac.zip',
-    'mac14-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-mac-arm64.zip',
-    mac15: 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-mac.zip',
-    'mac15-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-mac-arm64.zip',
-    win64: 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-win64.zip',
+    'debian13-x64': cft('linux64/chrome-linux64.zip'),
+    'debian13-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-linux-arm64.zip',
+    'mac10.13': cft('mac-x64/chrome-mac-x64.zip'),
+    'mac10.14': cft('mac-x64/chrome-mac-x64.zip'),
+    'mac10.15': cft('mac-x64/chrome-mac-x64.zip'),
+    mac11: cft('mac-x64/chrome-mac-x64.zip'),
+    'mac11-arm64': cft('mac-arm64/chrome-mac-arm64.zip'),
+    mac12: cft('mac-x64/chrome-mac-x64.zip'),
+    'mac12-arm64': cft('mac-arm64/chrome-mac-arm64.zip'),
+    mac13: cft('mac-x64/chrome-mac-x64.zip'),
+    'mac13-arm64': cft('mac-arm64/chrome-mac-arm64.zip'),
+    mac14: cft('mac-x64/chrome-mac-x64.zip'),
+    'mac14-arm64': cft('mac-arm64/chrome-mac-arm64.zip'),
+    mac15: cft('mac-x64/chrome-mac-x64.zip'),
+    'mac15-arm64': cft('mac-arm64/chrome-mac-arm64.zip'),
+    win64: cft('win64/chrome-win64.zip'),
   },
   'chromium-tip-of-tree-headless-shell': {
     '<unknown>': undefined,
     'ubuntu18.04-x64': undefined,
-    'ubuntu20.04-x64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-linux.zip',
-    'ubuntu22.04-x64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-linux.zip',
-    'ubuntu24.04-x64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-linux.zip',
+    'ubuntu20.04-x64': cft('linux64/chrome-headless-shell-linux64.zip'),
+    'ubuntu22.04-x64': cft('linux64/chrome-headless-shell-linux64.zip'),
+    'ubuntu24.04-x64': cft('linux64/chrome-headless-shell-linux64.zip'),
     'ubuntu18.04-arm64': undefined,
     'ubuntu20.04-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-linux-arm64.zip',
     'ubuntu22.04-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-linux-arm64.zip',
     'ubuntu24.04-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-linux-arm64.zip',
-    'debian11-x64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-linux.zip',
+    'debian11-x64': cft('linux64/chrome-headless-shell-linux64.zip'),
     'debian11-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-linux-arm64.zip',
-    'debian12-x64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-linux.zip',
+    'debian12-x64': cft('linux64/chrome-headless-shell-linux64.zip'),
     'debian12-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-linux-arm64.zip',
+    'debian13-x64': cft('linux64/chrome-headless-shell-linux64.zip'),
+    'debian13-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-linux-arm64.zip',
     'mac10.13': undefined,
     'mac10.14': undefined,
     'mac10.15': undefined,
-    mac11: 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-mac.zip',
-    'mac11-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-mac-arm64.zip',
-    mac12: 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-mac.zip',
-    'mac12-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-mac-arm64.zip',
-    mac13: 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-mac.zip',
-    'mac13-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-mac-arm64.zip',
-    mac14: 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-mac.zip',
-    'mac14-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-mac-arm64.zip',
-    mac15: 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-mac.zip',
-    'mac15-arm64': 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-mac-arm64.zip',
-    win64: 'builds/chromium-tip-of-tree/%s/chromium-tip-of-tree-headless-shell-win64.zip',
+    mac11: cft('mac-x64/chrome-headless-shell-mac-x64.zip'),
+    'mac11-arm64': cft('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
+    mac12: cft('mac-x64/chrome-headless-shell-mac-x64.zip'),
+    'mac12-arm64': cft('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
+    mac13: cft('mac-x64/chrome-headless-shell-mac-x64.zip'),
+    'mac13-arm64': cft('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
+    mac14: cft('mac-x64/chrome-headless-shell-mac-x64.zip'),
+    'mac14-arm64': cft('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
+    mac15: cft('mac-x64/chrome-headless-shell-mac-x64.zip'),
+    'mac15-arm64': cft('mac-arm64/chrome-headless-shell-mac-arm64.zip'),
+    win64: cft('win64/chrome-headless-shell-win64.zip'),
   },
   firefox: {
     '<unknown>': undefined,
@@ -338,6 +349,15 @@ export class PlaywrightBinary extends AbstractBinary {
         size: '-',
         date: nowDateISO,
       });
+      // builds/cft/ holds Chrome for Testing downloads
+      // (Playwright 1.58.1+ moved chromium downloads to builds/cft/{browserVersion}/{platform}/)
+      buildDirs.push({
+        name: 'cft/',
+        isDir: true,
+        url: '',
+        size: '-',
+        date: nowDateISO,
+      });
       this.dirItems = {
         '/': [
           {
@@ -349,6 +369,7 @@ export class PlaywrightBinary extends AbstractBinary {
           },
         ],
         '/builds/': buildDirs,
+        '/builds/cft/': [],
       };
       for (const browserName of Object.keys(DOWNLOAD_PATHS)) {
         if (browserName === 'chromium-headless-shell' || browserName === 'chromium-tip-of-tree-headless-shell') {
@@ -467,21 +488,57 @@ export class PlaywrightBinary extends AbstractBinary {
           browserDirname = 'chromium-tip-of-tree';
         }
         for (const [platform, remotePath] of Object.entries(downloadPaths)) {
-          if (typeof remotePath !== 'string') continue;
+          if (!remotePath) continue;
           const revision = browser.revisionOverrides?.[platform] ?? browser.revision;
           const itemDate = browser.browserVersion || revision;
-          const url = DOWNLOAD_HOST + util.format(remotePath, revision);
-          const name = path.basename(remotePath);
-          const dir = `/builds/${browserDirname}/${revision}/`;
-          if (!this.dirItems[dir]) {
-            this.dirItems[`/builds/${browserDirname}/`].push({
-              name: `${revision}/`,
-              isDir: true,
-              url: '',
-              size: '-',
-              date: revision,
-            });
-            this.dirItems[dir] = [];
+          let url: string;
+          let name: string;
+          let dir: string;
+          if (typeof remotePath === 'string') {
+            url = DOWNLOAD_HOST + util.format(remotePath, revision);
+            name = path.basename(remotePath);
+            dir = `/builds/${browserDirname}/${revision}/`;
+            if (!this.dirItems[dir]) {
+              this.dirItems[`/builds/${browserDirname}/`].push({
+                name: `${revision}/`,
+                isDir: true,
+                url: '',
+                size: '-',
+                date: revision,
+              });
+              this.dirItems[dir] = [];
+            }
+          } else {
+            // Chrome for Testing path: builds/cft/{browserVersion}/{suffix}
+            if (!browser.browserVersion) continue;
+            const cftSuffix = remotePath.cft;
+            url = `${DOWNLOAD_HOST}builds/cft/${browser.browserVersion}/${cftSuffix}`;
+            name = path.basename(cftSuffix);
+            const platformDir = path.dirname(cftSuffix);
+            const versionDir = `/builds/cft/${browser.browserVersion}/`;
+            dir = `${versionDir}${platformDir}/`;
+            if (!this.dirItems[versionDir]) {
+              this.dirItems['/builds/cft/'].push({
+                name: `${browser.browserVersion}/`,
+                isDir: true,
+                url: '',
+                size: '-',
+                date: browser.browserVersion,
+              });
+              this.dirItems[versionDir] = [];
+            }
+            if (!this.dirItems[versionDir].some((item) => item.name === `${platformDir}/`)) {
+              this.dirItems[versionDir].push({
+                name: `${platformDir}/`,
+                isDir: true,
+                url: '',
+                size: '-',
+                date: browser.browserVersion,
+              });
+            }
+            if (!this.dirItems[dir]) {
+              this.dirItems[dir] = [];
+            }
           }
           if (!this.dirItems[dir].some((item) => item.name === name)) {
             this.dirItems[dir].push({

--- a/app/common/adapter/binary/PlaywrightBinary.ts
+++ b/app/common/adapter/binary/PlaywrightBinary.ts
@@ -509,7 +509,6 @@ export class PlaywrightBinary extends AbstractBinary {
               this.dirItems[dir] = [];
             }
           } else {
-            // Chrome for Testing path: builds/cft/{browserVersion}/{suffix}
             if (!browser.browserVersion) continue;
             const cftSuffix = remotePath.cft;
             url = `${DOWNLOAD_HOST}builds/cft/${browser.browserVersion}/${cftSuffix}`;

--- a/test/common/adapter/binary/PlaywrightBinary.test.ts
+++ b/test/common/adapter/binary/PlaywrightBinary.test.ts
@@ -103,6 +103,14 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
           /https:\/\/playwright\.azureedge\.net\/builds\/cft\/133\.0\.6943\.16\/mac-arm64\/(chrome|chrome-headless-shell)-mac-arm64\.zip/,
         );
       }
+
+      // linux-arm64 did NOT migrate to CFT and must still resolve under builds/chromium/{revision}/.
+      // Fixture revision is 1155.
+      const chromiumRevResult = await binary.fetch('/builds/chromium/1155/');
+      assert.ok(chromiumRevResult);
+      const linuxArm64 = chromiumRevResult.items.find((item) => item.name === 'chromium-linux-arm64.zip');
+      assert.ok(linuxArm64, 'chromium-linux-arm64.zip should still live at /builds/chromium/1155/');
+      assert.equal(linuxArm64.url, 'https://playwright.azureedge.net/builds/chromium/1155/chromium-linux-arm64.zip');
     });
 
     it('should fetch subdir: /builds/, /builds/chromium/ work', async () => {

--- a/test/common/adapter/binary/PlaywrightBinary.test.ts
+++ b/test/common/adapter/binary/PlaywrightBinary.test.ts
@@ -41,6 +41,70 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
       assert.ok(matchDir1);
     });
 
+    // https://github.com/cnpm/cnpmcore/issues/1033
+    // Playwright 1.58.1+ moved chromium downloads to builds/cft/{browserVersion}/{platform}/{file}.zip
+    it('should mirror builds/cft/{browserVersion}/{platform}/ entries for chromium', async () => {
+      app.mockHttpclient('https://registry.npmjs.com/playwright-core', 'GET', {
+        data: await TestUtil.readFixturesFile('registry.npmjs.com/playwright-core.json'),
+        persist: false,
+      });
+      app
+        .mockAgent()
+        .get('https://unpkg.com')
+        .intercept({
+          method: 'GET',
+          path: /browsers\.json/,
+        })
+        .reply(200, await TestUtil.readFixturesFile('unpkg.com/playwright-core-browsers.json'))
+        .persist();
+
+      const buildsResult = await binary.fetch('/builds/');
+      assert.ok(buildsResult);
+      assert.ok(
+        buildsResult.items.some((item) => item.name === 'cft/' && item.isDir),
+        'builds/ should include cft/ subdir',
+      );
+
+      const cftResult = await binary.fetch('/builds/cft/');
+      assert.ok(cftResult);
+      // chromium browserVersion from fixture: 133.0.6943.16
+      // chromium-tip-of-tree browserVersion from fixture: 133.0.6943.0
+      const cftVersionDirs = cftResult.items.map((item) => item.name);
+      assert.ok(
+        cftVersionDirs.includes('133.0.6943.16/'),
+        `cft/ should include 133.0.6943.16/, got: ${cftVersionDirs.join(', ')}`,
+      );
+      assert.ok(
+        cftVersionDirs.includes('133.0.6943.0/'),
+        `cft/ should include 133.0.6943.0/, got: ${cftVersionDirs.join(', ')}`,
+      );
+
+      const cftVersionResult = await binary.fetch('/builds/cft/133.0.6943.16/');
+      assert.ok(cftVersionResult);
+      const platformDirs = cftVersionResult.items.map((item) => item.name).sort();
+      assert.deepEqual(platformDirs, ['linux64/', 'mac-arm64/', 'mac-x64/', 'win64/']);
+
+      const macArm64Result = await binary.fetch('/builds/cft/133.0.6943.16/mac-arm64/');
+      assert.ok(macArm64Result);
+      const macFileNames = macArm64Result.items.map((item) => item.name).sort();
+      // chrome (chromium) + chrome-headless-shell variants
+      assert.ok(
+        macFileNames.includes('chrome-mac-arm64.zip'),
+        `should include chrome-mac-arm64.zip, got: ${macFileNames.join(', ')}`,
+      );
+      assert.ok(
+        macFileNames.includes('chrome-headless-shell-mac-arm64.zip'),
+        `should include chrome-headless-shell-mac-arm64.zip, got: ${macFileNames.join(', ')}`,
+      );
+      for (const item of macArm64Result.items) {
+        assert.equal(item.isDir, false);
+        assert.match(
+          item.url,
+          /https:\/\/playwright\.azureedge\.net\/builds\/cft\/133\.0\.6943\.16\/mac-arm64\/(chrome|chrome-headless-shell)-mac-arm64\.zip/,
+        );
+      }
+    });
+
     it('should fetch subdir: /builds/, /builds/chromium/ work', async () => {
       app.mockHttpclient('https://registry.npmjs.com/playwright-core', 'GET', {
         data: await TestUtil.readFixturesFile('registry.npmjs.com/playwright-core.json'),
@@ -57,7 +121,7 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
         .persist();
       let result = await binary.fetch('/builds/');
       assert.ok(result);
-      assert.equal(result.items.length, 9, JSON.stringify(result, null, 2));
+      assert.equal(result.items.length, 10, JSON.stringify(result, null, 2));
       assert.equal(result.items[0].name, 'chromium/');
       assert.equal(result.items[1].name, 'chromium-tip-of-tree/');
       assert.equal(result.items[2].name, 'firefox/');
@@ -67,6 +131,7 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
       assert.equal(result.items[6].name, 'winldd/');
       assert.equal(result.items[7].name, 'android/');
       assert.equal(result.items[8].name, 'driver/');
+      assert.equal(result.items[9].name, 'cft/');
       assert.equal(result.items[0].isDir, true);
 
       const driverDirs = ['driver/', 'driver/next/'];


### PR DESCRIPTION
## Summary

Playwright 1.58.1 moved chromium downloads to Chrome for Testing URLs (`builds/cft/{browserVersion}/{platform}/{file}.zip`) for mac, win64, and x64 linux. linux-arm64 still uses the old `builds/chromium/{revision}/` path. The mirror only knew the old layout, so newer chromium revisions stopped appearing under `playwright/builds/chromium/` (see [the playwright registry source](https://github.com/microsoft/playwright/blob/v1.59.1/packages/playwright-core/src/server/registry/index.ts) and [PR #39037](https://github.com/microsoft/playwright/pull/39037) which introduced the change).

Closes #1033

## URL changes (chromium revision `1217`, browserVersion `147.0.7727.15`)

### Upstream (`https://playwright.azureedge.net`)

What playwright requests from `PLAYWRIGHT_DOWNLOAD_HOST`:

| Platform | Before (playwright ≤ 1.58.0) | After (playwright ≥ 1.58.1) |
| --- | --- | --- |
| `mac-x64` | https://playwright.azureedge.net/builds/chromium/1217/chromium-mac.zip | https://playwright.azureedge.net/builds/cft/147.0.7727.15/mac-x64/chrome-mac-x64.zip |
| `mac-arm64` | https://playwright.azureedge.net/builds/chromium/1217/chromium-mac-arm64.zip | https://playwright.azureedge.net/builds/cft/147.0.7727.15/mac-arm64/chrome-mac-arm64.zip |
| `win64` | https://playwright.azureedge.net/builds/chromium/1217/chromium-win64.zip | https://playwright.azureedge.net/builds/cft/147.0.7727.15/win64/chrome-win64.zip |
| `ubuntu/debian x64` | https://playwright.azureedge.net/builds/chromium/1217/chromium-linux.zip | https://playwright.azureedge.net/builds/cft/147.0.7727.15/linux64/chrome-linux64.zip |
| `ubuntu/debian arm64` | https://playwright.azureedge.net/builds/chromium/1217/chromium-linux-arm64.zip | https://playwright.azureedge.net/builds/chromium/1217/chromium-linux-arm64.zip *(unchanged)* |

### Mirror (`https://cdn.npmmirror.com/binaries/playwright`)

What cnpmcore exposes — these are the URLs a playwright client hits after setting `PLAYWRIGHT_DOWNLOAD_HOST=https://cdn.npmmirror.com/binaries/playwright`:

| Platform | Before this PR | After this PR |
| --- | --- | --- |
| `mac-x64` | ❌ not mirrored at the path playwright requests | ✅ https://cdn.npmmirror.com/binaries/playwright/builds/cft/147.0.7727.15/mac-x64/chrome-mac-x64.zip |
| `mac-arm64` | ❌ not mirrored at the path playwright requests | ✅ https://cdn.npmmirror.com/binaries/playwright/builds/cft/147.0.7727.15/mac-arm64/chrome-mac-arm64.zip |
| `win64` | ❌ not mirrored at the path playwright requests | ✅ https://cdn.npmmirror.com/binaries/playwright/builds/cft/147.0.7727.15/win64/chrome-win64.zip |
| `ubuntu/debian x64` | ❌ not mirrored at the path playwright requests | ✅ https://cdn.npmmirror.com/binaries/playwright/builds/cft/147.0.7727.15/linux64/chrome-linux64.zip |
| `ubuntu/debian arm64` | ✅ https://cdn.npmmirror.com/binaries/playwright/builds/chromium/1217/chromium-linux-arm64.zip | ✅ https://cdn.npmmirror.com/binaries/playwright/builds/chromium/1217/chromium-linux-arm64.zip *(unchanged)* |

`chromium-headless-shell` files share the same `builds/cft/{browserVersion}/{platform}/` directory, e.g. https://cdn.npmmirror.com/binaries/playwright/builds/cft/147.0.7727.15/mac-arm64/chrome-headless-shell-mac-arm64.zip. `chromium-tip-of-tree` follows the same pattern with its own `browserVersion`.

## Mirror directory tree (before / after)

Before — for revision 1217, only the linux-arm64 file existed in the tree, so the chromium directory effectively stalled at the last pre-CFT revision (1200) for most users:

```
https://registry.npmmirror.com/binary.html?path=playwright/builds/chromium/1217/
  chromium-linux-arm64.zip
  chromium-headless-shell-linux-arm64.zip
```

After — chromium directory still gets the linux-arm64 entries, and a new `builds/cft/` tree exposes the CFT downloads:

```
https://registry.npmmirror.com/binary.html?path=playwright/builds/chromium/1217/
  chromium-linux-arm64.zip
  chromium-headless-shell-linux-arm64.zip

https://registry.npmmirror.com/binary.html?path=playwright/builds/cft/147.0.7727.15/linux64/
  chrome-linux64.zip
  chrome-headless-shell-linux64.zip

https://registry.npmmirror.com/binary.html?path=playwright/builds/cft/147.0.7727.15/mac-x64/
  chrome-mac-x64.zip
  chrome-headless-shell-mac-x64.zip

https://registry.npmmirror.com/binary.html?path=playwright/builds/cft/147.0.7727.15/mac-arm64/
  chrome-mac-arm64.zip
  chrome-headless-shell-mac-arm64.zip

https://registry.npmmirror.com/binary.html?path=playwright/builds/cft/147.0.7727.15/win64/
  chrome-win64.zip
  chrome-headless-shell-win64.zip
```

## Changes

- `app/common/adapter/binary/PlaywrightBinary.ts`
  - Introduced a `cft(suffix)` helper and switched `chromium` / `chromium-headless-shell` / `chromium-tip-of-tree` / `chromium-tip-of-tree-headless-shell` entries for mac, win64, and x64 linux platforms to CFT objects.
  - Added the new `debian13-*` platform keys playwright now ships.
  - Emit `builds/cft/` as a top-level directory and populate `/builds/cft/{browserVersion}/{platform}/` with deduplicated entries so chromium and chromium-headless-shell share the same version+platform dir.

## Test plan

- [x] `npm run test:local test/common/adapter/binary/PlaywrightBinary.test.ts` — 3 tests pass, including a new test asserting `/builds/cft/{browserVersion}/{platform}/` contains `chrome-*.zip` and `chrome-headless-shell-*.zip` with correctly-formed CFT URLs.
- [x] `npm run lint`
- [x] `npm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Chrome for Testing (CFT) binary downloads with optimized download structure.

* **Tests**
  * Added comprehensive test coverage validating CFT mirror layout and download URL patterns.
  * Updated existing tests to reflect new directory organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cnpm/cnpmcore/pull/1050?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->