### PR TITLE
fix(playwright): sync from cdn.playwright.dev instead of deprecated azureedge

### DIFF
--- a/app/common/adapter/binary/PlaywrightBinary.ts
+++ b/app/common/adapter/binary/PlaywrightBinary.ts
@@ -7,7 +7,10 @@ import { BinaryType } from '../../enum/Binary.ts';
 import { AbstractBinary, BinaryAdapter, type BinaryItem, type FetchResult } from './AbstractBinary.ts';
 
 const PACKAGE_URL = 'https://registry.npmjs.com/playwright-core';
-const DOWNLOAD_HOST = 'https://playwright.azureedge.net/';
+// playwright.azureedge.net is deprecated and returns 400 for the new
+// `builds/cft/*` namespace; cdn.playwright.dev serves both the legacy
+// `builds/*` and the CFT paths. See https://github.com/cnpm/cnpmcore/issues/1033
+const DOWNLOAD_HOST = 'https://cdn.playwright.dev/';
 // https://github.com/playwright-community/playwright-go/blob/56e30d60f8b42785982469eaca6ad969bc2e1946/run.go#L341-L374
 const PLAYWRIGHT_DRIVER_ARCHS = ['win32_x64', 'mac-arm64', 'mac', 'linux-arm64', 'linux'];
 
@@ -480,11 +483,11 @@ export class PlaywrightBinary extends AbstractBinary {
         let browserDirname = browser.name;
         if (browser.name === 'chromium-headless-shell') {
           // chromium-headless-shell should be under chromium
-          // https://playwright.azureedge.net/builds/chromium/1155/chromium-headless-shell-mac-arm64.zip
+          // https://cdn.playwright.dev/builds/chromium/1155/chromium-headless-shell-mac-arm64.zip
           browserDirname = 'chromium';
         } else if (browser.name === 'chromium-tip-of-tree-headless-shell') {
           // chromium-tip-of-tree-headless-shell should be under chromium-tip-of-tree
-          // https://playwright.azureedge.net/builds/chromium-tip-of-tree/1293/chromium-tip-of-tree-headless-shell-mac-arm64.zip
+          // https://cdn.playwright.dev/builds/chromium-tip-of-tree/1293/chromium-tip-of-tree-headless-shell-mac-arm64.zip
           browserDirname = 'chromium-tip-of-tree';
         }
         for (const [platform, remotePath] of Object.entries(downloadPaths)) {

--- a/test/common/adapter/binary/PlaywrightBinary.test.ts
+++ b/test/common/adapter/binary/PlaywrightBinary.test.ts
@@ -100,7 +100,7 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
         assert.equal(item.isDir, false);
         assert.match(
           item.url,
-          /https:\/\/playwright\.azureedge\.net\/builds\/cft\/133\.0\.6943\.16\/mac-arm64\/(chrome|chrome-headless-shell)-mac-arm64\.zip/,
+          /https:\/\/cdn\.playwright\.dev\/builds\/cft\/133\.0\.6943\.16\/mac-arm64\/(chrome|chrome-headless-shell)-mac-arm64\.zip/,
         );
       }
 
@@ -110,7 +110,7 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
       assert.ok(chromiumRevResult);
       const linuxArm64 = chromiumRevResult.items.find((item) => item.name === 'chromium-linux-arm64.zip');
       assert.ok(linuxArm64, 'chromium-linux-arm64.zip should still live at /builds/chromium/1155/');
-      assert.equal(linuxArm64.url, 'https://playwright.azureedge.net/builds/chromium/1155/chromium-linux-arm64.zip');
+      assert.equal(linuxArm64.url, 'https://cdn.playwright.dev/builds/chromium/1155/chromium-linux-arm64.zip');
     });
 
     it('should fetch subdir: /builds/, /builds/chromium/ work', async () => {
@@ -156,10 +156,7 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
             assert.ok(item.size === '-');
             assert.ok(item.url);
             assert.ok(item.date);
-            assert.match(
-              item.url,
-              /https:\/\/playwright\.azureedge\.net\/builds\/driver\/(?:next\/)?playwright-\S+-\S+.zip/,
-            );
+            assert.match(item.url, /https:\/\/cdn\.playwright\.dev\/builds\/driver\/(?:next\/)?playwright-\S+-\S+.zip/);
           }
         }
       }
