### PR TITLE
fix: preserve latest tag during dependency isolation

### DIFF
--- a/app/common/adapter/NPMRegistry.ts
+++ b/app/common/adapter/NPMRegistry.ts
@@ -73,6 +73,20 @@ export class NPMRegistry {
     throw lastError;
   }
 
+  public async getDistTags(
+    registry: string,
+    fullname: string,
+    optionalConfig?: { remoteAuthToken?: string },
+  ): Promise<{ method: HttpMethod } & HttpClientResponse<Record<string, string>>> {
+    const url = `${registry}/-/package/${encodeURIComponent(fullname)}/dist-tags?t=${Date.now()}&cache=0`;
+    const headers = optionalConfig?.remoteAuthToken
+      ? { authorization: this.genAuthorizationHeader(optionalConfig.remoteAuthToken) }
+      : undefined;
+    return await this.request('GET', url, undefined, {
+      headers,
+    });
+  }
+
   // app.put('/:name/sync', sync.sync);
   public async createSyncTask(fullname: string, optionalConfig?: { remoteAuthToken?:string}): Promise<RegistryResponse> {
     const authorization = this.genAuthorizationHeader(optionalConfig?.remoteAuthToken);

--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -11,6 +11,7 @@ import { RequireAtLeastOne } from 'type-fest';
 import npa from 'npm-package-arg';
 import semver from 'semver';
 import pMap from 'p-map';
+import { NPMRegistry } from '../../common/adapter/NPMRegistry';
 import {
   calculateIntegrity,
   detectInstallScript,
@@ -97,6 +98,8 @@ export class PackageManagerService extends AbstractService {
   private readonly distRepository: DistRepository;
   @Inject()
   private readonly registryManagerService: RegistryManagerService;
+  @Inject()
+  private readonly npmRegistry: NPMRegistry;
   @Inject()
   private readonly packageVersionService: PackageVersionService;
 
@@ -288,10 +291,11 @@ export class PackageManagerService extends AbstractService {
     }
     if (cmd.tags) {
       for (const tag of cmd.tags) {
-        await this.savePackageTag(pkg, tag, cmd.version, true);
-        if (!shouldIsolate) {
-          this.eventBus.emit(PACKAGE_VERSION_ADDED, pkg.fullname, pkgVersion.version, tag);
+        if (shouldIsolate) {
+          continue;
         }
+        await this.savePackageTag(pkg, tag, cmd.version, true);
+        this.eventBus.emit(PACKAGE_VERSION_ADDED, pkg.fullname, pkgVersion.version, tag);
       }
     } else if (!shouldIsolate) {
       this.eventBus.emit(PACKAGE_VERSION_ADDED, pkg.fullname, pkgVersion.version, undefined);
@@ -548,10 +552,22 @@ export class PackageManagerService extends AbstractService {
       }
     }
     if (released.length === 0) return [];
+    const rollbackTags: { tag: string; version?: string }[] = [];
     try {
+      await this._syncReleasedVersionDistTags(pkg, released.map(r => r.version), rollbackTags);
       // rebuild the package manifest once for the whole batch (restores released versions + dist-tags)
       await this._refreshPackageManifestsToDists(pkg);
     } catch (err) {
+      for (const rollbackTag of rollbackTags.reverse()) {
+        if (rollbackTag.version) {
+          await this.savePackageTag(pkg, rollbackTag.tag, rollbackTag.version, true, true);
+        } else {
+          const tagEntity = await this.packageRepository.findPackageTag(packageId, rollbackTag.tag);
+          if (tagEntity) {
+            await this.packageRepository.removePackageTag(tagEntity);
+          }
+        }
+      }
       // the manifest rebuild (NFS write) is the only non-transactional step. if it fails after the
       // buffer rows were removed, re-create them so the dispatcher re-enqueues and retries — keeping
       // DB rows as the release source-of-truth instead of leaving the version permanently stale.
@@ -833,7 +849,12 @@ export class PackageManagerService extends AbstractService {
     }
   }
 
-  public async savePackageTag(pkg: Package, tag: string, version: string, skipEvent = false) {
+  public async savePackageTag(pkg: Package, tag: string, version: string, skipEvent = false, skipRefresh = false) {
+    if (await this._isPackageVersionBlocked(pkg.packageId, version)) {
+      this.logger.info('[PackageManagerService:savePackageTag:skipBlockedVersion] packageId: %s, tag: %s, version: %s',
+        pkg.packageId, tag, version);
+      return false;
+    }
     let tagEntity = await this.packageRepository.findPackageTag(pkg.packageId, tag);
     if (!tagEntity) {
       tagEntity = PackageTag.create({
@@ -842,7 +863,9 @@ export class PackageManagerService extends AbstractService {
         version,
       });
       await this.packageRepository.savePackageTag(tagEntity);
-      await this._refreshPackageManifestRootAttributeOnlyToDists(pkg, 'dist-tags');
+      if (!skipRefresh) {
+        await this._refreshPackageManifestRootAttributeOnlyToDists(pkg, 'dist-tags');
+      }
       if (!skipEvent) {
         this.eventBus.emit(PACKAGE_TAG_ADDED, pkg.fullname, tagEntity.tag);
       }
@@ -854,7 +877,9 @@ export class PackageManagerService extends AbstractService {
     }
     tagEntity.version = version;
     await this.packageRepository.savePackageTag(tagEntity);
-    await this._refreshPackageManifestRootAttributeOnlyToDists(pkg, 'dist-tags');
+    if (!skipRefresh) {
+      await this._refreshPackageManifestRootAttributeOnlyToDists(pkg, 'dist-tags');
+    }
     if (!skipEvent) {
       this.eventBus.emit(PACKAGE_TAG_CHANGED, pkg.fullname, tagEntity.tag);
     }
@@ -958,7 +983,8 @@ export class PackageManagerService extends AbstractService {
     for (const tag of tags) {
       // Only handle 'latest' tag fallback when blocked
       if (tag.tag === 'latest' && blockedVersionSet?.has(tag.version)) {
-        // Find the latest non-blocked version
+        // Fall back only when latest was already written to a blocked version. Dependency
+        // isolation skips tag updates to invisible versions and reconciles source dist-tags on release.
         const allVersions = await this.packageRepository.listPackageVersions(pkg.packageId);
         const nonBlockedVersion = allVersions.find(v => !blockedVersionSet!.has(v.version));
         if (nonBlockedVersion) {
@@ -970,6 +996,45 @@ export class PackageManagerService extends AbstractService {
       }
     }
     return distTags;
+  }
+
+  private async _isPackageVersionBlocked(packageId: string, version: string): Promise<boolean> {
+    if (!this.config.cnpmcore.enableBlockPackageVersion) return false;
+    const block = await this.packageVersionBlockRepository.findPackageVersionBlockExact(packageId, version);
+    return !!block;
+  }
+
+  private async _syncReleasedVersionDistTags(
+    pkg: Package,
+    releasedVersions: string[],
+    rollbackTags: { tag: string; version?: string }[],
+  ): Promise<void> {
+    const registry = await this.getSourceRegistry(pkg);
+    const registryHost = registry?.host || this.config.cnpmcore.sourceRegistry;
+    const releasedVersionSet = new Set(releasedVersions);
+    let distTags: Record<string, string> | undefined;
+    try {
+      const res = await this.npmRegistry.getDistTags(registryHost, pkg.fullname, { remoteAuthToken: registry?.authToken });
+      if (res.status !== 200 || !res.data) {
+        throw new Error(`Get dist-tags from ${registryHost} failed, status: ${res.status}`);
+      }
+      distTags = res.data;
+    } catch (err) {
+      this.logger.warn('[PackageManagerService:syncReleasedVersionDistTags:error] packageId: %s, registry: %s, err: %s',
+        pkg.packageId, registryHost, err);
+      throw err;
+    }
+
+    for (const [ tag, version ] of Object.entries(distTags)) {
+      if (!releasedVersionSet.has(version)) continue;
+      if (await this._isPackageVersionBlocked(pkg.packageId, version)) continue;
+      const packageVersion = await this.packageRepository.findPackageVersion(pkg.packageId, version);
+      if (!packageVersion) continue;
+      const oldTag = await this.packageRepository.findPackageTag(pkg.packageId, tag);
+      if (oldTag?.version === version) continue;
+      rollbackTags.push({ tag, version: oldTag?.version });
+      await this.savePackageTag(pkg, tag, version, true, true);
+    }
   }
 
   // refresh package full manifests and abbreviated manifests to NFS

--- a/app/core/service/PackageVersionService.ts
+++ b/app/core/service/PackageVersionService.ts
@@ -101,18 +101,21 @@ export class PackageVersionService {
       if (versionMatchTag) {
         version = versionMatchTag;
       } else {
-        // Skip blocked versions (both dependency-isolation buffer and permanent blocks)
-        // so range resolution matches what the client sees in the manifest — e.g. for
-        // ^1.0.0 with 1.1.0 visible and 1.2.0 blocked, resolve to 1.1.0 instead of
-        // returning 1.2.0 and forcing a blockReason response.
         const excludeVersions = await this.findBlockedVersions(scope, name);
         const range = new Range(spec.fetchSpec!);
-        const paddingSemVer = new SqlRange(range);
-        if (paddingSemVer.containPreRelease) {
-          const versions = await this.packageVersionRepository.findSatisfyVersionsWithPrerelease(scope, name, paddingSemVer, excludeVersions);
-          version = semver.maxSatisfying(versions, range);
+        // Prefer latest tag version if it satisfies the range, unless it is hidden by
+        // dependency-isolation buffering or a permanent version block.
+        const latestVersion = await this.packageVersionRepository.findVersionByTag(scope, name, 'latest');
+        if (latestVersion && !excludeVersions.includes(latestVersion) && semver.satisfies(latestVersion, range)) {
+          version = latestVersion;
         } else {
-          version = await this.packageVersionRepository.findMaxSatisfyVersion(scope, name, paddingSemVer, excludeVersions);
+          const paddingSemVer = new SqlRange(range);
+          if (paddingSemVer.containPreRelease) {
+            const versions = await this.packageVersionRepository.findSatisfyVersionsWithPrerelease(scope, name, paddingSemVer, excludeVersions);
+            version = semver.maxSatisfying(versions, range);
+          } else {
+            version = await this.packageVersionRepository.findMaxSatisfyVersion(scope, name, paddingSemVer, excludeVersions);
+          }
         }
       }
     }

--- a/test/core/service/PackageManagerService/dependencyIsolation.test.ts
+++ b/test/core/service/PackageManagerService/dependencyIsolation.test.ts
@@ -39,12 +39,12 @@ describe('test/core/service/PackageManagerService/dependencyIsolation.test.ts', 
     await TestUtil.truncateDatabase();
   });
 
-  async function publishVersion(name: string, version: string, isPrivate: boolean) {
+  async function publishVersion(name: string, version: string, isPrivate: boolean, tags = [ '' ]) {
     const [ scope, pkgName ] = getScopeAndName(name);
     app.mockLog();
     return await packageManagerService.publish({
       dist: { content: Buffer.alloc(0) },
-      tags: [ '' ],
+      tags,
       scope,
       name: pkgName,
       description: name,
@@ -53,6 +53,15 @@ describe('test/core/service/PackageManagerService/dependencyIsolation.test.ts', 
       version,
       isPrivate,
     }, publisher);
+  }
+
+  function mockSourceDistTags(distTags: Record<string, string>) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mock((packageManagerService as any).npmRegistry, 'getDistTags', async () => ({
+      method: 'GET',
+      status: 200,
+      data: distTags,
+    }));
   }
 
   describe('isolate new version on publish (C3/C7)', () => {
@@ -73,6 +82,42 @@ describe('test/core/service/PackageManagerService/dependencyIsolation.test.ts', 
       assert.equal(data.versions['1.0.0'], undefined);
       assert(data.blockVersions);
       assert.match(data.blockVersions['1.0.0'], /^\[buffer\]/);
+    });
+
+    it('should preserve previous visible latest while the new latest is isolated', async () => {
+      mock(app.config.cnpmcore, 'enableDependencyIsolation', false);
+      await publishVersion('foo', '1.1.0', false, [ 'latest' ]);
+      await publishVersion('foo', '1.2.0', false, [ 'next' ]);
+
+      let manifest = await packageManagerService.listPackageFullManifests('', 'foo');
+      assert.equal(manifest.data?.['dist-tags'].latest, '1.1.0');
+      assert.equal(manifest.data?.['dist-tags'].next, '1.2.0');
+      assert(manifest.data?.versions['1.2.0']);
+
+      mock(app.config.cnpmcore, 'enableDependencyIsolation', true);
+      const { packageId } = await publishVersion('foo', '1.2.1', false, []);
+      const pkg = await packageRepository.findPackageByPackageId(packageId);
+      assert(pkg);
+      assert.equal(await packageManagerService.savePackageTag(pkg, 'latest', '1.2.1'), false);
+
+      const latestTag = await packageRepository.findPackageTag(packageId, 'latest');
+      assert.equal(latestTag?.version, '1.1.0');
+      manifest = await packageManagerService.listPackageFullManifests('', 'foo');
+      assert.equal(manifest.data?.['dist-tags'].latest, '1.1.0');
+      assert.equal(manifest.data?.['dist-tags'].next, '1.2.0');
+      assert.equal(manifest.data?.versions['1.2.1'], undefined);
+      assert(manifest.data?.versions['1.2.0']);
+
+      mockSourceDistTags({
+        latest: '1.2.1',
+        next: '1.2.0',
+      });
+      const released = await packageManagerService.releaseBufferedVersions(packageId, [ '1.2.1' ]);
+      assert.deepEqual(released, [ '1.2.1' ]);
+      assert.equal((await packageRepository.findPackageTag(packageId, 'latest'))?.version, '1.2.1');
+      manifest = await packageManagerService.listPackageFullManifests('', 'foo');
+      assert.equal(manifest.data?.['dist-tags'].latest, '1.2.1');
+      assert(manifest.data?.versions['1.2.1']);
     });
 
     it('should NOT isolate a private (user) publish', async () => {
@@ -116,6 +161,7 @@ describe('test/core/service/PackageManagerService/dependencyIsolation.test.ts', 
     it('should release a buffer version and restore it to the manifest', async () => {
       const { packageId } = await publishVersion('foo', '1.0.0', false);
       assert.equal((await packageManagerService.listPackageFullManifests('', 'foo')).data?.versions['1.0.0'], undefined);
+      mockSourceDistTags({});
 
       const released = await packageManagerService.releaseBufferedVersions(packageId, [ '1.0.0' ]);
       assert.deepEqual(released, [ '1.0.0' ]);
@@ -160,6 +206,7 @@ describe('test/core/service/PackageManagerService/dependencyIsolation.test.ts', 
       mock((packageManagerService as any).eventBus, 'emit', (name: string) => { emitted.push(name); });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mock(PackageManagerService.prototype as any, '_refreshPackageManifestsToDists', async () => { throw new Error('nfs down'); });
+      mockSourceDistTags({});
 
       await assert.rejects(packageManagerService.releaseBufferedVersions(packageId, [ '1.0.0' ]), /nfs down/);
       // no phantom publish event on failure

--- a/test/core/service/PackageVersionService.test.ts
+++ b/test/core/service/PackageVersionService.test.ts
@@ -101,27 +101,19 @@ describe('test/core/service/PackageVersionService.test.ts', () => {
             publishTime: new Date(),
           });
 
-          mock(distRepository, 'findPackageVersionManifest', async (_: string, version: string) => {
-            assert.equal(version, '1.1.0');
-            return {
-              name: 'mock_package',
-              version: '1.1.0',
-            };
-          });
-
         });
 
         it('should return latest for *', async () => {
           const manifest = await packageVersionService.readManifest('mock_package_id', npa('mock_package@*'), true);
           assert(manifest);
-          assert.equal(manifest.version, '1.1.0');
+          assert.equal(manifest.version, '1.0.0');
         });
 
         describe('getVersion should work', () => {
           it('should work without options', async () => {
             const wildVersion = await packageVersionService.getVersion(npa('mock_package@*'));
             const tagVersion = await packageVersionService.getVersion(npa('mock_package@latest'));
-            assert.equal(wildVersion, '1.1.0');
+            assert.equal(wildVersion, '1.0.0');
             assert.equal(tagVersion, '1.0.0');
           });
         });
@@ -129,13 +121,13 @@ describe('test/core/service/PackageVersionService.test.ts', () => {
         it('should return latest for x', async () => {
           const manifest = await packageVersionService.readManifest('mock_package_id', npa('mock_package@*'), true);
           assert(manifest);
-          assert.equal(manifest.version, '1.1.0');
+          assert.equal(manifest.version, '1.0.0');
         });
 
         it('should return latest for compose', async () => {
           const manifest = await packageVersionService.readManifest('mock_package_id', npa('mock_package@^*||~x'), true);
           assert(manifest);
-          assert.equal(manifest.version, '1.1.0');
+          assert.equal(manifest.version, '1.0.0');
         });
       });
     });
@@ -483,7 +475,7 @@ describe('test/core/service/PackageVersionService.test.ts', () => {
           type: 'buffer',
           expiredAt: new Date(Date.now() + 6 * 3600 * 1000),
         });
-        const version = await packageVersionService.getVersion(npa('mock_package@^1.0.0'));
+        const version = await packageVersionService.getVersion(npa('mock_package@^1.1.0'));
         assert.equal(version, '1.1.0');
       });
 
@@ -501,7 +493,7 @@ describe('test/core/service/PackageVersionService.test.ts', () => {
           type: 'buffer',
           expiredAt: new Date(Date.now() - 1000),
         });
-        const version = await packageVersionService.getVersion(npa('mock_package@^1.0.0'));
+        const version = await packageVersionService.getVersion(npa('mock_package@^1.1.0'));
         assert.equal(version, '1.1.0');
       });
 
@@ -514,7 +506,7 @@ describe('test/core/service/PackageVersionService.test.ts', () => {
           type: null,
           expiredAt: null,
         });
-        const version = await packageVersionService.getVersion(npa('mock_package@^1.0.0'));
+        const version = await packageVersionService.getVersion(npa('mock_package@^1.1.0'));
         assert.equal(version, '1.1.0');
       });
 

--- a/test/port/controller/package/ShowPackageVersionController.test.ts
+++ b/test/port/controller/package/ShowPackageVersionController.test.ts
@@ -258,6 +258,61 @@ describe('test/port/controller/package/ShowPackageVersionController.test.ts', ()
       assert.equal(res.body.error, `[NOT_FOUND] ${pkg.name}@beta-not-exists not found`);
     });
 
+    it('should prefer latest tag version when it satisfies semver range', async () => {
+      mock(app.config.cnpmcore, 'allowPublishNonScopePackage', true);
+
+      const pkg110 = await TestUtil.getFullPackage({
+        name: 'foo-prefer-latest',
+        version: '1.1.0',
+        versionObject: {
+          description: 'version 1.1.0',
+        },
+      });
+      await app.httpRequest()
+        .put(`/${pkg110.name}`)
+        .set('authorization', publisher.authorization)
+        .set('user-agent', publisher.ua)
+        .send(pkg110)
+        .expect(201);
+
+      const pkg120 = await TestUtil.getFullPackage({
+        name: 'foo-prefer-latest',
+        version: '1.2.0',
+        versionObject: {
+          description: 'version 1.2.0',
+        },
+        distTags: {
+          next: '1.2.0',
+        },
+      });
+      await app.httpRequest()
+        .put(`/${pkg120.name}`)
+        .set('authorization', publisher.authorization)
+        .set('user-agent', publisher.ua)
+        .send(pkg120)
+        .expect(201);
+
+      let res = await app.httpRequest()
+        .get(`/${pkg110.name}/latest`)
+        .expect(200);
+      assert.equal(res.body.version, '1.1.0');
+
+      res = await app.httpRequest()
+        .get(`/${pkg110.name}/^1`)
+        .expect(200);
+      assert.equal(res.body.version, '1.1.0');
+
+      res = await app.httpRequest()
+        .get(`/${pkg110.name}/%5E1`)
+        .expect(200);
+      assert.equal(res.body.version, '1.1.0');
+
+      res = await app.httpRequest()
+        .get(`/${pkg110.name}/^1.2.0`)
+        .expect(200);
+      assert.equal(res.body.version, '1.2.0');
+    });
+
     it('should 404 when version not exists', async () => {
       const pkg = await TestUtil.getFullPackage({
         name: '@cnpm/foo',


### PR DESCRIPTION
## Background

This PR continues the 3.x backport for the semver latest-range behavior and fixes a dependency isolation regression around dist-tags.

When a synced version enters dependency isolation, updating dist-tags immediately can lose the previous visible latest tag. For example:

- 1.1.0 is latest
- 1.2.0 exists but is not latest
- 1.2.1 is synced and buffered by dependency isolation

During the buffer window, clients should still see latest as 1.1.0. The previous behavior could let latest drift to 1.2.0 because the DB latest tag pointed at the blocked/buffered version and manifest generation tried to fall back to the newest visible version.

## Changes

- Skip dist-tag updates when the target version is blocked or buffered.
- Do not write publish tags for newly isolated versions.
- On buffer release, fetch upstream dist-tags from the lightweight /-/package/:name/dist-tags endpoint and update only tags pointing to versions released in the current batch.
- Roll back tag changes and restore buffer rows if release manifest rebuild fails.
- Add regression coverage for preserving the previous visible latest during isolation and updating it after release.

## Verification

- ut run lint
- ut run tsc
- git diff --check

Note: the targeted dependency isolation test could not start locally because MySQL on 127.0.0.1:3306 is unavailable.