### PR TITLE
fix(TaskService): only retry changes_stream task on changesStream-enabled machine

### DIFF
--- a/app/core/service/TaskService.ts
+++ b/app/core/service/TaskService.ts
@@ -124,6 +124,12 @@ export class TaskService extends AbstractService {
     const tasks = await this.taskRepository.findTimeoutTasks(TaskState.Processing, 60000 * 10);
     for (const task of tasks) {
       try {
+        // changes_stream 任务只能由开启了 enableChangesStream 的机器重试
+        // 否则在多集群 + redis 不共享的场景下，未开启 changesStream 的机器会把任务
+        // 重新推入自己的队列，导致任务被无法执行它的机器抢占，且无法被正常调度执行
+        if (task.type === TaskType.ChangesStream && !this.config.cnpmcore.enableChangesStream) {
+          continue;
+        }
         // ignore ChangesStream task, it won't timeout
         if (task.attempts >= 3 && task.type !== TaskType.ChangesStream) {
           await this.finishTask(task, TaskState.Timeout);
@@ -150,6 +156,10 @@ export class TaskService extends AbstractService {
     const waitingTasks = await this.taskRepository.findTimeoutTasks(TaskState.Waiting, 60000 * 30);
     for (const task of waitingTasks) {
       try {
+        // 同上，changes_stream 任务只能由开启了 enableChangesStream 的机器重试
+        if (task.type === TaskType.ChangesStream && !this.config.cnpmcore.enableChangesStream) {
+          continue;
+        }
         await this.retryTask(task);
         this.logger.warn(
           '[TaskService.retryExecuteTimeoutTasks:retryWaiting] taskType: %s, targetName: %s, taskId: %s waiting too long',

--- a/test/schedule/ChangesStreamWorker.test.ts
+++ b/test/schedule/ChangesStreamWorker.test.ts
@@ -52,6 +52,43 @@ describe('test/schedule/ChangesStreamWorker.test.ts', () => {
     assert(result.waiting === 0);
   });
 
+  it('should not retry changes_stream task when enableChangesStream is disabled', async () => {
+    app.mockHttpclient('https://r.cnpmjs.org/', 'GET', {
+      data: await TestUtil.readFixturesFile('r.cnpmjs.org/index.json'),
+    });
+    app.mockHttpclient('https://r.cnpmjs.org/_changes', 'GET', {
+      data: await TestUtil.readFixturesFile('r.cnpmjs.org/_changes.json'),
+    });
+    app.mockLog();
+    // syncMode=all and enableChangesStream = true, task picked up and processing
+    mock(app.config.cnpmcore, 'syncMode', 'all');
+    mock(app.config.cnpmcore, 'changesStreamRegistry', 'https://r.cnpmjs.org');
+    mock(app.config.cnpmcore, 'enableChangesStream', true);
+    await app.runSchedule(ChangesStreamWorkerPath);
+    app.expectLog('[ChangesStreamWorker:start]');
+
+    // mock no changed after 10 mins
+    const existsTask = await Task.findOne({ type: 'changes_stream' });
+    assert(existsTask);
+    assert(existsTask.state === 'processing');
+    existsTask.updatedAt = new Date(existsTask.updatedAt.getTime() - 60000 * 10 - 1);
+    await existsTask.save();
+
+    // the machine running timeout handler has changesStream disabled
+    // (e.g. consumer cluster with non-shared redis), it must NOT retry the
+    // changes_stream task, otherwise the task is pushed into a queue that no
+    // machine listens on and can never be scheduled again
+    mock(app.config.cnpmcore, 'enableChangesStream', false);
+    app.mockLog();
+    const result = await taskService.retryExecuteTimeoutTasks();
+    app.notExpectLog('[TaskService.retryExecuteTimeoutTasks:retry]');
+    assert(result.waiting === 0);
+    // task is left untouched, still processing (not requeued to waiting)
+    const afterTask = await Task.findOne({ type: 'changes_stream' });
+    assert(afterTask);
+    assert(afterTask.state === 'processing');
+  });
+
   it('should work on replicate: r.cnpmjs.org', async () => {
     app.mockHttpclient('https://r.cnpmjs.org/', 'GET', {
       data: await TestUtil.readFixturesFile('r.cnpmjs.org/index.json'),


### PR DESCRIPTION
## 问题

在生产的多集群拓扑（sync / consumer 集群 Redis 不共享）下，`changes_stream` 任务会被错误的机器抢占、最终无法被调度执行。

**根因：**
- `TaskTimeoutHandler` 通过集群级分布式锁运行，集群里**任意一台**机器都可能执行 `retryExecuteTimeoutTasks`。
- 该方法从**共享的 DB** 查超时任务，但 `retryTask` 把重试任务 `push` 进了**本机所在集群的 Redis 队列**。
- `changes_stream` 任务只有 `ChangesStreamWorker` 会消费，而它被 `enableChangesStream` 开关 gate。
- 于是一台**没开 `enableChangesStream`** 的 consumer 集群机器执行重试时，会把任务推进自己集群里**没人监听**的队列 → 任务搁浅，DB 状态被改成 waiting，sync 集群也再难正常调度。

## 修复

在 `retryExecuteTimeoutTasks` 的 Processing 和 Waiting 两个重试循环里加守卫：**只有当前机器开启了 `enableChangesStream` 时才重试 `changes_stream` 任务**，否则跳过，留给真正能执行它的（sync 集群）机器去重新入队。非 changesStream 任务逻辑不变。

## 测试

- 新增 `test/schedule/ChangesStreamWorker.test.ts` 用例：关闭 `enableChangesStream` 后，超时的 `changes_stream` 任务**不被重试**（无 retry 日志、状态仍为 `processing`、未被推回队列）。
- 本地 `tsc` + `eslint` 通过；集成测试需 MySQL 环境运行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)