@@ -193,7 +190,7 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
           // {
           //   name: 'chromium-linux.zip',
           //   isDir: false,
-          //   url: 'https://playwright.azureedge.net/builds/chromium/1000/chromium-linux.zip',
+          //   url: 'https://cdn.playwright.dev/builds/chromium/1000/chromium-linux.zip',
           //   size: '-',
           //   date: '2022-04-18T20:51:53.788Z'
           // },
@@ -204,16 +201,13 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
           assert.ok(item.date);
           if (dirname === 'chromium' && item.name.startsWith('chromium-headless-shell')) {
             // chromium should include chromium-headless-shell
-            assert.match(
-              item.url,
-              /https:\/\/playwright\.azureedge\.net\/builds\/chromium\/\d+\/chromium-headless-shell/,
-            );
+            assert.match(item.url, /https:\/\/cdn\.playwright\.dev\/builds\/chromium\/\d+\/chromium-headless-shell/);
             shouldIncludeChromiumHeadlessShell = true;
           }
           if (dirname === 'chromium-tip-of-tree' && item.name.startsWith('chromium-tip-of-tree-headless-shell')) {
             assert.match(
               item.url,
-              /https:\/\/playwright\.azureedge\.net\/builds\/chromium-tip-of-tree\/\d+\/chromium-tip-of-tree-headless-shell/,
+              /https:\/\/cdn\.playwright\.dev\/builds\/chromium-tip-of-tree\/\d+\/chromium-tip-of-tree-headless-shell/,
             );
             shouldIncludeChromiumTipOfTreeHeadlessShell = true;
           }


### PR DESCRIPTION
## 问题

playwright >= 1.58 的 chromium 从镜像下载会 404：`binaries/playwright/builds/cft/{browserVersion}/...` 目录为空，从未被同步落盘。

## 根因

`PlaywrightBinary` 的上游 `DOWNLOAD_HOST` 用的是已废弃的 `playwright.azureedge.net`。实测（跟随 307 重定向）：

| 上游路径 | azureedge | cdn.playwright.dev |
|---|---|---|
| `builds/chromium/1200/...`（老，≤1.57） | 200 | 200 |
| `builds/cft/145.0.7632.6/mac-arm64/...`（新，1.58.1+） | **400** ❌ | **200** ✅ |

azureedge 只认老的 `builds/*`，**不认 playwright 1.58.1 起启用的 `builds/cft/*` 新命名空间**。所以同步 worker 抓 CFT 产物时拿到 400，chromium 二进制永远进不了镜像。

补充确认：playwright 从 1.58 起不再发布老结构 `builds/chromium/{rev}`（`cdn.playwright.dev/builds/chromium/1208` 也 404），1.58+ 的 chromium **只存在于 CFT 路径**，没有旧目录可回退——所以必须把 CFT 同步跑通。

## 改动

`DOWNLOAD_HOST` 从 `https://playwright.azureedge.net/` 换成 `https://cdn.playwright.dev/`，并同步更新测试断言。

已验证 cdn.playwright.dev 对 driver / firefox / webkit / ffmpeg / 老 chromium / 新 cft chromium **全部 200**，是 azureedge 的安全超集，不影响已有同步。

合并后需触发一次 playwright binary 重新同步，`builds/cft/` 产物才会落盘。

> 配套修复：cnpm/binary-mirror-config#71（把 `PLAYWRIGHT_CHROMIUM_DOWNLOAD_HOST` 从错误的 `chrome-for-testing` 指向移除，修复 ≤1.57 的回归）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)