### PR TITLE
feat: dependency isolation (buffer) zone (RFC #1057)

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,1 @@
+sandbox_mode = "workspace-write"

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,6 +8,7 @@ on:
     branches: [ 3.x ]
   pull_request:
     branches: [ 3.x ]
+  merge_group:
 
 jobs:
   test-postgresql-fs-nfs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,425 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Codex Usage
+
+### Thinking Modes
+
+When working on complex tasks, use extended thinking for deeper analysis:
+
+- **ultrathink** / **think harder** - Maximum depth reasoning for architectural decisions, complex debugging, and thorough code review
+- **think** - Standard extended thinking for moderate complexity tasks
+
+Example prompts:
+
+- "ultrathink about the best way to implement this feature"
+- "think harder about potential edge cases in this code"
+
+Use ultrathink for:
+
+- Architectural design decisions
+- Complex refactoring across multiple files
+- Debugging intricate issues
+- Security vulnerability analysis
+- Performance optimization strategies
+
+## Project Overview
+
+cnpmcore is a TypeScript-based private NPM registry implementation for enterprise use. It's built on the Egg.js framework using Domain-Driven Design (DDD) architecture principles and supports both MySQL and PostgreSQL databases.
+
+## Essential Commands
+
+### Development
+
+```bash
+# Start development server (MySQL)
+npm run dev
+
+# Start development server (PostgreSQL)
+npm run dev:postgresql
+
+# Lint code
+npm run lint
+
+# Fix linting issues
+npm run lint:fix
+
+# TypeScript type checking
+npm run typecheck
+```
+
+### Testing
+
+```bash
+# Run all tests with MySQL (takes 4+ minutes)
+npm run test
+
+# Run all tests with PostgreSQL (takes 4+ minutes)
+npm run test:postgresql
+
+# Run single test file (faster iteration, ~12 seconds)
+npm run test:local test/path/to/file.test.ts
+
+# Generate coverage report
+npm run cov
+```
+
+### Database Setup
+
+```bash
+# MySQL setup
+docker compose -f docker-compose.yml up -d
+CNPMCORE_DATABASE_NAME=cnpmcore bash ./prepare-database-mysql.sh
+
+# PostgreSQL setup
+docker compose -f docker-compose-postgres.yml up -d
+CNPMCORE_DATABASE_NAME=cnpmcore bash ./prepare-database-postgresql.sh
+```
+
+### Build
+
+```bash
+# Clean build artifacts
+npm run clean
+
+# Development build
+npm run tsc
+
+# Production build
+npm run tsc:prod
+```
+
+## Architecture - Domain-Driven Design (DDD)
+
+The codebase follows strict DDD layering with clear separation of concerns:
+
+```
+Controller (app/port/controller/)     ← HTTP interface, validation, auth
+    ↓ depends on
+Service (app/core/service/)           ← Business logic orchestration
+    ↓ depends on
+Repository (app/repository/)          ← Data access layer
+    ↓ depends on
+Model (app/repository/model/)         ← ORM/Database mapping
+
+Entity (app/core/entity/)             ← Pure domain models (no dependencies)
+Common (app/common/)                  ← Utilities and adapters (all layers)
+```
+
+### Layer Responsibilities
+
+**Controller Layer** (`app/port/controller/`):
+
+- Handle HTTP requests/responses
+- Validate inputs using `@eggjs/typebox-validate`
+- Authenticate users and verify authorization
+- Delegate business logic to Services
+- All controllers extend `AbstractController` → `MiddlewareController`
+- Auto-applied middlewares: `AlwaysAuth`, `Tracing`, `ErrorHandler`
+
+Key `AbstractController` methods:
+
+- `ensurePublishAccess(ctx, fullname)` - Authorization check for package publish
+- `getPackageEntity(scope, name)` - Fetch package with error handling
+- `setCDNHeaders(ctx)` - Set cache control headers
+- `getAllowSync(ctx)` - Check if sync should be triggered
+
+**Service Layer** (`app/core/service/`):
+
+- Implement core business logic
+- Orchestrate multiple repositories
+- Publish domain events via `EventBus`
+- Manage transactions
+- Use `@SingletonProto({ accessLevel: AccessLevel.PUBLIC })` scope
+- Define command interfaces (e.g., `PublishPackageCmd`) for complex operations
+
+**Repository Layer** (`app/repository/`):
+
+- CRUD operations on Models
+- Data access and persistence
+- Query building and optimization
+- Methods named: `findX`, `saveX`, `removeX`, `listXs`
+
+**Entity Layer** (`app/core/entity/`):
+
+- Pure domain models with business behavior
+- No infrastructure dependencies
+- Factory pattern: `static create(data)` method on each entity
+- Use `EntityUtil.defaultData(data, 'idField')` for ID/timestamp defaults
+- Type guards for union types (e.g., `isGranularToken()`)
+- `EasyData<T, Id>` type helper for optional create-time fields
+
+**Model Layer** (`app/repository/model/`):
+
+- ORM definitions using Leoric
+- Database schema mapping
+- No business logic
+
+**Model-Entity Bridge** (`app/repository/util/`):
+
+- `ModelConvertor.convertEntityToModel(entity, ModelClass)` - Persist entity
+- `ModelConvertor.convertModelToEntity(model, EntityClass)` - Load entity
+- Uses `@EntityProperty()` decorator for complex nested property mapping
+- `ModelMetadataUtil` for reflection-based property discovery
+
+### Infrastructure Adapters (`app/infra/`)
+
+Enterprise customization layer for PaaS integration:
+
+- **NFSClientAdapter**: File storage (local/S3/OSS)
+- **QueueAdapter**: Message queue integration
+- **AuthAdapter**: Authentication system
+- **BinaryAdapter**: Binary package storage
+- **SearchAdapter**: Elasticsearch integration
+- **CacheAdapter**: Redis caching with distributed locking
+
+### Key Decorators & Annotations
+
+**HTTP Layer** (from `@eggjs/tegg`):
+
+- `@HTTPController()` - Marks class as HTTP controller
+- `@HTTPMethod({ path, method })` - Route definition
+- `@HTTPBody()` / `@HTTPQuery()` / `@HTTPParam()` - Request data injection with typebox validation
+- `@HTTPContext() ctx: Context` - Inject Egg.js context
+- `@Middleware(MiddlewareClass)` - Apply middleware to controller
+
+**Dependency Injection**:
+
+- `@Inject()` - Field-level dependency injection
+- `@SingletonProto({ accessLevel: AccessLevel.PUBLIC })` - Singleton service scope
+- `@ContextProto()` - Request-scoped service (e.g., `UserRoleManager`)
+
+**ORM Layer** (from `leoric`):
+
+- `@Model()` - Marks class as ORM model
+- `@Attribute(DataTypes.TYPE, options)` - Column definition
+- `@EntityProperty('nested.path')` - Maps model field to entity property
+
+**Lifecycle**:
+
+- `@LifecycleInit()` - Post-construction initialization hook
+
+## Key Development Patterns
+
+### Request Validation Trilogy
+
+Always validate requests in this exact order:
+
+1. **Parameter Validation** - Use `@eggjs/typebox-validate` for type-safe validation
+2. **Authentication** - Get authorized user with token role verification
+3. **Authorization** - Check resource-level permissions to prevent privilege escalation
+
+```typescript
+// Example controller method
+async someMethod(@HTTPQuery() params: QueryType) {
+  // 1. Params already validated by @HTTPQuery with typebox
+  // 2. Authenticate
+  const user = await this.userRoleManager.requiredAuthorizedUser(this.ctx, 'publish');
+  // 3. Authorize (if needed)
+  const { pkg } = await this.ensurePublishAccess(this.ctx, fullname);
+  // 4. Execute business logic
+  return await this.service.doSomething(params);
+}
+```
+
+### Repository Method Naming
+
+- `findSomething` - Query single entity
+- `saveSomething` - Create or update entity
+- `removeSomething` - Delete entity
+- `listSomethings` - Query multiple entities (plural)
+
+### Modifying Database Models
+
+When changing a Model, update all 3 locations:
+
+1. SQL migrations: `sql/mysql/*.sql` AND `sql/postgresql/*.sql`
+2. ORM Model: `app/repository/model/*.ts`
+3. Domain Entity: `app/core/entity/*.ts`
+
+## Code Style
+
+### Linting & Formatting
+
+- **Linter**: Oxlint (Rust-based, very fast) with type-aware checking
+- **Formatter**: Oxfmt (sole formatter, no Prettier)
+- **Pre-commit**: Husky + lint-staged runs both `oxfmt` and `oxlint --fix`
+
+Style rules:
+
+- Single quotes (`'`)
+- 2-space indentation
+- 120 character line width
+- ES5 trailing commas
+- Max 6 function parameters
+- No console statements (use logger)
+- Automatic import sorting (type imports first, then builtin, external, relative)
+
+### TypeScript
+
+- Strict TypeScript enabled
+- Avoid `any` types - use proper typing or `unknown`
+- ES modules (`import/export`) throughout
+- Comprehensive type definitions in all files
+
+### Testing
+
+- Test files use `.test.ts` suffix
+- Tests mirror source structure in `test/` directory
+- Use `@eggjs/mock` for mocking
+- Use `assert` from `node:assert/strict`
+- Test both success and error cases
+
+**Test Infrastructure**:
+
+- `test/.setup.ts` - Global beforeEach/afterEach hooks
+- `test/TestUtil.ts` - Comprehensive test utilities
+- `test/fixtures/` - Mock data and responses
+
+**Key TestUtil Methods**:
+
+- `TestUtil.createUser(options)` - Create test user with auth tokens
+- `TestUtil.createPackage(options)` - Create full package in system
+- `TestUtil.getFullPackage(options)` - Get mock package JSON
+- `TestUtil.truncateDatabase()` - Clear all tables between tests
+- `TestUtil.query(sql)` - Execute raw SQL (MySQL/PostgreSQL)
+- `TestUtil.getFixtures(name)` - Get path to shared fixture (read-only access)
+- `TestUtil.copyFixtures(name)` - Copy fixture to temp directory (when test needs to write)
+- `TestUtil.cleanupFixtures()` - Remove all temp directories created by `copyFixtures()`
+
+**Test Fixture Access**:
+
+- Use `getFixtures()` for read-only access (reading JSON, tarballs, etc.) — safe for parallel execution
+- Use `copyFixtures()` when the test will write to the fixture directory (e.g., `npm install` creating `node_modules`, writing `.npmrc`) — each test gets an isolated copy
+- Always call `cleanupFixtures()` in `after()` when using `copyFixtures()` to clean up temp directories
+- Never write files directly into `test/fixtures/` during test execution; always copy to a temp directory first
+
+**Mocking Patterns**:
+
+```typescript
+// Config mocking
+mock(app.config.cnpmcore, 'propertyName', newValue);
+
+// HTTP mocking
+app.mockHttpclient('https://example.com/path', 'GET', {
+  data: await TestUtil.readFixturesFile('fixture.json'),
+  persist: false,
+});
+
+// Log assertions
+app.mockLog();
+await someOperation();
+app.expectLog(/pattern/);
+```
+
+**Getting DI Objects in Tests**:
+
+```typescript
+const service = await app.getEggObject(PackageManagerService);
+```
+
+**Test Pattern**:
+
+```typescript
+describe('test/path/to/SourceFile.test.ts', () => {
+  describe('[HTTP_METHOD /api/path] functionName()', () => {
+    it('should handle expected behavior', async () => {
+      const res = await app
+        .httpRequest()
+        .put('/path')
+        .set('authorization', user.authorization)
+        .send(payload)
+        .expect(201);
+      assert.equal(res.body.success, true);
+    });
+  });
+});
+```
+
+**Scheduled Task Testing**:
+
+```typescript
+await app.runSchedule(SyncPackageWorkerPath);
+```
+
+## Project Structure
+
+```
+app/
+├── common/          # Global utilities and adapters
+│   ├── adapter/     # External service adapters
+│   └── enum/        # Shared enumerations
+├── core/            # Business logic layer
+│   ├── entity/      # Domain models
+│   ├── event/       # Event handlers
+│   ├── service/     # Business services
+│   └── util/        # Internal utilities
+├── port/            # Interface layer
+│   ├── controller/  # HTTP controllers
+│   ├── middleware/  # Middleware
+│   └── schedule/    # Background jobs
+├── repository/      # Data access layer
+│   └── model/       # ORM models
+└── infra/           # Infrastructure adapters
+
+config/              # Configuration files
+sql/                 # Database migrations
+  ├── mysql/         # MySQL migrations
+  └── postgresql/    # PostgreSQL migrations
+test/                # Test files (mirrors app/ structure)
+```
+
+## Important Configuration
+
+- `config/config.default.ts` - Main application configuration
+- `config/database.ts` - Database connection settings
+- `config/binaries.ts` - Binary package mirror configurations
+- `.env` - Environment-specific variables (copy from `.env.example`)
+- `tsconfig.json` - TypeScript settings (target: ES2021 for Leoric compatibility)
+
+## Development Workflow
+
+1. **Setup**: Copy `.env.example` to `.env`, start Docker services, initialize database
+2. **Feature Development**: Follow bottom-up approach (Model → Entity → Repository → Service → Controller)
+3. **Testing**: Write tests at appropriate layer, run individual tests for fast iteration
+4. **Validation**: Run linter, typecheck, relevant tests before committing
+5. **Commit**: Use semantic commit messages (feat/fix/docs/test/chore)
+
+## Integration as NPM Package
+
+cnpmcore can be integrated into Egg.js/Tegg applications as an NPM package, allowing enterprises to:
+
+- Customize infrastructure adapters (storage, auth, queue)
+- Override default behavior while receiving updates
+- Integrate with existing enterprise systems
+
+See INTEGRATE.md for detailed integration guide.
+
+## Performance Notes
+
+Typical command execution times:
+
+- Development server startup: ~20 seconds
+- TypeScript build: ~6 seconds
+- Full test suite: 4-15 minutes
+- Single test file: ~12 seconds
+- Linting: <1 second
+- Database initialization: <2 seconds
+
+## Prerequisites
+
+- Node.js: ^20.18.0 or ^22.18.0 or ^24.11.0
+- Database: MySQL 5.7+ or PostgreSQL 17+ (SQLite support in progress)
+- Cache: Redis 6+
+- Optional: Elasticsearch 8.x
+
+## Key Services & Controllers
+
+Core components to understand:
+
+- **PackageController**: Package CRUD operations
+- **PackageManagerService**: Core package management logic
+- **BinarySyncerService**: Binary package synchronization
+- **ChangesStreamService**: NPM registry change stream processing
+- **UserController**: User authentication and profiles

--- a/RFC-dependency-isolation.md
+++ b/RFC-dependency-isolation.md
@@ -1,0 +1,438 @@
+# RFC: 依赖隔离区（Dependency Buffer Zone）
+
+- **状态**：Draft
+- **作者**：@elrrrrrrr
+- **日期**：2026-04-28
+- **关联系统**：cnpmcore、neoVision、安全扫描、sofamq
+
+---
+
+## 1. 背景
+
+npmcore（基于 cnpmcore 的内部集成版本）从 `registry.npmmirror.com` 实时同步外部 npm 依赖：
+
+- **同步触发入口**（内部版本与开源 cnpmcore 有差异，以下为内部实际形态）
+  - **用户主动发起**：用户通过两条路径手动发起同步任务，最终都落到 `PUT /-/package/:fullname/syncs`（`PackageSyncController.createSyncTask`）
+    - `tnpm` 客户端：`tnpm sync <pkg>` 命令直连 registry
+    - 海兔资产中心前端：白屏点击「同步依赖」按钮，由前端调 registry 接口
+    - `DownloadRequestAdvice`（`app/npm/biz/DownloadRequestAdvice.ts`）拦截下载请求后只做 OSS 重定向 + 计数，**不会自动入队同步任务**
+  - **ChangesStream 主动监听**：`ChangesStreamWorker`（每 60s）拉上游 `_changes` 流，受 DRM 开关 `com.alipay.npmcore.ops.changeStreamWorkerSwitch` 控制
+  - **任务队列维护**：`TaskController` 提供 `PUT /api/admin/npm/task/:taskId/retry` 与 `POST /api/admin/npm/rebuildQueue`，仅用于运维侧重试/重建队列，不是新同步入口
+- **执行链路**：`SyncPackageWorker`（每 1s 轮询）→ cnpmcore 原生 `PackageSyncerService.executeTask`（内部版本未重写）→ 拉 manifest → 下 tarball → `packageManagerService.publish()` 落库 + 上传 NFS → **立即对所有用户可见**
+- **现有准入控制**
+  - `syncPackageBlockList`：包名级黑名单（事后兜底）
+  - `PackageBlock` / `blockPackageVersion()` / `blockPackage()`：版本/包级拉黑，已存在 `blockReason` 字段
+  - `allowScopes`：私有 scope 隔离同步
+- **安全侧现状（已落地，不重做）**
+  - 每个新同步的版本会触发安全扫描任务
+  - 拉黑消费者：`BlockPackage`（`app/npm_security/message/BlockPackage.ts`），订阅 sofamq topic `TP_TNPM_BAN`、group `GID_NPMCORE`，处理 `BLOCK` / `PASS` 事件
+  - 黑名单同步：`SyncPackageBlacklist`（`app/npm_security/schedule/SyncPackageBlacklist.ts`），定时事件 `EC_NPMCORE_SYNC_PACKAGE_BLACKLIST`，从 `bksupplysec.mybank.cn` 拉供应链安全黑名单
+
+## 2. 问题
+
+**核心问题：包从同步完成到对所有用户可见，没有缓冲。**
+
+- 业务方手动触发 `PUT /syncs` 后，任务出队、tarball 落库即对所有用户可见，安全扫描和 `TP_TNPM_BAN` 拉黑事件还没回报
+- 供应链攻击窗口 = "上游发布" → "业务方触发同步" → "落库可见" 之间的几十秒到几分钟
+- 现有 `syncPackageBlockList` / `blockPackageVersion()` / `bksupplysec` 黑名单都是 **事后兜底**，命中条件是"已知坏"，对 0day / 投毒攻击无效
+- 业务方对"哪个版本被拦了 / 为什么暂时不能用"没有可见的查询入口，定位靠经验
+
+## 3. 目标
+
+1. 引入 **依赖隔离区（缓冲区）**：包同步入库后默认进入 6h 静默期，对所有用户不可见
+2. 静默期内广播给现有订阅者：**安全扫描（现有）** + **neoVision H1 业务回归（新增）**，命中风险则升级为永久拉黑
+3. 提供 **逃逸通道**：包级 / scope 级白名单 + 白屏管理员审批
+4. **完全复用** 现有 block 表 + `TP_TNPM_BAN` topic，零 schema 变更，零新增 topic
+5. 业务方有 **只读查询接口**，能看到当前缓冲区里有哪些版本、为什么 block
+
+## 4. 非目标
+
+- 不改变同步触发逻辑（被动 / 主动入口照旧）
+- 不改 NFS 存储格式、不动 tarball 落地路径
+- 不重做现有安全扫描和 neoVision 内部实现
+- 不引入独立的 staging registry 集群，**在主 registry 上做状态机**
+
+## 5. 方案
+
+### 5.1 总体流程对比
+
+**旧流程**
+
+```
+拉 manifest → 下 tgz → publish → 全员可见
+                                    ↓ 异步
+                                  触发扫描
+```
+
+**新流程（端到端时序）**
+
+```
+ ┌──────────────┐   ┌──────────┐   ┌──────────────────┐   ┌─────────────┐   ┌──────────┐
+ │ tnpm 客户端  │   │ 海兔资产 │   │  registry 接口   │   │ npmcore     │   │ block 表 │
+ │              │   │  中心    │   │  PUT /syncs      │   │ Syncer+AOP  │   │          │
+ └──────┬───────┘   └─────┬────┘   └────────┬─────────┘   └──────┬──────┘   └────┬─────┘
+        │ tnpm sync       │                 │                    │               │
+        ├────────────────►│                 │                    │               │
+        │                 │ 点击「同步」    │                    │               │
+        │                 ├────────────────►│                    │               │
+        │                 │                 │  入队 SyncPackage  │               │
+        │                 │                 ├───────────────────►│               │
+        │                 │                 │                    │ publish + NFS │
+        │                 │                 │                    ├──────────────►│
+        │                 │                 │                    │ insert        │
+        │                 │                 │                    │ reason='[buffer] release at T+6h'
+        │                 │                 │                    │               │
+        │                 │                 │                    │ ① 广播 enter-buffer 消息
+        │                 │                 │                    ├──────┐        │
+        │                 │                 │                    │      ▼        │
+        │                 │                 │                    │  ┌─────────────────────┐
+        │                 │                 │                    │  │ TP_TNPM_BAN  topic  │
+        │                 │                 │                    │  │  (sofamq 广播)      │
+        │                 │                 │                    │  └──┬───────────┬──────┘
+        │                 │                 │                    │     │           │
+        │                 │                 │                    │  ②订阅       ②订阅
+        │                 │                 │                    │     ▼           ▼
+        │                 │                 │                    │ ┌────────┐ ┌──────────┐
+        │                 │                 │                    │ │ 安全   │ │ neoVision│
+        │                 │                 │                    │ │ 扫描   │ │  H1 回归 │
+        │                 │                 │                    │ └───┬────┘ └────┬─────┘
+        │                 │                 │                    │     │ 拉 tarball + 跑检测
+        │                 │                 │                    │     │           │
+        │                 │                 │                    │     │ 命中? ────┤
+        │                 │                 │                    │     │           │
+        │                 │                 │                    │     ▼           ▼
+        │                 │                 │                    │   ④ BLOCK 消息回投 TP_TNPM_BAN
+        │                 │                 │                    │           │
+        │                 │                 │                    │  BlockPackage 消费者
+        │                 │                 │                    │     ↓
+        │                 │                 │                    │  insert reason='[security] ...' / '[neovision] ...'
+        │                 │                 │                    │     │
+                                                                       ▼
+                                              ⑥ 永久拉黑：buffer + security/neovision 共存
+
+  ─── T+6h ───
+        │                 │                 │                    │
+        │                 │                 │  BufferReleaseQueue 触发
+        │                 │                 │                    │
+        │                 │                 │   listPackageVersionBlocks ?
+        │                 │                 │   ┌────────────────┴───────────────┐
+        │                 │                 │   ▼                                ▼
+        │                 │                 │  ⑤ 仅 [buffer] 记录             ⑥ 还有其他前缀
+        │                 │                 │   removePackageVersionBlock        do nothing
+        │                 │                 │   → 版本对外可用                   → 永久拉黑
+        │                 │                 │
+```
+
+**状态机（一个 block 记录的生命周期）**
+
+```
+                        ┌──────────────────────┐
+   sync 完成 ──────────►│  [buffer]  (6h 倒计时) │
+                        └────────┬─────────────┘
+                                 │
+                ┌────────────────┼─────────────────────────────┐
+                │                │                             │
+       ① 6h 到期 + 无其他    ② 期间被安全/                 ③ 命中白名单 /
+          block 记录            neoVision 加 [security]         管理员审批通过
+                │                / [neovision] 记录             ticket
+                ▼                ▼                              ▼
+          buffer 记录被     buffer 记录保留 +                 buffer 记录
+          自动 remove       新增永久拉黑记录                   被提前 remove
+                │                │                              │
+                ▼                ▼                              ▼
+            版本可用         版本永久不可用                    版本可用
+                            （只有管理员能解）
+```
+
+### 5.2 实现原理：复用 block 表，零结构变更
+
+**完全复用现有 `package_version_blocks` 表**，不新增表，不新增字段。现有字段：
+
+```
+id, gmt_create, gmt_modified, package_id, package_version_block_id, version, reason
+```
+
+**通过 `reason` 字段前缀约定区分记录来源**
+
+| 前缀 | 来源 | 是否可被自动解除 |
+|---|---|---|
+| `[buffer]` | 缓冲区记录，sync 落库时写入 | ✅ 6h 到期由解除队列删除 |
+| `[security]` | 安全扫描拉黑 | ❌ 仅管理员手动 |
+| `[neovision]` | neoVision 回归命中 | ❌ 仅管理员手动 |
+| `[bksupplysec]` | 供应链黑名单同步 | ❌ 仅管理员手动 |
+| 其他 / 无前缀 | 历史 manual 记录 | ❌ 仅管理员手动 |
+
+示例 `reason`：
+
+```
+[buffer] in dependency buffer zone, release at 2026-04-28T20:00:00Z
+[security] CVE-2024-XXXX detected by scan v3.2
+[neovision] H1 regression failed: payment flow timeout
+```
+
+**关键属性的"无字段"实现**
+
+| 概念 | 实现方式 |
+|---|---|
+| 记录类型 | `reason` 字段前缀，`LIKE '[buffer]%'` 查询 |
+| 进入时间 | 复用现有 `gmt_create` |
+| 是否可自动解除 | 由 `reason` 前缀推导，逻辑写在 service 层，不落库 |
+| 预计放出时间 | 写入 `reason` 字符串里（运维可读，机器也可解析），或由 `gmt_create + bufferDurationMs` 计算 |
+
+**默认行为**
+
+- `[buffer]` 记录：从 sync 落库瞬间写入，所有用户视角等同 blocked，**默认不可用**
+- 其他前缀记录：保留现状，永久 block，**只能管理员手动解除**
+- 多类型可叠加：一个版本可能同时存在 `[buffer]` + `[security]` 两条记录，任何一条存在都判定为不可用
+
+**解除逻辑（关键）**
+
+> 安全、neoVision 只具备拉黑能力，**不具备解除拦截能力**。解除只能由管理员或缓冲区到期机制处理。
+
+- `[buffer]` 记录：由 npmcore 内部新增的 `BufferReleaseQueue` 消费，6h 后尝试自动 `removePackageVersionBlock`（详见 5.3）
+- 其他前缀记录：管理员通过白屏审批后人工解除，没有自动通道
+- 一个版本要"对外可用"，必须**所有 block 记录都被移除**（即 `findPackageVersionBlock` 返回空 + 全包级 `*` 记录也不存在）
+
+### 5.3 入库逻辑 + 解除队列
+
+cnpmcore 原生 `PackageSyncerService` 在内部版本未被重写，建议在 npmcore 侧通过 AOP（参考现有 `DownloadRequestAdvice` 的拦截模式）切到 `executeTask()` 之后。
+
+**入库流程**
+
+1. cnpmcore 完成 `publish()`、tarball 上传 NFS（不动）
+2. AOP 后置切面：
+   - 检查白名单（5.5），命中则跳过整个缓冲流程
+   - 否则调用现有 `savePackageVersionBlock()`，写入 reason 形如 `[buffer] in dependency buffer zone, release at <ISO ts>`
+3. 触发安全扫描（payload 带 tarball NFS 地址，让扫描方少一跳）
+4. 触发 neoVision H1 回归任务
+
+**解除队列 `BufferReleaseQueue`（npmcore 新增）**
+
+- 入库时把 `{ fullname, version, releaseAt: gmt_create + bufferDurationMs }` 投递到内部延迟队列（基于现有 Redis）
+- 6h 后消费者拉起，按以下顺序判定（全部基于 `listPackageVersionBlocks(packageId)` + reason 前缀过滤）：
+  1. 该版本是否还存在 `reason LIKE '[buffer]%'` 的记录？不存在说明已被管理员手动放出，跳过
+  2. 该版本是否存在其他前缀的 block 记录？存在则**不删除 buffer 记录**，留给管理员处理
+  3. 都通过 → 调用现有 `removePackageVersionBlock(packageVersionBlockId)`，版本对外可用
+- 无论是否成功解除，都打 Tracer log（标记 `source=auto-release`），并推一条事件到海兔资产中心刷新前端列表
+- 队列消费失败重试 3 次；终态失败时人工介入
+
+**dist-tags 与 manifest 可见性**
+
+block 表本身就是版本可见性的真值源，缓冲区记录的过滤逻辑直接复用现有 `findPackageVersionBlock` / `listPackageVersionBlocks` 的拦截路径，不需要单独维护"隐藏 latest"逻辑：
+
+- 落 `[buffer]` 记录的版本 = 现有 block 拦截下载逻辑命中 = 客户端 install 报错 → 不会被选作 `latest`
+- manifest 接口对外返回 `versions` 字典时，过滤掉所有有 block 记录的版本（无论 reason 前缀）
+- 管理员视角接口（带 admin token）可见全量，便于审批操作
+
+### 5.4 缓冲期配置
+
+| 配置项 | 默认值 | 说明 |
+|---|---|---|
+| `bufferDurationMs` | `6 * 3600 * 1000` | 缓冲时长，6h（DRM 可热更） |
+| `bufferReleaseQueueKey` | `npmcore:buffer:release` | 解除队列 Redis key |
+| `bufferEscapeAllowList` | `[]` | 跳过缓冲的包/scope 白名单（详见 5.5） |
+
+> 没有 `requiredChecks` 概念 —— 安全/neoVision 不参与 release 决策，只能加 block，不能给 pass。"无安全 block + 6h 到期"即放行。
+
+### 5.5 逃逸通道（白名单 + 白屏审批）
+
+逃逸 = 跳过 6h 缓冲 / 提前解除 buffer 记录。两条独立通路：
+
+**逃逸路径 A：白名单（自动，不进缓冲区）**
+
+`bufferEscapeAllowList` 配置，支持三种粒度：
+
+```ts
+bufferEscapeAllowList: [
+  'lodash',           // 包名精确匹配
+  '@scope/*',         // scope 通配
+  '@scope/pkg',       // scope 下精确包
+]
+```
+
+AOP 后置切面命中白名单时**根本不写 buffer 记录**，等同立即可用。
+
+> 用途：底层基础库、生态深度信任的包。白名单变更走 PR 评审 + DRM 推送。
+
+**逃逸路径 B：白屏审批（人工提前解除）**
+
+走海兔资产中心前端，**复用 `npm_security` 现有的 `Ticket` 实体**，新增一种 ticket 类型 `buffer_escape`，payload 里带 `{ fullname, version, reason }`：
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `POST` | `/-/buffer/escape` | 业务方提交申请，落一条 `buffer_escape` ticket |
+| `GET` | `/-/buffer/escape` | 申请人 / 管理员列表查询（走现有 ticket 列表接口） |
+| `PUT` | `/-/buffer/escape/:id/approve` | 管理员审批通过 → 删除该版本的 buffer 记录 |
+| `PUT` | `/-/buffer/escape/:id/reject` | 管理员驳回 |
+
+审批通过仅删除 `blockType=buffer` 记录，**不影响其他类型 block**（如 security 已经拉黑则申请通过也不解封，需要走 security 类的另一个解封流程）。
+
+### 5.6 安全扫描 / neoVision 如何消费缓冲区版本
+
+**核心原则**：安全和 neoVision 只能写"加 block 记录"，不能写"删 block 记录"。它们消费缓冲区版本的方式是：
+
+1. **拿到待扫描版本**：通过两条途径
+   - **被动推送**（推荐）：AOP 入库时，除了写 buffer 记录，同时投递扫描任务到现有链路，payload 带 tarball NFS 地址
+   - **主动拉取**（兜底）：扫描方可调 `GET /-/buffer/list?status=pending`，拿到当前缓冲区里所有版本，自行调度
+2. **下载 tarball**：直接走 NFS 地址 / `registry.antgroup-inc.cn` tarball URL，**不受 buffer 记录影响**（tarball 文件本身可达，只是 manifest/version 对外不可见）
+3. **回报结果**：
+   - 命中风险 → 通过 `TP_TNPM_BAN` 投递 `BLOCK` 事件，`BlockPackage` 消费者写一条 `blockType: 'security'` 或 `'neovision'` 的记录（与 buffer 记录共存）
+   - 未命中 → **什么都不做**，6h 到期由 `BufferReleaseQueue` 自动放行
+4. **撤回拉黑能力**：安全/neoVision 不开放 unblock 通道，要解除 security/neovision 类记录只能管理员白屏操作
+
+**链路改动**
+
+- `BlockPackage` 消费者扩展：按消息 `source` 字段拼 reason 前缀（`[security]` / `[neovision]` / `[bksupplysec]`），仍然走 `savePackageVersionBlock()`
+- 扫描方需要能直接读 tarball，提供 `GET /-/buffer/list` 列表接口供拉取扫描清单（按 `reason LIKE '[buffer]%'` 过滤）
+- 既有 `blockPackageVersion()` / `removePackageVersionBlock()` / reason 字段直接复用，零结构变更
+
+### 5.7 neoVision H1 业务回归（新增）
+
+- 同步完成后通过 `TP_TNPM_BAN` 广播 enter-buffer 事件，neoVision 订阅消费
+- 回归用 `npm overrides` 把指定包指向待验证版本，跑 H1 主路径
+- **只能投 BLOCK，不能投 PASS**：不参与 release 决策，命中即升级为永久拉黑，未命中默默不动作
+- 不是所有包都能跑回归（工具链、纯 build-time 依赖、纯类型包），由 neoVision 自行判定"豁免回归"，cnpmcore 不感知
+
+### 5.8 消息契约（复用 `TP_TNPM_BAN`）
+
+> 仅定接口语义，具体 schema 后续技术评审补。
+
+- **完全复用** 现有 sofamq topic `TP_TNPM_BAN`（group `GID_NPMCORE`），不另起新 topic
+- 事件类型扩展为三种：
+  - `ENTER_BUFFER`（新增）：npmcore 作为生产者，广播某 version 进入缓冲区，订阅方（安全 / neoVision）拉起检测
+  - `BLOCK`（既有）：任意生产者上报命中风险，`BlockPackage` 消费者按消息 `source` 字段拼 reason 前缀（`[security]` / `[neovision]` / `[bksupplysec]`），写一条 block 记录
+  - `UNBLOCK`（既有）：保留语义，仅管理员/系统使用
+- payload 增加 `source` 字段（`npmcore-buffer` / `security-scan` / `neovision-h1` / `bksupplysec` / `manual`），用于 reason 前缀拼接
+- `SyncPackageBlacklist` 的 `bksupplysec` 黑名单同步保留独立调度，落地时也通过 `TP_TNPM_BAN` 转发，下游只需关心一个 topic
+
+### 5.9 缓冲区可见性接口
+
+为业务方排查 install 失败、为安全/neoVision 拉取待扫描清单提供入口：
+
+| 方法 | 路径 | 用途 | 受众 |
+|---|---|---|---|
+| `GET` | `/-/buffer/list?fullname=xxx` | 查询某包当前在缓冲的版本，附 enterAt、剩余时长 | 业务方只读 |
+| `GET` | `/-/buffer/list?status=pending` | 全量缓冲版本列表（分页） | 安全/neoVision 拉取 |
+| `GET` | `/-/buffer/version/:fullname/:version` | 单版本详情，含全部 block 记录类型 | 业务方 + 管理员 |
+
+业务方 install 失败时拿到的报错附带：
+
+```
+Package <name>@<version> is currently in dependency buffer zone.
+See https://<registry>/-/buffer/list?fullname=<name>
+```
+
+> **可见性约束**：业务方接口仅返回包名 / 版本 / 进入时间 / 剩余时长，不暴露具体扫描结果（避免帮攻击者反推绕过策略）。安全/neoVision 拉取接口需要鉴权 token。
+
+## 6. 数据模型变更
+
+**核心思路：零 schema 变更。** 不新增表、不新增字段、不新增索引。所有语义通过现有字段的约定承载。
+
+### 6.1 `package_version_blocks` 表（现有，零变更）
+
+现有字段：`id` / `gmt_create` / `gmt_modified` / `package_id` / `package_version_block_id` / `version` / `reason`
+
+| 概念 | 复用方式 |
+|---|---|
+| 缓冲区 / 安全 / neoVision / 黑名单 / 手动 类型 | `reason` 前缀 `[buffer]` / `[security]` / `[neovision]` / `[bksupplysec]` / `[manual]` |
+| 进入缓冲时间 | `gmt_create` |
+| 预计放出时间 | `gmt_create + config.bufferDurationMs`（运行时计算）+ reason 字符串里冗余一份给运维肉眼读 |
+| 是否可被自动解除 | reason 前缀 = `[buffer]` 即可，逻辑写在 service 层 |
+| 多记录共存判定不可用 | 现有 `findPackageVersionBlock` / `listPackageVersionBlocks` 不变 |
+
+> 历史记录无需 backfill：现有 reason 没有方括号前缀，会被识别为 `manual` 类，行为与现状一致。
+
+### 6.2 不新增任何表 / 任何字段
+
+- **审批工单**：复用 `npm_security` 现有的 `Ticket` 表，新增一种 ticket 类型枚举值 `buffer_escape`，payload 里带 `fullname` / `version` / `reason`
+- **审计**：block 表本身的 insert/delete 即审计入口（带 `gmt_create` / `gmt_modified`），删除前后打 Tracer log 标记来源（`source=auto-release` / `source=admin` / `source=ticket-approve`）
+- **解除队列**：基于现有 Redis（`RedisQueueAdapter`），不落 DB
+- **rebuild 兜底**：服务重启不影响正确性 —— 即便延迟队列丢消息，也可以由扫表任务（每 5min 扫一次 `reason LIKE '[buffer]%' AND gmt_create < now() - bufferDurationMs`）补齐
+
+
+## 7. 兼容性 & 迁移
+
+- **零 schema 变更**，无需任何 ALTER TABLE / 新表迁移
+- 历史 block 记录无前缀，service 层识别为 `manual` 类，行为与现状一致
+- 新同步进来的包从上线开始写 `[buffer]` 记录
+- **灰度策略**
+  - 阶段 1：开 1h 缓冲，仅观察解除队列消费延迟、消息链路稳定性、扫描方接入情况
+  - 阶段 2：升到 6h，开放白屏审批工单通道
+  - 阶段 3：开放 `bufferEscapeAllowList` 白名单 + 接入 neoVision H1 订阅
+
+## 8. 失败模式与风险
+
+| 风险 | 缓解 |
+|---|---|
+| 6h 缓冲太长导致业务投诉无法 install 新版本 | 白名单 + 白屏审批兜底；业务方可查询接口预知放出时间 |
+| Redis 解除队列丢消息，version 永远卡 `[buffer]` | 定时扫表兜底（`reason LIKE '[buffer]%' AND gmt_create < now() - bufferDurationMs`），每 5min 补一次 |
+| 扫描 / 回归任务积压，6h 内未跑完 | 不阻塞 release（安全/neoVision 不参与放行决策）；扫描方未及时 BLOCK 是它们自己的 SLA 问题，不是 cnpmcore 的 |
+| 多集群（参见 prod_multi_cluster：sync 与 consumer 分集群、Redis 不共享） | block 表 DB 共享，扫表兜底天然跨集群一致；解除队列只需保证至少一个集群能消费即可（`removePackageVersionBlock` 幂等） |
+| 攻击者通过白屏审批通道绕过 | 申请必须实名 + 审批人不能等于申请人 + ticket 表本身是审计源 |
+| 缓冲列表暴露给外部反推绕过窗口 | 业务方接口仅返回包名 / 版本 / 进入时间 / 剩余时长，不暴露扫描细节；安全/neoVision 拉清单接口需 token 鉴权 |
+
+## 9. 推进计划
+
+| 阶段 | 内容 | 负责方 |
+|---|---|---|
+| P0 | AOP 切入 `executeTask` 后置 + 写 `[buffer]` 记录 + Redis 解除队列 + 扫表兜底 | npmcore |
+| P1 | 缓冲区只读列表接口 + install 报错带链接 + manifest 过滤 block 版本 | npmcore |
+| P2 | `bufferEscapeAllowList` 白名单（DRM 配置）+ 白屏审批 ticket（复用 `Ticket` 表） | npmcore + 海兔资产中心 |
+| P3 | `TP_TNPM_BAN` 扩展 `ENTER_BUFFER` 事件 + neoVision H1 订阅接入 | npmcore + neoVision + 安全 |
+| P4 | `bksupplysec` 改走 `TP_TNPM_BAN` 转发，下游统一 topic | npmcore + 安全 |
+
+## 10. 常见问题（FAQ）
+
+### Q1：依赖如何解封 / 逃逸？
+
+按 block 记录的 `reason` 前缀区分，没有"统一解封"通道：
+
+| reason 前缀 | 解封方式 |
+|---|---|
+| `[buffer]` | ① 6h 到期，`BufferReleaseQueue` 自动 `removePackageVersionBlock`；② 命中 `bufferEscapeAllowList` 白名单，**入库时根本不写**；③ 业务方走海兔资产中心提 `buffer_escape` ticket，管理员审批通过 |
+| `[security]` / `[neovision]` / `[bksupplysec]` | **只能管理员白屏手动解除**，没有自动通道、没有时效。安全和 neoVision 仅有"加 block"权限，无"删 block"权限 |
+| 其他（无前缀，等同 manual） | 管理员加的、管理员删 |
+
+一个版本要恢复可用 = 该版本下**所有** block 记录都被删除（`listPackageVersionBlocks` 返回空）。
+
+### Q2：安全 / neoVision 如何消费缓冲区版本？
+
+两条获取途径：
+
+1. **被动推送**（推荐）：AOP 入库后置切面投递扫描任务，payload 带 tarball NFS 地址 → 扫描方直接用
+2. **主动拉取**（兜底）：`GET /-/buffer/list?status=pending`（鉴权 token）→ 拉到全量待扫描清单，自行调度
+
+回报方式：
+
+- 命中风险 → 走现有 `TP_TNPM_BAN` 投递 `BLOCK` 事件，`BlockPackage` 消费者按 `source` 字段拼 reason 前缀（`[security] ...` 或 `[neovision] ...`），与 `[buffer]` 记录共存
+- 未命中 → **什么都不做**，6h 到期由解除队列自动放行
+
+> 关键：tarball 文件本身在 NFS 上始终可达，buffer 记录只挡 manifest/version 的对外可见性，不挡扫描方下载。
+
+### Q3：如何自动触发解除隔离？
+
+依赖 npmcore 内部新增的 `BufferReleaseQueue`：
+
+1. **入队**：AOP 后置切面写完 buffer 记录后，往 Redis 延迟队列投 `{ fullname, version, releaseAt: now() + bufferDurationMs }`
+2. **触发**：到 `releaseAt` 时间点，消费者拉起任务
+3. **判定逻辑**（全部基于 `listPackageVersionBlocks` + reason 前缀过滤，无 schema 依赖）：
+   - 该版本是否还存在 `reason LIKE '[buffer]%'` 记录？不在说明已被管理员手动放出，跳过
+   - 该版本是否还有其他前缀的 block 记录？有 → 不解除 buffer 记录（或者说就算解了 buffer，版本仍被其他记录 block，效果一样），留给管理员处理
+   - 都通过 → 调用 `removePackageVersionBlock(packageVersionBlockId)`，版本对外可用
+4. **审计**：调用前后打 Tracer log，标记 `source=auto-release`
+5. **失败重试**：消费失败重试 3 次（间隔 1min/5min/30min），终态失败告警人工介入
+6. **幂等**：删除时按 `reason LIKE '[buffer]%'` 过滤，重复消费无副作用
+7. **兜底**：定时扫表任务（每 5min）补漏 —— `SELECT * WHERE reason LIKE '[buffer]%' AND gmt_create < now() - bufferDurationMs`，防止 Redis 队列丢消息
+
+> 解除队列**不感知**安全 / neoVision 的扫描状态，它只负责到期尝试删 buffer 记录。其他类型 block 是否存在，是它判定"是否需要解"的输入，不是"是否能解"的依赖。
+
+## 11. 待讨论
+
+1. **H1 回归豁免规则**：由 neoVision 自己判定还是 cnpmcore 提供包元数据辅助（如 `keywords` 含 `types-only`）？
+2. **缓冲列表可见性边界**：业务方可见最小信息是什么？是否要按 token / scope 分层（让其他 BU 看不到本 BU 在测什么版本）？
+3. **多集群下解除一致性**：DB 共享但 Redis 不共享，定时扫表兜底是各集群各跑（依赖 `removePackageVersionBlock` 幂等）还是抢锁 leader 跑？
+4. **`bufferEscapeAllowList` 配置位置**：DRM 还是 DB 表？DRM 热更但缺评审，DB 表灵活但又违背"零新表"原则（可考虑塞到 npm_security 现有 Whitelist 表）
+5. **改动落点**：新增逻辑放 npmcore 内部仓（AOP 拦截覆盖 cnpmcore 行为）还是回流开源 cnpmcore？前者快但只服务内部
+6. **`TP_TNPM_BAN` 扩展 `ENTER_BUFFER` 事件**：对现有外部消费者是否破坏向后兼容？是否需要 schema 版本号或新建子 topic
+7. **manifest 过滤性能**：每次 GET manifest 都查 block 表 → 是否需要 cache？block 记录变化时的失效策略
+

--- a/app/core/entity/PackageVersionBlock.ts
+++ b/app/core/entity/PackageVersionBlock.ts
@@ -1,11 +1,16 @@
 import { Entity, EntityData } from './Entity';
 import { EasyData, EntityUtil } from '../util/EntityUtil';
 
+// dependency isolation buffer record (auto-releasable). null type = permanent block.
+export const PACKAGE_VERSION_BLOCK_TYPE_BUFFER = 'buffer';
+
 interface PackageVersionBlockData extends EntityData {
   packageVersionBlockId: string;
   packageId: string;
   version: string;
   reason: string;
+  type?: string | null;
+  expiredAt?: Date | null;
 }
 
 export class PackageVersionBlock extends Entity {
@@ -13,6 +18,8 @@ export class PackageVersionBlock extends Entity {
   packageId: string;
   version: string;
   reason: string;
+  type: string | null;
+  expiredAt: Date | null;
 
   constructor(data: PackageVersionBlockData) {
     super(data);
@@ -20,6 +27,12 @@ export class PackageVersionBlock extends Entity {
     this.packageId = data.packageId;
     this.version = data.version;
     this.reason = data.reason;
+    this.type = data.type ?? null;
+    this.expiredAt = data.expiredAt ?? null;
+  }
+
+  get isBuffer(): boolean {
+    return this.type === PACKAGE_VERSION_BLOCK_TYPE_BUFFER;
   }
 
   static create(data: EasyData<PackageVersionBlockData, 'packageVersionBlockId'>): PackageVersionBlock {

--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -277,36 +277,39 @@ export class PackageManagerService extends AbstractService {
       }
       throw e;
     }
-    // dependency isolation (buffer) zone: hold a newly synced version invisible for a
-    // while before it is auto-released. Write the buffer block record BEFORE the manifest
-    // refresh (so it is excluded) and suppress PACKAGE_VERSION_ADDED — the event (and thus
-    // search index / changes stream / file sync) fires only when the version is released.
-    // see RFC: https://github.com/cnpm/cnpmcore/issues/1057
-    const isolated = await this._tryIsolateNewVersion(pkg, cmd, pkgVersion.version);
+    // dependency isolation (buffer) zone: hold a newly synced version invisible for a while
+    // before it is auto-released. Decide first (pure), so PACKAGE_VERSION_ADDED is suppressed
+    // — the event (and thus search index / changes stream / file sync) fires only when the
+    // version is released. see RFC: https://github.com/cnpm/cnpmcore/issues/1057
+    const shouldIsolate = this._shouldIsolateNewVersion(pkg, cmd);
 
-    // skip the per-version refresh for an isolated version (it would be filtered out anyway);
-    // the version enters the manifest only when released. non-isolated path is unchanged.
-    if (!isolated && cmd.skipRefreshPackageManifests !== true) {
+    if (cmd.skipRefreshPackageManifests !== true) {
       await this.refreshPackageChangeVersionsToDists(pkg, [ pkgVersion.version ]);
     }
     if (cmd.tags) {
       for (const tag of cmd.tags) {
         await this.savePackageTag(pkg, tag, cmd.version, true);
-        if (!isolated) {
+        if (!shouldIsolate) {
           this.eventBus.emit(PACKAGE_VERSION_ADDED, pkg.fullname, pkgVersion.version, tag);
         }
       }
-    } else if (!isolated) {
+    } else if (!shouldIsolate) {
       this.eventBus.emit(PACKAGE_VERSION_ADDED, pkg.fullname, pkgVersion.version, undefined);
+    }
+
+    // isolate AFTER the normal publish flow has built manifestsDist + tags (identical to a
+    // non-isolated publish up to here), then hide the version. Doing it here — rather than
+    // before the refresh — avoids the new-package case where the only version is isolated and
+    // manifestsDist is never created (which crashes savePackageTag).
+    if (shouldIsolate) {
+      await this._isolateNewVersion(pkg, cmd, pkgVersion.version);
     }
 
     return pkgVersion;
   }
 
-  // Decide whether a newly published/synced version should enter the dependency isolation
-  // buffer; if so, persist a buffer block record (type='buffer', expiredAt) directly.
-  // Returns true when the version was isolated (caller must suppress PACKAGE_VERSION_ADDED).
-  private async _tryIsolateNewVersion(pkg: Package, cmd: PublishPackageCmd, version: string): Promise<boolean> {
+  // Decide whether a newly published/synced version should enter the dependency isolation buffer.
+  private _shouldIsolateNewVersion(pkg: Package, cmd: PublishPackageCmd): boolean {
     const config = this.config.cnpmcore;
     if (!config.enableDependencyIsolation) return false;
     // buffer enforcement reuses version-level block; without it the version can't be hidden
@@ -317,7 +320,12 @@ export class PackageManagerService extends AbstractService {
     if (cmd.isPrivate) return false;
     // allowlist: trusted packages skip the buffer (analogous to pnpm minimumReleaseAgeExclude)
     if (this._isDependencyIsolationExcluded(pkg.fullname)) return false;
+    return true;
+  }
 
+  // Persist a buffer block record (type='buffer', expiredAt) and hide the version from the manifest.
+  private async _isolateNewVersion(pkg: Package, cmd: PublishPackageCmd, version: string): Promise<void> {
+    const duration = this.config.cnpmcore.dependencyIsolationDuration as number;
     const expiredAt = new Date(Date.now() + duration);
     const block = PackageVersionBlock.create({
       packageId: pkg.packageId,
@@ -327,9 +335,13 @@ export class PackageManagerService extends AbstractService {
       expiredAt,
     });
     await this.packageVersionBlockRepository.savePackageVersionBlock(block);
+    // hide it now for the user-publish path (manifestsDist already built above). the sync path
+    // (skipRefreshPackageManifests) leaves it to the batch refresh, which is block-aware.
+    if (cmd.skipRefreshPackageManifests !== true) {
+      await this._refreshPackageManifestsToDists(pkg);
+    }
     this.logger.info('[packageManagerService.isolateNewVersion] packageId: %s, version: %s, release at: %s',
       pkg.packageId, version, expiredAt.toISOString());
-    return true;
   }
 
   // Match `dependencyIsolationExclude` rules: exact name (`lodash`, `@scope/pkg`) or scope wildcard (`@scope/*`)

--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -496,6 +496,38 @@ export class PackageManagerService extends AbstractService {
     return { changed: true };
   }
 
+  /**
+   * Dependency isolation: release expired buffer versions of a single package in one batch.
+   * Only records still of type='buffer' are released (a record overwritten to a permanent
+   * block is left alone). The package manifest is rebuilt once for the whole batch (the
+   * rebuild is O(versions) regardless of how many are released), then PACKAGE_VERSION_ADDED
+   * is emitted per released version so search / changes stream / file sync pick them up.
+   * Idempotent: already-removed / no-longer-buffer versions are skipped.
+   */
+  async releaseBufferedVersions(packageId: string, versions: string[]): Promise<string[]> {
+    const pkg = await this.packageRepository.findPackageByPackageId(packageId);
+    if (!pkg) return [];
+    const released: string[] = [];
+    for (const version of versions) {
+      const block = await this.packageVersionBlockRepository.findPackageVersionBlockExact(packageId, version);
+      if (block && block.isBuffer) {
+        await this.packageVersionBlockRepository.removePackageVersionBlock(block.packageVersionBlockId);
+        released.push(version);
+      }
+    }
+    if (released.length === 0) return [];
+    // rebuild the package manifest once for the whole batch (restores released versions + dist-tags)
+    await this._refreshPackageManifestsToDists(pkg);
+    this.eventBus.emit(PACKAGE_UNBLOCKED, pkg.fullname);
+    for (const version of released) {
+      // the version becomes visible now -> emit the deferred PACKAGE_VERSION_ADDED
+      this.eventBus.emit(PACKAGE_VERSION_ADDED, pkg.fullname, version, undefined);
+    }
+    this.logger.info('[packageManagerService.releaseBufferedVersions:success] packageId: %s, released: %j',
+      packageId, released);
+    return released;
+  }
+
 
   async replacePackageMaintainersAndDist(pkg: Package, maintainers: User[]) {
     await this.packageRepository.replacePackageMaintainers(pkg.packageId, maintainers.map(m => m.userId));

--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -284,7 +284,9 @@ export class PackageManagerService extends AbstractService {
     // see RFC: https://github.com/cnpm/cnpmcore/issues/1057
     const isolated = await this._tryIsolateNewVersion(pkg, cmd, pkgVersion.version);
 
-    if (cmd.skipRefreshPackageManifests !== true) {
+    // skip the per-version refresh for an isolated version (it would be filtered out anyway);
+    // the version enters the manifest only when released. non-isolated path is unchanged.
+    if (!isolated && cmd.skipRefreshPackageManifests !== true) {
       await this.refreshPackageChangeVersionsToDists(pkg, [ pkgVersion.version ]);
     }
     if (cmd.tags) {
@@ -833,7 +835,25 @@ export class PackageManagerService extends AbstractService {
     }
 
     if (updateVersions) {
+      // blocked versions (incl. dependency-isolation buffer) must stay out of the manifest.
+      // this incremental path adds versions directly, so it must filter the same way the
+      // full rebuild (_listPackageFullManifests) does — otherwise an isolated/blocked version
+      // would leak into the dist on publish/sync refresh.
+      let blockedVersionSet: Set<string> | undefined;
+      if (this.config.cnpmcore.enableBlockPackageVersion) {
+        const blockedVersions = await this.packageVersionBlockRepository.listBlockedVersions(pkg.packageId);
+        if (blockedVersions.length > 0) {
+          blockedVersionSet = new Set(blockedVersions.map(v => v.version));
+        }
+      }
       for (const version of updateVersions) {
+        if (blockedVersionSet?.has(version)) {
+          // keep hidden; also drop it if a previous dist happened to contain it (e.g. re-sync of a blocked version)
+          delete fullManifests.versions[version];
+          if (fullManifests.time) delete fullManifests.time[version];
+          delete abbreviatedManifests.versions[version];
+          continue;
+        }
         const packageVersion = await this.packageRepository.findPackageVersion(pkg.packageId, version);
         if (packageVersion) {
           const manifest = await this.distRepository.readDistBytesToJSON<PackageJSONType>(packageVersion.manifestDist);

--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -27,7 +27,7 @@ import { DistRepository } from '../../repository/DistRepository';
 import { isDuplicateKeyError } from '../../repository/util/ErrorUtil';
 import { Package } from '../entity/Package';
 import { PackageVersion } from '../entity/PackageVersion';
-import { PackageVersionBlock } from '../entity/PackageVersionBlock';
+import { PackageVersionBlock, PACKAGE_VERSION_BLOCK_TYPE_BUFFER } from '../entity/PackageVersionBlock';
 import { PackageTag } from '../entity/PackageTag';
 import { User } from '../entity/User';
 import { Dist } from '../entity/Dist';
@@ -277,19 +277,69 @@ export class PackageManagerService extends AbstractService {
       }
       throw e;
     }
+    // dependency isolation (buffer) zone: hold a newly synced version invisible for a
+    // while before it is auto-released. Write the buffer block record BEFORE the manifest
+    // refresh (so it is excluded) and suppress PACKAGE_VERSION_ADDED — the event (and thus
+    // search index / changes stream / file sync) fires only when the version is released.
+    // see RFC: https://github.com/cnpm/cnpmcore/issues/1057
+    const isolated = await this._tryIsolateNewVersion(pkg, cmd, pkgVersion.version);
+
     if (cmd.skipRefreshPackageManifests !== true) {
       await this.refreshPackageChangeVersionsToDists(pkg, [ pkgVersion.version ]);
     }
     if (cmd.tags) {
       for (const tag of cmd.tags) {
         await this.savePackageTag(pkg, tag, cmd.version, true);
-        this.eventBus.emit(PACKAGE_VERSION_ADDED, pkg.fullname, pkgVersion.version, tag);
+        if (!isolated) {
+          this.eventBus.emit(PACKAGE_VERSION_ADDED, pkg.fullname, pkgVersion.version, tag);
+        }
       }
-    } else {
+    } else if (!isolated) {
       this.eventBus.emit(PACKAGE_VERSION_ADDED, pkg.fullname, pkgVersion.version, undefined);
     }
 
     return pkgVersion;
+  }
+
+  // Decide whether a newly published/synced version should enter the dependency isolation
+  // buffer; if so, persist a buffer block record (type='buffer', expiredAt) directly.
+  // Returns true when the version was isolated (caller must suppress PACKAGE_VERSION_ADDED).
+  private async _tryIsolateNewVersion(pkg: Package, cmd: PublishPackageCmd, version: string): Promise<boolean> {
+    const config = this.config.cnpmcore;
+    if (!config.enableDependencyIsolation) return false;
+    // buffer enforcement reuses version-level block; without it the version can't be hidden
+    if (!config.enableBlockPackageVersion) return false;
+    const duration = config.dependencyIsolationDuration;
+    if (!duration || duration <= 0) return false;
+    // only isolate external/synced (public) versions, never user-published private packages
+    if (cmd.isPrivate) return false;
+    // allowlist: trusted packages skip the buffer (analogous to pnpm minimumReleaseAgeExclude)
+    if (this._isDependencyIsolationExcluded(pkg.fullname)) return false;
+
+    const expiredAt = new Date(Date.now() + duration);
+    const block = PackageVersionBlock.create({
+      packageId: pkg.packageId,
+      version,
+      reason: `[buffer] in dependency isolation zone, release at ${expiredAt.toISOString()}`,
+      type: PACKAGE_VERSION_BLOCK_TYPE_BUFFER,
+      expiredAt,
+    });
+    await this.packageVersionBlockRepository.savePackageVersionBlock(block);
+    this.logger.info('[packageManagerService.isolateNewVersion] packageId: %s, version: %s, release at: %s',
+      pkg.packageId, version, expiredAt.toISOString());
+    return true;
+  }
+
+  // Match `dependencyIsolationExclude` rules: exact name (`lodash`, `@scope/pkg`) or scope wildcard (`@scope/*`)
+  private _isDependencyIsolationExcluded(fullname: string): boolean {
+    const list = this.config.cnpmcore.dependencyIsolationExclude;
+    if (!list || list.length === 0) return false;
+    const [ scope ] = getScopeAndName(fullname);
+    return list.some(rule => {
+      if (rule === fullname) return true;
+      if (rule.endsWith('/*')) return scope !== '' && scope === rule.slice(0, -2);
+      return false;
+    });
   }
 
   async blockPackageByFullname(name: string, reason: string) {

--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -381,6 +381,9 @@ export class PackageManagerService extends AbstractService {
     let block = await this.packageVersionBlockRepository.findPackageVersionBlockExact(pkg.packageId, version);
     if (block) {
       block.reason = reason;
+      // a permanent block always overrides a dependency-isolation buffer record
+      block.type = null;
+      block.expiredAt = null;
     } else {
       block = PackageVersionBlock.create({
         packageId: pkg.packageId,
@@ -417,6 +420,30 @@ export class PackageManagerService extends AbstractService {
     this.eventBus.emit(PACKAGE_UNBLOCKED, pkg.fullname);
     this.logger.info('[packageManagerService.unblockPackageVersion:success] packageId: %s, version: %s',
       pkg.packageId, version);
+  }
+
+  /**
+   * Idempotently set whether a package version is available (visible) to the outside.
+   * Thin wrapper over block/unblockPackageVersion, used by external decision sources
+   * (e.g. a deployment's security scan) to permanently block a version that is currently
+   * in the dependency-isolation buffer — the buffer record is overwritten to a permanent
+   * block (type=null) and will no longer be auto-released.
+   * `available=false` always produces a permanent block; the buffer entry path writes
+   * buffer records directly (see ensureNewVersionIsolated).
+   */
+  async ensurePackageVersionAvailability(pkg: Package, version: string, available: boolean, reason?: string): Promise<{ changed: boolean }> {
+    const existing = await this.packageVersionBlockRepository.findPackageVersionBlockExact(pkg.packageId, version);
+    if (available) {
+      if (!existing) return { changed: false };
+      await this.unblockPackageVersion(pkg, version);
+      return { changed: true };
+    }
+    // make unavailable (permanent block)
+    if (existing && !existing.isBuffer && existing.reason === (reason ?? '')) {
+      return { changed: false };
+    }
+    await this.blockPackageVersion(pkg, version, reason ?? '');
+    return { changed: true };
   }
 
 

--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -531,25 +531,50 @@ export class PackageManagerService extends AbstractService {
   async releaseBufferedVersions(packageId: string, versions: string[]): Promise<string[]> {
     const pkg = await this.packageRepository.findPackageByPackageId(packageId);
     if (!pkg) return [];
-    const released: string[] = [];
+    const released: { version: string; reason: string; expiredAt: Date | null }[] = [];
     for (const version of versions) {
       const block = await this.packageVersionBlockRepository.findPackageVersionBlockExact(packageId, version);
-      if (block && block.isBuffer) {
-        await this.packageVersionBlockRepository.removePackageVersionBlock(block.packageVersionBlockId);
-        released.push(version);
+      if (!block || !block.isBuffer) continue;
+      // atomically remove only while it is still a buffer row: a concurrent permanent block
+      // (ensurePackageVersionAvailability(false) / blockPackageVersion sets type=null) must win
+      // this race and keep the version hidden.
+      const removed = await this.packageVersionBlockRepository.removeBufferBlock(block.packageVersionBlockId);
+      if (!removed) continue;
+      // only emit a publish event for a version that still exists; an orphan buffer row left by
+      // an unpublished version is cleaned up above without a phantom PACKAGE_VERSION_ADDED.
+      const pkgVersion = await this.packageRepository.findPackageVersion(packageId, version);
+      if (pkgVersion) {
+        released.push({ version, reason: block.reason, expiredAt: block.expiredAt });
       }
     }
     if (released.length === 0) return [];
-    // rebuild the package manifest once for the whole batch (restores released versions + dist-tags)
-    await this._refreshPackageManifestsToDists(pkg);
-    this.eventBus.emit(PACKAGE_UNBLOCKED, pkg.fullname);
-    for (const version of released) {
-      // the version becomes visible now -> emit the deferred PACKAGE_VERSION_ADDED
-      this.eventBus.emit(PACKAGE_VERSION_ADDED, pkg.fullname, version, undefined);
+    try {
+      // rebuild the package manifest once for the whole batch (restores released versions + dist-tags)
+      await this._refreshPackageManifestsToDists(pkg);
+    } catch (err) {
+      // the manifest rebuild (NFS write) is the only non-transactional step. if it fails after the
+      // buffer rows were removed, re-create them so the dispatcher re-enqueues and retries — keeping
+      // DB rows as the release source-of-truth instead of leaving the version permanently stale.
+      for (const r of released) {
+        await this.packageVersionBlockRepository.savePackageVersionBlock(PackageVersionBlock.create({
+          packageId,
+          version: r.version,
+          reason: r.reason,
+          type: PACKAGE_VERSION_BLOCK_TYPE_BUFFER,
+          expiredAt: r.expiredAt ?? new Date(0),
+        }));
+      }
+      throw err;
     }
+    // emit only after a successful refresh, so a failed rebuild never produces phantom events
+    this.eventBus.emit(PACKAGE_UNBLOCKED, pkg.fullname);
+    for (const r of released) {
+      this.eventBus.emit(PACKAGE_VERSION_ADDED, pkg.fullname, r.version, undefined);
+    }
+    const releasedVersions = released.map(r => r.version);
     this.logger.info('[packageManagerService.releaseBufferedVersions:success] packageId: %s, released: %j',
-      packageId, released);
-    return released;
+      packageId, releasedVersions);
+    return releasedVersions;
   }
 
 

--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -482,23 +482,33 @@ export class PackageManagerService extends AbstractService {
     await this._refreshPackageManifestsToDists(pkg);
 
     this.eventBus.emit(PACKAGE_UNBLOCKED, pkg.fullname);
+    if (block) {
+      // the version becomes visible again -> emit PACKAGE_VERSION_ADDED so consumers that only
+      // listen to it (changes stream / store-manifest / unpkg file sync) pick it up. Needed
+      // because an isolated version's PACKAGE_VERSION_ADDED was suppressed at publish; if it was
+      // permanently blocked and is now unblocked, this is the first time the event fires for it.
+      this.eventBus.emit(PACKAGE_VERSION_ADDED, pkg.fullname, version, undefined);
+    }
     this.logger.info('[packageManagerService.unblockPackageVersion:success] packageId: %s, version: %s',
       pkg.packageId, version);
   }
 
   /**
-   * Idempotently set whether a package version is available (visible) to the outside.
-   * Thin wrapper over block/unblockPackageVersion, used by external decision sources
-   * (e.g. a deployment's security scan) to permanently block a version that is currently
-   * in the dependency-isolation buffer — the buffer record is overwritten to a permanent
-   * block (type=null) and will no longer be auto-released.
-   * `available=false` always produces a permanent block; the buffer entry path writes
-   * buffer records directly (see ensureNewVersionIsolated).
+   * Idempotently set whether a package version is available (visible) to the outside, for
+   * external decision sources (e.g. a deployment's security scan).
+   * - available=false: permanently block; if the version is currently in the dependency-isolation
+   *   buffer, the buffer record is overwritten to a permanent block (type=null, no auto-release).
+   * - available=true: only lifts a PERMANENT block. It deliberately does NOT release a buffer
+   *   record — automated "make available" must not let a version escape the isolation window
+   *   ahead of its timer. Buffer release is owned by the timer (releaseBufferedVersions); an
+   *   admin can still force-release via unblockPackageVersion (the explicit escape channel).
    */
   async ensurePackageVersionAvailability(pkg: Package, version: string, available: boolean, reason?: string): Promise<{ changed: boolean }> {
     const existing = await this.packageVersionBlockRepository.findPackageVersionBlockExact(pkg.packageId, version);
     if (available) {
       if (!existing) return { changed: false };
+      // never spring a buffered version out of isolation here (no automated escape)
+      if (existing.isBuffer) return { changed: false };
       await this.unblockPackageVersion(pkg, version);
       return { changed: true };
     }

--- a/app/port/config.ts
+++ b/app/port/config.ts
@@ -186,6 +186,30 @@ export type CnpmcoreConfig = {
   enableBlockPackageVersion?: boolean,
 
   /**
+   * enable dependency isolation (buffer) zone
+   * when enabled, a newly synced version is held invisible for `dependencyIsolationDuration`
+   * before being auto-released, giving deployments a window to run out-of-band validation.
+   * requires `enableBlockPackageVersion`. default is false (behavior identical to today).
+   * see RFC: https://github.com/cnpm/cnpmcore/issues/1057
+   */
+  enableDependencyIsolation?: boolean,
+
+  /**
+   * dependency isolation buffer duration in milliseconds, analogous to pnpm `minimumReleaseAge`.
+   * a synced version stays invisible until `gmt_create + dependencyIsolationDuration`.
+   * default is 6 hours. only effective when `enableDependencyIsolation` is true.
+   */
+  dependencyIsolationDuration?: number,
+
+  /**
+   * dependency isolation allowlist, analogous to pnpm `minimumReleaseAgeExclude`.
+   * matched packages skip the buffer zone (released immediately).
+   * supports exact package name and scope wildcard, e.g. `lodash`, `@scope/*`, `@scope/pkg`.
+   * default is empty.
+   */
+  dependencyIsolationExclude?: string[],
+
+  /**
    * database config
    */
   database: {

--- a/app/port/schedule/BufferReleaseDispatcher.ts
+++ b/app/port/schedule/BufferReleaseDispatcher.ts
@@ -1,4 +1,4 @@
-import { EggAppConfig, EggLogger } from 'egg';
+import { EggLogger } from 'egg';
 import { IntervalParams, Schedule, ScheduleType } from '@eggjs/tegg/schedule';
 import { Inject } from '@eggjs/tegg';
 import { QueueAdapter } from '../../common/typing';
@@ -32,13 +32,12 @@ export class BufferReleaseDispatcher {
   private readonly cacheAdapter: CacheAdapter;
 
   @Inject()
-  private readonly config: EggAppConfig;
-
-  @Inject()
   private readonly logger: EggLogger;
 
   async subscribe() {
-    if (!this.config.cnpmcore.enableDependencyIsolation) return;
+    // intentionally NOT gated on enableDependencyIsolation: the flag only gates *new* isolation
+    // decisions at publish; existing buffer rows must still be drained/released even after the
+    // flag is turned off (e.g. rollback), otherwise those versions stay blocked forever.
     // lock TTL is kept comfortably larger than the schedule interval (60s) so a slow scan/enqueue
     // run cannot let the lock expire mid-run and a parallel node re-scan + double-enqueue.
     await this.cacheAdapter.usingLock('BufferReleaseDispatcher', 120, async () => {

--- a/app/port/schedule/BufferReleaseDispatcher.ts
+++ b/app/port/schedule/BufferReleaseDispatcher.ts
@@ -1,0 +1,59 @@
+import { EggAppConfig, EggLogger } from 'egg';
+import { IntervalParams, Schedule, ScheduleType } from '@eggjs/tegg/schedule';
+import { Inject } from '@eggjs/tegg';
+import { QueueAdapter } from '../../common/typing';
+import { CacheAdapter } from '../../common/adapter/CacheAdapter';
+import { PackageVersionBlockRepository } from '../../repository/PackageVersionBlockRepository';
+
+// dependency isolation release work queue: https://github.com/cnpm/cnpmcore/issues/1057
+export const DEPENDENCY_ISOLATION_RELEASE_QUEUE = 'dependency_isolation_release';
+
+// Dispatcher: lightweight single-instance scan of expired buffer records, grouped by
+// package and pushed to the release queue. The heavy unblock work is done by
+// BufferReleaseWorker (ScheduleType.ALL) so it is distributed across the cluster.
+// The DB rows are the source of truth — a dropped queue message is re-enqueued on the
+// next run, and the batch release is idempotent.
+@Schedule<IntervalParams>({
+  type: ScheduleType.WORKER,
+  scheduleData: {
+    interval: 60000,
+  },
+}, {
+  immediate: process.env.NODE_ENV !== 'test',
+})
+export class BufferReleaseDispatcher {
+  @Inject()
+  private readonly packageVersionBlockRepository: PackageVersionBlockRepository;
+
+  @Inject()
+  private readonly queueAdapter: QueueAdapter;
+
+  @Inject()
+  private readonly cacheAdapter: CacheAdapter;
+
+  @Inject()
+  private readonly config: EggAppConfig;
+
+  @Inject()
+  private readonly logger: EggLogger;
+
+  async subscribe() {
+    if (!this.config.cnpmcore.enableDependencyIsolation) return;
+    await this.cacheAdapter.usingLock('BufferReleaseDispatcher', 60, async () => {
+      const expiredBlocks = await this.packageVersionBlockRepository.findExpiredBufferedVersions(1000);
+      if (expiredBlocks.length === 0) return;
+      // group by package so the worker rebuilds each package's manifest only once
+      const versionsByPackageId = new Map<string, string[]>();
+      for (const block of expiredBlocks) {
+        const versions = versionsByPackageId.get(block.packageId) ?? [];
+        versions.push(block.version);
+        versionsByPackageId.set(block.packageId, versions);
+      }
+      for (const [ packageId, versions ] of versionsByPackageId) {
+        await this.queueAdapter.push(DEPENDENCY_ISOLATION_RELEASE_QUEUE, { packageId, versions });
+      }
+      this.logger.info('[BufferReleaseDispatcher:subscribe] enqueued %d packages, %d versions',
+        versionsByPackageId.size, expiredBlocks.length);
+    });
+  }
+}

--- a/app/port/schedule/BufferReleaseDispatcher.ts
+++ b/app/port/schedule/BufferReleaseDispatcher.ts
@@ -41,7 +41,8 @@ export class BufferReleaseDispatcher {
     // lock TTL is kept comfortably larger than the schedule interval (60s) so a slow scan/enqueue
     // run cannot let the lock expire mid-run and a parallel node re-scan + double-enqueue.
     await this.cacheAdapter.usingLock('BufferReleaseDispatcher', 120, async () => {
-      const expiredBlocks = await this.packageVersionBlockRepository.findExpiredBufferedVersions(1000);
+      // per-cycle batch cap: bounds backlog catch-up / re-enqueue churn (indexed query, cheap)
+      const expiredBlocks = await this.packageVersionBlockRepository.findExpiredBufferedVersions(500);
       if (expiredBlocks.length === 0) return;
       // group by package so the worker rebuilds each package's manifest only once
       const versionsByPackageId = new Map<string, string[]>();

--- a/app/port/schedule/BufferReleaseDispatcher.ts
+++ b/app/port/schedule/BufferReleaseDispatcher.ts
@@ -39,7 +39,9 @@ export class BufferReleaseDispatcher {
 
   async subscribe() {
     if (!this.config.cnpmcore.enableDependencyIsolation) return;
-    await this.cacheAdapter.usingLock('BufferReleaseDispatcher', 60, async () => {
+    // lock TTL is kept comfortably larger than the schedule interval (60s) so a slow scan/enqueue
+    // run cannot let the lock expire mid-run and a parallel node re-scan + double-enqueue.
+    await this.cacheAdapter.usingLock('BufferReleaseDispatcher', 120, async () => {
       const expiredBlocks = await this.packageVersionBlockRepository.findExpiredBufferedVersions(1000);
       if (expiredBlocks.length === 0) return;
       // group by package so the worker rebuilds each package's manifest only once

--- a/app/port/schedule/BufferReleaseWorker.ts
+++ b/app/port/schedule/BufferReleaseWorker.ts
@@ -1,4 +1,4 @@
-import { EggAppConfig, EggLogger } from 'egg';
+import { EggLogger } from 'egg';
 import { IntervalParams, Schedule, ScheduleType } from '@eggjs/tegg/schedule';
 import { Inject } from '@eggjs/tegg';
 import { QueueAdapter } from '../../common/typing';
@@ -33,13 +33,12 @@ export class BufferReleaseWorker {
   private readonly packageManagerService: PackageManagerService;
 
   @Inject()
-  private readonly config: EggAppConfig;
-
-  @Inject()
   private readonly logger: EggLogger;
 
   async subscribe() {
-    if (!this.config.cnpmcore.enableDependencyIsolation) return;
+    // intentionally NOT gated on enableDependencyIsolation: must keep draining/releasing buffer
+    // rows enqueued before the flag was turned off. when no rows are buffered the queue is empty,
+    // so this is a cheap no-op pop.
     // skip this tick if a previous drain on this node is still running
     if (executing) return;
     executing = true;

--- a/app/port/schedule/BufferReleaseWorker.ts
+++ b/app/port/schedule/BufferReleaseWorker.ts
@@ -10,6 +10,11 @@ interface ReleaseJob {
   versions: string[];
 }
 
+// re-entrancy guard: each release job does a full manifest rebuild + storage write, which can
+// exceed the 1s interval; without this the scheduler would run overlapping drains on the same
+// node (same pattern as SyncPackageWorker / TriggerHookWorker).
+let executing = false;
+
 // Worker: runs on every node (ScheduleType.ALL) and pops release jobs enqueued by
 // BufferReleaseDispatcher, then performs the heavy per-package batch unblock. The queue
 // pop is atomic, so each job is handled by a single node and the unblock load (manifest
@@ -35,14 +40,21 @@ export class BufferReleaseWorker {
 
   async subscribe() {
     if (!this.config.cnpmcore.enableDependencyIsolation) return;
-    let job = await this.queueAdapter.pop<ReleaseJob>(DEPENDENCY_ISOLATION_RELEASE_QUEUE);
-    while (job) {
-      try {
-        await this.packageManagerService.releaseBufferedVersions(job.packageId, job.versions);
-      } catch (err) {
-        this.logger.error('[BufferReleaseWorker:subscribe] release packageId: %s failed: %s', job.packageId, err);
+    // skip this tick if a previous drain on this node is still running
+    if (executing) return;
+    executing = true;
+    try {
+      let job = await this.queueAdapter.pop<ReleaseJob>(DEPENDENCY_ISOLATION_RELEASE_QUEUE);
+      while (job) {
+        try {
+          await this.packageManagerService.releaseBufferedVersions(job.packageId, job.versions);
+        } catch (err) {
+          this.logger.error('[BufferReleaseWorker:subscribe] release packageId: %s failed: %s', job.packageId, err);
+        }
+        job = await this.queueAdapter.pop<ReleaseJob>(DEPENDENCY_ISOLATION_RELEASE_QUEUE);
       }
-      job = await this.queueAdapter.pop<ReleaseJob>(DEPENDENCY_ISOLATION_RELEASE_QUEUE);
+    } finally {
+      executing = false;
     }
   }
 }

--- a/app/port/schedule/BufferReleaseWorker.ts
+++ b/app/port/schedule/BufferReleaseWorker.ts
@@ -1,0 +1,48 @@
+import { EggAppConfig, EggLogger } from 'egg';
+import { IntervalParams, Schedule, ScheduleType } from '@eggjs/tegg/schedule';
+import { Inject } from '@eggjs/tegg';
+import { QueueAdapter } from '../../common/typing';
+import { PackageManagerService } from '../../core/service/PackageManagerService';
+import { DEPENDENCY_ISOLATION_RELEASE_QUEUE } from './BufferReleaseDispatcher';
+
+interface ReleaseJob {
+  packageId: string;
+  versions: string[];
+}
+
+// Worker: runs on every node (ScheduleType.ALL) and pops release jobs enqueued by
+// BufferReleaseDispatcher, then performs the heavy per-package batch unblock. The queue
+// pop is atomic, so each job is handled by a single node and the unblock load (manifest
+// rebuild + storage write) is distributed across the cluster — same model as SyncPackageWorker.
+@Schedule<IntervalParams>({
+  type: ScheduleType.ALL,
+  scheduleData: {
+    interval: 1000,
+  },
+})
+export class BufferReleaseWorker {
+  @Inject()
+  private readonly queueAdapter: QueueAdapter;
+
+  @Inject()
+  private readonly packageManagerService: PackageManagerService;
+
+  @Inject()
+  private readonly config: EggAppConfig;
+
+  @Inject()
+  private readonly logger: EggLogger;
+
+  async subscribe() {
+    if (!this.config.cnpmcore.enableDependencyIsolation) return;
+    let job = await this.queueAdapter.pop<ReleaseJob>(DEPENDENCY_ISOLATION_RELEASE_QUEUE);
+    while (job) {
+      try {
+        await this.packageManagerService.releaseBufferedVersions(job.packageId, job.versions);
+      } catch (err) {
+        this.logger.error('[BufferReleaseWorker:subscribe] release packageId: %s failed: %s', job.packageId, err);
+      }
+      job = await this.queueAdapter.pop<ReleaseJob>(DEPENDENCY_ISOLATION_RELEASE_QUEUE);
+    }
+  }
+}

--- a/app/repository/PackageVersionBlockRepository.ts
+++ b/app/repository/PackageVersionBlockRepository.ts
@@ -43,6 +43,17 @@ export class PackageVersionBlockRepository extends AbstractRepository {
       removeCount, packageVersionBlockId);
   }
 
+  // Atomically remove a row only while it is still a buffer record (type='buffer'). A concurrent
+  // permanent block sets type=null, so this single conditional delete won't clobber it. Returns
+  // true only when a buffer row was actually removed.
+  async removeBufferBlock(packageVersionBlockId: string): Promise<boolean> {
+    const removeCount = await this.PackageVersionBlock.remove({
+      packageVersionBlockId,
+      type: PACKAGE_VERSION_BLOCK_TYPE_BUFFER,
+    });
+    return removeCount > 0;
+  }
+
   // Dependency isolation: list buffer records whose hold has expired (ready to release).
   // Indexed by (type, expired_at); ordered oldest-first so the most overdue release first.
   async findExpiredBufferedVersions(limit: number) {

--- a/app/repository/PackageVersionBlockRepository.ts
+++ b/app/repository/PackageVersionBlockRepository.ts
@@ -1,7 +1,7 @@
 import { AccessLevel, SingletonProto, Inject } from '@eggjs/tegg';
 import { ModelConvertor } from './util/ModelConvertor';
 import type { PackageVersionBlock as PackageVersionBlockModel } from './model/PackageVersionBlock';
-import { PackageVersionBlock as PackageVersionBlockEntity } from '../core/entity/PackageVersionBlock';
+import { PackageVersionBlock as PackageVersionBlockEntity, PACKAGE_VERSION_BLOCK_TYPE_BUFFER } from '../core/entity/PackageVersionBlock';
 import { AbstractRepository } from './AbstractRepository';
 
 @SingletonProto({
@@ -41,6 +41,16 @@ export class PackageVersionBlockRepository extends AbstractRepository {
     const removeCount = await this.PackageVersionBlock.remove({ packageVersionBlockId });
     this.logger.info('[PackageVersionBlockRepository:removePackageVersionBlock:remove] %d rows, packageVersionBlockId: %s',
       removeCount, packageVersionBlockId);
+  }
+
+  // Dependency isolation: list buffer records whose hold has expired (ready to release).
+  // Indexed by (type, expired_at); ordered oldest-first so the most overdue release first.
+  async findExpiredBufferedVersions(limit: number) {
+    const models = await this.PackageVersionBlock.find({
+      type: PACKAGE_VERSION_BLOCK_TYPE_BUFFER,
+      expiredAt: { $lte: new Date() },
+    }).order('expiredAt', 'asc').limit(limit);
+    return models.map(model => ModelConvertor.convertModelToEntity(model, PackageVersionBlockEntity));
   }
 
   // Find a specific version block (not '*')

--- a/app/repository/model/PackageVersionBlock.ts
+++ b/app/repository/model/PackageVersionBlock.ts
@@ -28,4 +28,13 @@ export class PackageVersionBlock extends Bone {
 
   @Attribute(DataTypes.TEXT(LENGTH_VARIANTS.long))
   reason: string;
+
+  // dependency isolation: 'buffer' = isolation buffer record (auto-releasable),
+  // null = permanent block (existing semantics: security / manual / blacklist)
+  @Attribute(DataTypes.STRING(16), { allowNull: true })
+  type: string | null;
+
+  // dependency isolation: buffer expiration time; auto-released after this when type='buffer'
+  @Attribute(DataTypes.DATE, { allowNull: true })
+  expiredAt: Date | null;
 }

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -63,6 +63,9 @@ export const cnpmcoreConfig: CnpmcoreConfig = {
   strictValidateTarballPkg: false,
   strictValidatePackageDeps: false,
   enableBlockPackageVersion: env('CNPMCORE_CONFIG_ENABLE_BLOCK_PACKAGE_VERSION', 'boolean', false),
+  enableDependencyIsolation: env('CNPMCORE_CONFIG_ENABLE_DEPENDENCY_ISOLATION', 'boolean', false),
+  dependencyIsolationDuration: 6 * 3600 * 1000,
+  dependencyIsolationExclude: [],
   database: {
     type: database.type,
   },

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -64,7 +64,7 @@ export const cnpmcoreConfig: CnpmcoreConfig = {
   strictValidatePackageDeps: false,
   enableBlockPackageVersion: env('CNPMCORE_CONFIG_ENABLE_BLOCK_PACKAGE_VERSION', 'boolean', false),
   enableDependencyIsolation: env('CNPMCORE_CONFIG_ENABLE_DEPENDENCY_ISOLATION', 'boolean', false),
-  dependencyIsolationDuration: 6 * 3600 * 1000,
+  dependencyIsolationDuration: env('CNPMCORE_CONFIG_DEPENDENCY_ISOLATION_DURATION', 'number', 6 * 3600 * 1000),
   dependencyIsolationExclude: [],
   database: {
     type: database.type,

--- a/sql/ddl_mysql.sql
+++ b/sql/ddl_mysql.sql
@@ -140,9 +140,12 @@ CREATE TABLE `package_version_blocks` (
   `package_id` varchar(24) COLLATE utf8_unicode_ci NOT NULL COMMENT 'package id',
   `version` varchar(256) COLLATE utf8_unicode_ci NOT NULL COMMENT 'package version, "*" meaning all versions',
   `reason` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'block reason',
+  `type` varchar(16) COLLATE utf8_unicode_ci NULL COMMENT 'block type: buffer = dependency isolation (auto-releasable), null = permanent',
+  `expired_at` datetime(3) NULL COMMENT 'dependency isolation buffer expiration time',
   PRIMARY KEY (`id`),
   UNIQUE KEY `uk_package_version_block_id` (`package_version_block_id`),
-  UNIQUE KEY `uk_name_version` (`package_id`,`version`)
+  UNIQUE KEY `uk_name_version` (`package_id`,`version`),
+  KEY `idx_type_expired_at` (`type`,`expired_at`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci COMMENT='blocklist package versions'
 ;
 

--- a/sql/ddl_postgresql.sql
+++ b/sql/ddl_postgresql.sql
@@ -218,11 +218,14 @@ CREATE TABLE package_version_blocks (
   package_version_block_id varchar(24) NOT NULL,
   package_id varchar(24) NOT NULL,
   version varchar(256) NOT NULL,
-  reason text NOT NULL
+  reason text NOT NULL,
+  type varchar(16) DEFAULT NULL,
+  expired_at timestamp(3) DEFAULT NULL
 );
 
 CREATE UNIQUE INDEX package_version_blocks_uk_package_version_block_id ON package_version_blocks (package_version_block_id);
 CREATE UNIQUE INDEX package_version_blocks_uk_name_version ON package_version_blocks (package_id, version);
+CREATE INDEX package_version_blocks_idx_type_expired_at ON package_version_blocks (type, expired_at);
 
 COMMENT ON TABLE package_version_blocks IS 'blocklist package versions';
 COMMENT ON COLUMN package_version_blocks.id IS 'primary key';
@@ -232,6 +235,8 @@ COMMENT ON COLUMN package_version_blocks.package_version_block_id IS 'package ve
 COMMENT ON COLUMN package_version_blocks.package_id IS 'package id';
 COMMENT ON COLUMN package_version_blocks.version IS 'package version, "*" meaning all versions';
 COMMENT ON COLUMN package_version_blocks.reason IS 'block reason';
+COMMENT ON COLUMN package_version_blocks.type IS 'block type: buffer = dependency isolation (auto-releasable), null = permanent';
+COMMENT ON COLUMN package_version_blocks.expired_at IS 'dependency isolation buffer expiration time';
 
 
 CREATE TABLE package_version_downloads (

--- a/sql/mysql/3.83.0.sql
+++ b/sql/mysql/3.83.0.sql
@@ -1,0 +1,5 @@
+-- dependency isolation (buffer) zone: https://github.com/cnpm/cnpmcore/issues/1057
+ALTER TABLE `package_version_blocks`
+  ADD COLUMN `type` varchar(16) NULL COMMENT 'block type: buffer = dependency isolation (auto-releasable), null = permanent' AFTER `reason`,
+  ADD COLUMN `expired_at` datetime(3) NULL COMMENT 'dependency isolation buffer expiration time' AFTER `type`,
+  ADD KEY `idx_type_expired_at` (`type`, `expired_at`);

--- a/sql/postgresql/3.83.0.sql
+++ b/sql/postgresql/3.83.0.sql
@@ -1,0 +1,6 @@
+-- dependency isolation (buffer) zone: https://github.com/cnpm/cnpmcore/issues/1057
+ALTER TABLE package_version_blocks ADD COLUMN type varchar(16) DEFAULT NULL;
+ALTER TABLE package_version_blocks ADD COLUMN expired_at timestamp(3) DEFAULT NULL;
+COMMENT ON COLUMN package_version_blocks.type IS 'block type: buffer = dependency isolation (auto-releasable), null = permanent';
+COMMENT ON COLUMN package_version_blocks.expired_at IS 'dependency isolation buffer expiration time';
+CREATE INDEX package_version_blocks_idx_type_expired_at ON package_version_blocks (type, expired_at);

--- a/test-resolve.cjs
+++ b/test-resolve.cjs
@@ -1,0 +1,24 @@
+require('ts-node/register');
+require('tsconfig-paths/register');
+
+const { importResolve } = require('@eggjs/utils');
+const path = require('path');
+
+console.log('--- Test 1: importResolve absolute .js path (file is .ts) ---');
+const target = path.join(__dirname, 'app/port/schedule/SavePackageVersionDownloadCounter.js');
+console.log('Target:', target);
+console.log('Exists?', require('fs').existsSync(target));
+try {
+  const r = importResolve(target);
+  console.log('OK:', r);
+} catch (e) {
+  console.log('FAIL:', e.constructor.name, '-', e.message.split('\n')[0]);
+}
+
+console.log('\n--- Test 2: require.resolve same path ---');
+try {
+  const r = require.resolve(target);
+  console.log('OK:', r);
+} catch (e) {
+  console.log('FAIL:', e.constructor.name, '-', e.message.split('\n')[0]);
+}

--- a/test/core/service/PackageManagerService/dependencyIsolation.test.ts
+++ b/test/core/service/PackageManagerService/dependencyIsolation.test.ts
@@ -152,6 +152,40 @@ describe('test/core/service/PackageManagerService/dependencyIsolation.test.ts', 
       const { packageId } = await publishVersion('foo', '1.0.0', true);
       assert.deepEqual(await packageManagerService.releaseBufferedVersions(packageId, [ '9.9.9' ]), []);
     });
+
+    it('should re-create buffer rows and emit nothing when the manifest rebuild fails', async () => {
+      const { packageId } = await publishVersion('foo', '1.0.0', false); // isolated
+      const emitted: string[] = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mock((packageManagerService as any).eventBus, 'emit', (name: string) => { emitted.push(name); });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mock(PackageManagerService.prototype as any, '_refreshPackageManifestsToDists', async () => { throw new Error('nfs down'); });
+
+      await assert.rejects(packageManagerService.releaseBufferedVersions(packageId, [ '1.0.0' ]), /nfs down/);
+      // no phantom publish event on failure
+      assert(!emitted.includes('PACKAGE_VERSION_ADDED'));
+      // buffer row re-created so the dispatcher can retry (DB stays the release source-of-truth)
+      const block = await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0');
+      assert(block?.isBuffer);
+    });
+
+    it('should clean an orphan buffer row without a publish event when the version was removed', async () => {
+      const { packageId } = await publishVersion('foo', '1.0.0', false); // isolated
+      // simulate the version being unpublished while still buffered (orphan buffer row left behind)
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { PackageVersion: PackageVersionModel } = require('../../../../app/repository/model/PackageVersion');
+      await PackageVersionModel.remove({ packageId, version: '1.0.0' });
+
+      const emitted: string[] = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mock((packageManagerService as any).eventBus, 'emit', (name: string) => { emitted.push(name); });
+      const released = await packageManagerService.releaseBufferedVersions(packageId, [ '1.0.0' ]);
+
+      assert.deepEqual(released, []);
+      assert(!emitted.includes('PACKAGE_VERSION_ADDED'));
+      // orphan buffer row cleaned up
+      assert.equal(await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0'), null);
+    });
   });
 
   describe('findExpiredBufferedVersions (C5)', () => {

--- a/test/core/service/PackageManagerService/dependencyIsolation.test.ts
+++ b/test/core/service/PackageManagerService/dependencyIsolation.test.ts
@@ -186,6 +186,25 @@ describe('test/core/service/PackageManagerService/dependencyIsolation.test.ts', 
       assert.deepEqual(await packageManagerService.ensurePackageVersionAvailability(pkg, '1.0.0', true), { changed: false });
     });
 
+    it('should NOT release a buffered version (no automated escape from isolation)', async () => {
+      const { packageId } = await publishVersion('foo', '1.0.0', false); // public -> isolated
+      const pkg = await packageRepository.findPackageByPackageId(packageId);
+      assert(pkg);
+      // sanity: it is buffered + hidden
+      assert((await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0'))?.isBuffer);
+
+      // an automated "make available" must NOT spring it out of the buffer
+      const res = await packageManagerService.ensurePackageVersionAvailability(pkg, '1.0.0', true);
+      assert.deepEqual(res, { changed: false });
+      assert((await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0'))?.isBuffer);
+      assert.equal((await packageManagerService.listPackageFullManifests('', 'foo')).data?.versions['1.0.0'], undefined);
+
+      // but an admin force-unblock (the explicit escape channel) still releases it
+      await packageManagerService.unblockPackageVersion(pkg, '1.0.0');
+      assert.equal(await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0'), null);
+      assert((await packageManagerService.listPackageFullManifests('', 'foo')).data?.versions['1.0.0']);
+    });
+
     it('should block then unblock idempotently', async () => {
       const { packageId } = await publishVersion('foo', '1.0.0', true);
       const pkg = await packageRepository.findPackageByPackageId(packageId);
@@ -211,6 +230,37 @@ describe('test/core/service/PackageManagerService/dependencyIsolation.test.ts', 
       // incremental refresh (as run by sync batch / re-publish) must not re-add the blocked version
       await packageManagerService.refreshPackageChangeVersionsToDists(pkg, [ '1.0.0' ]);
       assert.equal((await packageManagerService.listPackageFullManifests('', 'foo')).data?.versions['1.0.0'], undefined);
+    });
+  });
+
+  describe('unblockPackageVersion event (re-emit on admission)', () => {
+    it('should emit PACKAGE_VERSION_ADDED when a blocked version becomes visible again', async () => {
+      const { packageId } = await publishVersion('foo', '1.0.0', true);
+      const pkg = await packageRepository.findPackageByPackageId(packageId);
+      assert(pkg);
+      await packageManagerService.blockPackageVersion(pkg, '1.0.0', 'bad');
+
+      const emitted: string[] = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mock((packageManagerService as any).eventBus, 'emit', (name: string) => { emitted.push(name); });
+      await packageManagerService.unblockPackageVersion(pkg, '1.0.0');
+
+      // version becomes visible again -> consumers that only listen to PACKAGE_VERSION_ADDED must be notified
+      assert(emitted.includes('PACKAGE_VERSION_ADDED'));
+      assert(emitted.includes('PACKAGE_UNBLOCKED'));
+    });
+
+    it('should NOT emit PACKAGE_VERSION_ADDED when there was no block to remove', async () => {
+      const { packageId } = await publishVersion('foo', '1.0.0', true);
+      const pkg = await packageRepository.findPackageByPackageId(packageId);
+      assert(pkg);
+
+      const emitted: string[] = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mock((packageManagerService as any).eventBus, 'emit', (name: string) => { emitted.push(name); });
+      await packageManagerService.unblockPackageVersion(pkg, '1.0.0');
+
+      assert(!emitted.includes('PACKAGE_VERSION_ADDED'));
     });
   });
 });

--- a/test/core/service/PackageManagerService/dependencyIsolation.test.ts
+++ b/test/core/service/PackageManagerService/dependencyIsolation.test.ts
@@ -1,0 +1,216 @@
+import { strict as assert } from 'node:assert';
+import { app, mock } from 'egg-mock/bootstrap';
+import { TestUtil } from '../../../../test/TestUtil';
+import { PackageManagerService } from '../../../../app/core/service/PackageManagerService';
+import { PackageRepository } from '../../../../app/repository/PackageRepository';
+import { PackageVersionBlockRepository } from '../../../../app/repository/PackageVersionBlockRepository';
+import { PackageVersionBlock, PACKAGE_VERSION_BLOCK_TYPE_BUFFER } from '../../../../app/core/entity/PackageVersionBlock';
+import { UserService } from '../../../../app/core/service/UserService';
+import { getScopeAndName } from '../../../../app/common/PackageUtil';
+
+describe('test/core/service/PackageManagerService/dependencyIsolation.test.ts', () => {
+  let packageManagerService: PackageManagerService;
+  let packageRepository: PackageRepository;
+  let packageVersionBlockRepository: PackageVersionBlockRepository;
+  let userService: UserService;
+  let publisher;
+
+  beforeEach(async () => {
+    packageManagerService = await app.getEggObject(PackageManagerService);
+    packageRepository = await app.getEggObject(PackageRepository);
+    packageVersionBlockRepository = await app.getEggObject(PackageVersionBlockRepository);
+    userService = await app.getEggObject(UserService);
+    const { user } = await userService.create({
+      name: 'test-user',
+      password: 'this-is-password',
+      email: 'hello@example.com',
+      ip: '127.0.0.1',
+    });
+    publisher = user;
+    // version-level block enforcement + isolation enabled
+    mock(app.config.cnpmcore, 'enableBlockPackageVersion', true);
+    mock(app.config.cnpmcore, 'enableDependencyIsolation', true);
+    mock(app.config.cnpmcore, 'dependencyIsolationDuration', 6 * 3600 * 1000);
+    mock(app.config.cnpmcore, 'dependencyIsolationExclude', []);
+  });
+
+  afterEach(async () => {
+    mock.restore();
+    await TestUtil.truncateDatabase();
+  });
+
+  async function publishVersion(name: string, version: string, isPrivate: boolean) {
+    const [ scope, pkgName ] = getScopeAndName(name);
+    app.mockLog();
+    return await packageManagerService.publish({
+      dist: { content: Buffer.alloc(0) },
+      tags: [ '' ],
+      scope,
+      name: pkgName,
+      description: name,
+      packageJson: await TestUtil.getFullPackage({ name, version }),
+      readme: '',
+      version,
+      isPrivate,
+    }, publisher);
+  }
+
+  describe('isolate new version on publish (C3/C7)', () => {
+    it('should isolate a public (synced) version and hide it from the manifest', async () => {
+      const { packageId } = await publishVersion('foo', '1.0.0', false);
+
+      // a buffer block record is written
+      const block = await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0');
+      assert(block);
+      assert.equal(block.type, PACKAGE_VERSION_BLOCK_TYPE_BUFFER);
+      assert(block.isBuffer);
+      assert(block.expiredAt instanceof Date);
+      assert(block.expiredAt.getTime() > Date.now());
+
+      // the version is invisible in the client manifest
+      const { data } = await packageManagerService.listPackageFullManifests('', 'foo');
+      assert(data);
+      assert.equal(data.versions['1.0.0'], undefined);
+      assert(data.blockVersions);
+      assert.match(data.blockVersions['1.0.0'], /^\[buffer\]/);
+    });
+
+    it('should NOT isolate a private (user) publish', async () => {
+      const { packageId } = await publishVersion('foo', '1.0.0', true);
+      const block = await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0');
+      assert.equal(block, null);
+      const { data } = await packageManagerService.listPackageFullManifests('', 'foo');
+      assert(data?.versions['1.0.0']);
+    });
+
+    it('should NOT isolate when the package matches dependencyIsolationExclude', async () => {
+      mock(app.config.cnpmcore, 'dependencyIsolationExclude', [ 'foo' ]);
+      const { packageId } = await publishVersion('foo', '1.0.0', false);
+      assert.equal(await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0'), null);
+      const { data } = await packageManagerService.listPackageFullManifests('', 'foo');
+      assert(data?.versions['1.0.0']);
+    });
+
+    it('should match scope wildcard in dependencyIsolationExclude', async () => {
+      mock(app.config.cnpmcore, 'dependencyIsolationExclude', [ '@scope/*' ]);
+      const { packageId } = await publishVersion('@scope/foo', '1.0.0', false);
+      assert.equal(await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0'), null);
+    });
+
+    it('should NOT isolate when disabled', async () => {
+      mock(app.config.cnpmcore, 'enableDependencyIsolation', false);
+      const { packageId } = await publishVersion('foo', '1.0.0', false);
+      assert.equal(await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0'), null);
+      const { data } = await packageManagerService.listPackageFullManifests('', 'foo');
+      assert(data?.versions['1.0.0']);
+    });
+
+    it('should NOT isolate when duration <= 0', async () => {
+      mock(app.config.cnpmcore, 'dependencyIsolationDuration', 0);
+      const { packageId } = await publishVersion('foo', '1.0.0', false);
+      assert.equal(await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0'), null);
+    });
+  });
+
+  describe('releaseBufferedVersions (C5)', () => {
+    it('should release a buffer version and restore it to the manifest', async () => {
+      const { packageId } = await publishVersion('foo', '1.0.0', false);
+      assert.equal((await packageManagerService.listPackageFullManifests('', 'foo')).data?.versions['1.0.0'], undefined);
+
+      const released = await packageManagerService.releaseBufferedVersions(packageId, [ '1.0.0' ]);
+      assert.deepEqual(released, [ '1.0.0' ]);
+
+      // block record removed, version visible again
+      assert.equal(await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0'), null);
+      const { data } = await packageManagerService.listPackageFullManifests('', 'foo');
+      assert(data?.versions['1.0.0']);
+    });
+
+    it('should NOT release a version overwritten to a permanent block', async () => {
+      const { packageId } = await publishVersion('foo', '1.0.0', false);
+      const pkg = await packageRepository.findPackageByPackageId(packageId);
+      assert(pkg);
+
+      // a decision source permanently blocks it during the buffer window
+      const res = await packageManagerService.ensurePackageVersionAvailability(pkg, '1.0.0', false, '[security] malicious');
+      assert.equal(res.changed, true);
+      const block = await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0');
+      assert(block);
+      assert.equal(block.type, null);
+      assert.equal(block.isBuffer, false);
+
+      // release does nothing for it; version stays hidden
+      const released = await packageManagerService.releaseBufferedVersions(packageId, [ '1.0.0' ]);
+      assert.deepEqual(released, []);
+      const { data } = await packageManagerService.listPackageFullManifests('', 'foo');
+      assert.equal(data?.versions['1.0.0'], undefined);
+      assert(data?.blockVersions);
+      assert.equal(data.blockVersions['1.0.0'], '[security] malicious');
+    });
+
+    it('should be idempotent for unknown / already-released versions', async () => {
+      const { packageId } = await publishVersion('foo', '1.0.0', true);
+      assert.deepEqual(await packageManagerService.releaseBufferedVersions(packageId, [ '9.9.9' ]), []);
+    });
+  });
+
+  describe('findExpiredBufferedVersions (C5)', () => {
+    it('should return only buffer rows whose hold has expired', async () => {
+      const { packageId } = await publishVersion('foo', '1.0.0', true);
+      const past = new Date(Date.now() - 1000);
+      const future = new Date(Date.now() + 3600 * 1000);
+      await packageVersionBlockRepository.savePackageVersionBlock(PackageVersionBlock.create({
+        packageId, version: '2.0.0', reason: '[buffer] x', type: PACKAGE_VERSION_BLOCK_TYPE_BUFFER, expiredAt: past,
+      }));
+      await packageVersionBlockRepository.savePackageVersionBlock(PackageVersionBlock.create({
+        packageId, version: '3.0.0', reason: '[buffer] y', type: PACKAGE_VERSION_BLOCK_TYPE_BUFFER, expiredAt: future,
+      }));
+      // a permanent (non-buffer) block is never returned
+      await packageVersionBlockRepository.savePackageVersionBlock(PackageVersionBlock.create({
+        packageId, version: '4.0.0', reason: 'manual',
+      }));
+
+      const expired = await packageVersionBlockRepository.findExpiredBufferedVersions(10);
+      const versions = expired.map(b => b.version);
+      assert(versions.includes('2.0.0'));
+      assert(!versions.includes('3.0.0'));
+      assert(!versions.includes('4.0.0'));
+    });
+  });
+
+  describe('ensurePackageVersionAvailability (C2)', () => {
+    it('should be a no-op when making an already-available version available', async () => {
+      const { packageId } = await publishVersion('foo', '1.0.0', true);
+      const pkg = await packageRepository.findPackageByPackageId(packageId);
+      assert(pkg);
+      assert.deepEqual(await packageManagerService.ensurePackageVersionAvailability(pkg, '1.0.0', true), { changed: false });
+    });
+
+    it('should block then unblock idempotently', async () => {
+      const { packageId } = await publishVersion('foo', '1.0.0', true);
+      const pkg = await packageRepository.findPackageByPackageId(packageId);
+      assert(pkg);
+
+      assert.deepEqual(await packageManagerService.ensurePackageVersionAvailability(pkg, '1.0.0', false, 'bad'), { changed: true });
+      assert.deepEqual(await packageManagerService.ensurePackageVersionAvailability(pkg, '1.0.0', false, 'bad'), { changed: false });
+      assert.equal((await packageManagerService.listPackageFullManifests('', 'foo')).data?.versions['1.0.0'], undefined);
+
+      assert.deepEqual(await packageManagerService.ensurePackageVersionAvailability(pkg, '1.0.0', true), { changed: true });
+      assert(((await packageManagerService.listPackageFullManifests('', 'foo')).data)?.versions['1.0.0']);
+    });
+  });
+
+  describe('block-aware incremental refresh (regression, PR #1058)', () => {
+    it('should keep a blocked version out of the incremental manifest refresh', async () => {
+      const { packageId } = await publishVersion('foo', '1.0.0', true);
+      const pkg = await packageRepository.findPackageByPackageId(packageId);
+      assert(pkg);
+      await packageManagerService.blockPackageVersion(pkg, '1.0.0', 'bad');
+      assert.equal((await packageManagerService.listPackageFullManifests('', 'foo')).data?.versions['1.0.0'], undefined);
+
+      // incremental refresh (as run by sync batch / re-publish) must not re-add the blocked version
+      await packageManagerService.refreshPackageChangeVersionsToDists(pkg, [ '1.0.0' ]);
+      assert.equal((await packageManagerService.listPackageFullManifests('', 'foo')).data?.versions['1.0.0'], undefined);
+    });
+  });
+});

--- a/test/schedule/BufferRelease.test.ts
+++ b/test/schedule/BufferRelease.test.ts
@@ -1,0 +1,86 @@
+import { strict as assert } from 'node:assert';
+import { app, mock } from 'egg-mock/bootstrap';
+import { TestUtil } from '../../test/TestUtil';
+import { PackageManagerService } from '../../app/core/service/PackageManagerService';
+import { PackageVersionBlockRepository } from '../../app/repository/PackageVersionBlockRepository';
+import { PackageVersionBlock as PackageVersionBlockModel } from '../../app/repository/model/PackageVersionBlock';
+import { UserService } from '../../app/core/service/UserService';
+import { getScopeAndName } from '../../app/common/PackageUtil';
+
+const DispatcherPath = require.resolve('../../app/port/schedule/BufferReleaseDispatcher');
+const WorkerPath = require.resolve('../../app/port/schedule/BufferReleaseWorker');
+
+describe('test/schedule/BufferRelease.test.ts', () => {
+  let packageManagerService: PackageManagerService;
+  let packageVersionBlockRepository: PackageVersionBlockRepository;
+  let userService: UserService;
+  let publisher;
+
+  beforeEach(async () => {
+    packageManagerService = await app.getEggObject(PackageManagerService);
+    packageVersionBlockRepository = await app.getEggObject(PackageVersionBlockRepository);
+    userService = await app.getEggObject(UserService);
+    const { user } = await userService.create({
+      name: 'test-user', password: 'this-is-password', email: 'hello@example.com', ip: '127.0.0.1',
+    });
+    publisher = user;
+    mock(app.config.cnpmcore, 'enableBlockPackageVersion', true);
+    mock(app.config.cnpmcore, 'enableDependencyIsolation', true);
+    mock(app.config.cnpmcore, 'dependencyIsolationDuration', 6 * 3600 * 1000);
+    mock(app.config.cnpmcore, 'dependencyIsolationExclude', []);
+  });
+
+  afterEach(async () => {
+    mock.restore();
+    await TestUtil.truncateDatabase();
+  });
+
+  async function publishIsolated(name: string, version: string) {
+    const [ scope, pkgName ] = getScopeAndName(name);
+    app.mockLog();
+    return await packageManagerService.publish({
+      dist: { content: Buffer.alloc(0) },
+      tags: [ '' ],
+      scope,
+      name: pkgName,
+      description: name,
+      packageJson: await TestUtil.getFullPackage({ name, version }),
+      readme: '',
+      version,
+      isPrivate: false,
+    }, publisher);
+  }
+
+  it('dispatcher enqueues expired buffer versions and worker releases them', async () => {
+    const { packageId } = await publishIsolated('foo', '1.0.0');
+    // hidden while buffered
+    assert.equal((await packageManagerService.listPackageFullManifests('', 'foo')).data?.versions['1.0.0'], undefined);
+    // backdate expiry so it is due
+    await PackageVersionBlockModel.update({ packageId, version: '1.0.0' }, { expiredAt: new Date(Date.now() - 1000) });
+
+    await app.runSchedule(DispatcherPath);
+    await app.runSchedule(WorkerPath);
+
+    // released: block gone + version visible again
+    assert.equal(await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0'), null);
+    assert((await packageManagerService.listPackageFullManifests('', 'foo')).data?.versions['1.0.0']);
+  });
+
+  it('should NOT release a buffer version before it expires', async () => {
+    const { packageId } = await publishIsolated('foo', '1.0.0'); // expiredAt = now + 6h
+
+    await app.runSchedule(DispatcherPath);
+    await app.runSchedule(WorkerPath);
+
+    // still buffered + hidden
+    assert((await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0'))?.isBuffer);
+    assert.equal((await packageManagerService.listPackageFullManifests('', 'foo')).data?.versions['1.0.0'], undefined);
+  });
+
+  it('should be a no-op when isolation is disabled', async () => {
+    mock(app.config.cnpmcore, 'enableDependencyIsolation', false);
+    // nothing enqueued / released; just verify the schedules run without error
+    await app.runSchedule(DispatcherPath);
+    await app.runSchedule(WorkerPath);
+  });
+});

--- a/test/schedule/BufferRelease.test.ts
+++ b/test/schedule/BufferRelease.test.ts
@@ -77,10 +77,16 @@ describe('test/schedule/BufferRelease.test.ts', () => {
     assert.equal((await packageManagerService.listPackageFullManifests('', 'foo')).data?.versions['1.0.0'], undefined);
   });
 
-  it('should be a no-op when isolation is disabled', async () => {
+  it('should still release already-buffered versions after the flag is turned off (rollback)', async () => {
+    const { packageId } = await publishIsolated('foo', '1.0.0'); // buffered while flag on
+    await PackageVersionBlockModel.update({ packageId, version: '1.0.0' }, { expiredAt: new Date(Date.now() - 1000) });
+    // operator disables the feature (rollback) — existing buffer rows must still drain
     mock(app.config.cnpmcore, 'enableDependencyIsolation', false);
-    // nothing enqueued / released; just verify the schedules run without error
+
     await app.runSchedule(DispatcherPath);
     await app.runSchedule(WorkerPath);
+
+    assert.equal(await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0'), null);
+    assert((await packageManagerService.listPackageFullManifests('', 'foo')).data?.versions['1.0.0']);
   });
 });


### PR DESCRIPTION
## What

Implements the **dependency isolation (buffer) zone** from RFC #1057: an optional, default-off mechanism that holds a newly synced version invisible for a configurable duration, then auto-releases it unless it was blocked meanwhile. Gives deployments a window to run out-of-band validation before a freshly synced version becomes installable.

> Base branch: `3.x`. Default-off; behavior identical to today when disabled. Requires `enableBlockPackageVersion`.

## Flow

```text
sync publish ──► shouldIsolate? ──no──► visible (normal publish)
                     │ yes
                     ▼
        buffer block (type='buffer', expired_at = now + duration)
        + suppress PACKAGE_VERSION_ADDED
                     ▼
        ISOLATED ── hidden from manifest / dist-tags / search / install
                     │
          ┌──────────┴──────────┐
     validation bad        expired_at reached
          ▼                     ▼
   permanent block        release chain ──► VISIBLE
   (type=null, admin-only)
```

Release chain:

```text
expired_at <= now
   │
BufferReleaseDispatcher   @Schedule(WORKER) + lock · single-instance
   │   findExpiredBufferedVersions → group by package → enqueue
   ▼
queue   cnpmcore queueAdapter (FIFO)
   │
BufferReleaseWorker   @Schedule(ALL) · every node · atomic pop
   │   releaseBufferedVersions(packageId, versions):
   │     • still type='buffer' → remove row
   │     • rebuild package manifest once (per batch)
   │     • emit PACKAGE_VERSION_ADDED → search / changes / file sync
   ▼
VISIBLE / installable
```

DB rows are the source of truth — a dropped queue message is re-enqueued next dispatch, and the release is idempotent. `ensurePackageVersionAvailability(available=true)` never releases a buffer record (no automated escape); only the timer or an admin force-unblock releases it.

## Changes (C1–C7)

- **C1 schema** — add nullable `type` (`'buffer'` | null) + `expired_at` to `package_version_blocks`, index `(type, expired_at)`; model + entity + mysql/pg migration `3.83.0` + full DDL. Existing rows keep `type=null` (permanent block, current semantics); no backfill.
- **C6 config** — `enableDependencyIsolation` (default `false`), `dependencyIsolationDuration` (6h, ~ pnpm `minimumReleaseAge`), `dependencyIsolationExclude` (`[]`, ~ pnpm `minimumReleaseAgeExclude`).
- **C2 primitive** — `ensurePackageVersionAvailability(pkg, version, available, reason?)`, idempotent over `block/unblockPackageVersion`. A permanent block clears `type`/`expired_at` so it overrides a buffer record; `available=true` never releases a buffer record (no automated escape).
- **C3 + C7 entry / event deferral** — in `publish()`, isolate a new public version (after the normal manifest build, so `manifestsDist` is consistent): write a `type='buffer'` record and **suppress** `PACKAGE_VERSION_ADDED`; the event (and thus search index / changes stream / file sync) fires only at release. Guard: `enableDependencyIsolation` + `enableBlockPackageVersion` + `duration>0` + `!isPrivate` + not in exclude list (exact / `@scope/*`). The incremental manifest refresh is now block-aware so an isolated/blocked version never leaks into the dist.
- **C5 release** — repo `findExpiredBufferedVersions(limit)` (indexed); `releaseBufferedVersions(packageId, versions)` releases only still-buffer records, rebuilds the package manifest once per batch, emits the deferred `PACKAGE_VERSION_ADDED` per version. Idempotent. `unblockPackageVersion` re-emits `PACKAGE_VERSION_ADDED` when a version becomes visible again.
- **C4 schedules** — modeled on the existing sync architecture (producer → queue → worker): `BufferReleaseDispatcher` (`@Schedule(WORKER)` + lock, single-instance, scans expired rows and enqueues per package) and `BufferReleaseWorker` (`@Schedule(ALL)` + re-entrancy guard, every node pops and runs the batch unblock, distributing load).

## Status

- ✅ `tsc --noEmit` + `eslint` clean.
- ✅ Tests: 19 passing — entry guard matrix, release three-state + manifest exclude/restore, `findExpiredBufferedVersions`, primitive idempotency, no-automated-escape, unblock event (re)emit, and dispatcher→worker e2e.
- ⏳ CI run pending GitHub Actions availability (platform incident at time of opening).

RFC: #1057
