### PR TITLE
feat: support custom dependency isolation policy

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -54,11 +54,14 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - name: Setup utoo
+      uses: utooland/setup-utoo@v1
+
     - name: Install Dependencies
-      run: npm i -g npminstall && npminstall
+      run: ut
 
     - name: Continuous Integration
-      run: npm run ci:postgresql
+      run: ut ci:postgresql
       env:
         # The hostname used to communicate with the PostgreSQL service container
         POSTGRES_HOST: localhost
@@ -106,11 +109,14 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - name: Setup utoo
+      uses: utooland/setup-utoo@v1
+
     - name: Install Dependencies
-      run: npm i -g npminstall && npminstall
+      run: ut
 
     - name: Continuous Integration
-      run: npm run ci
+      run: ut ci
 
     - name: Code Coverage
       uses: codecov/codecov-action@v3

--- a/INTEGRATE.md
+++ b/INTEGRATE.md
@@ -210,6 +210,7 @@ export class MyAuthAdapter extends AuthAdapter {
 ### 自定义依赖冷静期
 
 开启 `enableDependencyIsolation` 后，集成侧可以重载 `DependencyIsolationAdapter`，为不同包版本返回自定义的冷静期截止时间和拦截文案。返回 `null` 表示该版本不进入冷静期。
+集成侧未提供 `dependencyIsolationAdapter` 时会自动使用默认策略，默认 reason 中的释放时间使用 GMT+8（`+08:00`）。
 
 ```typescript
 import { AccessLevel, SingletonProto } from '@eggjs/tegg';

--- a/INTEGRATE.md
+++ b/INTEGRATE.md
@@ -207,6 +207,37 @@ export class MyAuthAdapter extends AuthAdapter {
 
 ```
 
+### 自定义依赖冷静期
+
+开启 `enableDependencyIsolation` 后，集成侧可以重载 `DependencyIsolationAdapter`，为不同包版本返回自定义的冷静期截止时间和拦截文案。返回 `null` 表示该版本不进入冷静期。
+
+```typescript
+import { AccessLevel, SingletonProto } from '@eggjs/tegg';
+import {
+  DependencyIsolationAdapter,
+} from 'cnpmcore/infra/DependencyIsolationAdapter';
+import {
+  DependencyIsolationContext,
+  DependencyIsolationPolicy,
+} from 'cnpmcore/common/typing';
+
+@SingletonProto({
+  name: 'dependencyIsolationAdapter',
+  accessLevel: AccessLevel.PUBLIC,
+})
+export class MyDependencyIsolationAdapter extends DependencyIsolationAdapter {
+  async ensureDependencyIsolation(
+    context: DependencyIsolationContext,
+  ): Promise<DependencyIsolationPolicy | null> {
+    const expiredAt = new Date(Date.now() + 12 * 60 * 60 * 1000);
+    return {
+      expiredAt,
+      reason: `${context.fullname}@${context.version} is waiting for security review`,
+    };
+  }
+}
+```
+
 修改 HelloController 的实现，实际也可以通过登录中心回调、页面确认等方式实现
 
 ```typescript

--- a/app/common/DependencyIsolationUtil.ts
+++ b/app/common/DependencyIsolationUtil.ts
@@ -1,0 +1,14 @@
+import { DependencyIsolationPolicy } from './typing';
+
+const GMT8_OFFSET = 8 * 60 * 60 * 1000;
+
+export function createDefaultDependencyIsolationPolicy(duration?: number): DependencyIsolationPolicy | null {
+  if (!duration || duration <= 0) return null;
+
+  const expiredAt = new Date(Date.now() + duration);
+  const expiredAtGMT8 = `${new Date(expiredAt.getTime() + GMT8_OFFSET).toISOString().slice(0, -1)}+08:00`;
+  return {
+    expiredAt,
+    reason: `[buffer] in dependency isolation zone, release at ${expiredAtGMT8}`,
+  };
+}

--- a/app/common/typing.ts
+++ b/app/common/typing.ts
@@ -71,6 +71,21 @@ export interface AuthClient {
   ensureCurrentUser(): Promise<userResult | null>;
 }
 
+export interface DependencyIsolationContext {
+  fullname: string;
+  version: string;
+  publishTime?: Date;
+}
+
+export interface DependencyIsolationPolicy {
+  expiredAt: Date;
+  reason: string;
+}
+
+export interface DependencyIsolationClient {
+  ensureDependencyIsolation(context: DependencyIsolationContext): Promise<DependencyIsolationPolicy | null>;
+}
+
 declare module 'egg' {
   // eslint-disable-next-line
   // @ts-ignore

--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -12,6 +12,7 @@ import npa from 'npm-package-arg';
 import semver from 'semver';
 import pMap from 'p-map';
 import { NPMRegistry } from '../../common/adapter/NPMRegistry';
+import { DependencyIsolationClient, DependencyIsolationPolicy } from '../../common/typing';
 import {
   calculateIntegrity,
   detectInstallScript,
@@ -102,6 +103,8 @@ export class PackageManagerService extends AbstractService {
   private readonly npmRegistry: NPMRegistry;
   @Inject()
   private readonly packageVersionService: PackageVersionService;
+  @Inject({ name: 'dependencyIsolationAdapter' })
+  private readonly dependencyIsolationAdapter: DependencyIsolationClient;
 
   private static downloadCounters = {};
 
@@ -281,10 +284,11 @@ export class PackageManagerService extends AbstractService {
       throw e;
     }
     // dependency isolation (buffer) zone: hold a newly synced version invisible for a while
-    // before it is auto-released. Decide first (pure), so PACKAGE_VERSION_ADDED is suppressed
+    // before it is auto-released. Resolve the policy first, so PACKAGE_VERSION_ADDED is suppressed
     // — the event (and thus search index / changes stream / file sync) fires only when the
     // version is released. see RFC: https://github.com/cnpm/cnpmcore/issues/1057
-    const shouldIsolate = this._shouldIsolateNewVersion(pkg, cmd);
+    const dependencyIsolationPolicy = await this._ensureDependencyIsolation(pkg, cmd);
+    const shouldIsolate = dependencyIsolationPolicy !== null;
 
     if (cmd.skipRefreshPackageManifests !== true) {
       await this.refreshPackageChangeVersionsToDists(pkg, [ pkgVersion.version ]);
@@ -306,35 +310,44 @@ export class PackageManagerService extends AbstractService {
     // before the refresh — avoids the new-package case where the only version is isolated and
     // manifestsDist is never created (which crashes savePackageTag).
     if (shouldIsolate) {
-      await this._isolateNewVersion(pkg, cmd, pkgVersion.version);
+      await this._isolateNewVersion(pkg, cmd, pkgVersion.version, dependencyIsolationPolicy);
     }
 
     return pkgVersion;
   }
 
   // Decide whether a newly published/synced version should enter the dependency isolation buffer.
-  private _shouldIsolateNewVersion(pkg: Package, cmd: PublishPackageCmd): boolean {
+  private async _ensureDependencyIsolation(
+    pkg: Package,
+    cmd: PublishPackageCmd,
+  ): Promise<DependencyIsolationPolicy | null> {
     const config = this.config.cnpmcore;
-    if (!config.enableDependencyIsolation) return false;
+    if (!config.enableDependencyIsolation) return null;
     // buffer enforcement reuses version-level block; without it the version can't be hidden
-    if (!config.enableBlockPackageVersion) return false;
-    const duration = config.dependencyIsolationDuration;
-    if (!duration || duration <= 0) return false;
+    if (!config.enableBlockPackageVersion) return null;
     // only isolate external/synced (public) versions, never user-published private packages
-    if (cmd.isPrivate) return false;
+    if (cmd.isPrivate) return null;
     // allowlist: trusted packages skip the buffer (analogous to pnpm minimumReleaseAgeExclude)
-    if (this._isDependencyIsolationExcluded(pkg.fullname)) return false;
-    return true;
+    if (this._isDependencyIsolationExcluded(pkg.fullname)) return null;
+    return await this.dependencyIsolationAdapter.ensureDependencyIsolation({
+      fullname: pkg.fullname,
+      version: cmd.version,
+      publishTime: cmd.publishTime,
+    });
   }
 
   // Persist a buffer block record (type='buffer', expiredAt) and hide the version from the manifest.
-  private async _isolateNewVersion(pkg: Package, cmd: PublishPackageCmd, version: string): Promise<void> {
-    const duration = this.config.cnpmcore.dependencyIsolationDuration as number;
-    const expiredAt = new Date(Date.now() + duration);
+  private async _isolateNewVersion(
+    pkg: Package,
+    cmd: PublishPackageCmd,
+    version: string,
+    policy: DependencyIsolationPolicy,
+  ): Promise<void> {
+    const { expiredAt, reason } = policy;
     const block = PackageVersionBlock.create({
       packageId: pkg.packageId,
       version,
-      reason: `[buffer] in dependency isolation zone, release at ${expiredAt.toISOString()}`,
+      reason,
       type: PACKAGE_VERSION_BLOCK_TYPE_BUFFER,
       expiredAt,
     });

--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -12,6 +12,7 @@ import npa from 'npm-package-arg';
 import semver from 'semver';
 import pMap from 'p-map';
 import { NPMRegistry } from '../../common/adapter/NPMRegistry';
+import { createDefaultDependencyIsolationPolicy } from '../../common/DependencyIsolationUtil';
 import { DependencyIsolationClient, DependencyIsolationPolicy } from '../../common/typing';
 import {
   calculateIntegrity,
@@ -103,8 +104,8 @@ export class PackageManagerService extends AbstractService {
   private readonly npmRegistry: NPMRegistry;
   @Inject()
   private readonly packageVersionService: PackageVersionService;
-  @Inject({ name: 'dependencyIsolationAdapter' })
-  private readonly dependencyIsolationAdapter: DependencyIsolationClient;
+  @Inject({ name: 'dependencyIsolationAdapter', optional: true })
+  private readonly dependencyIsolationAdapter?: DependencyIsolationClient;
 
   private static downloadCounters = {};
 
@@ -329,11 +330,14 @@ export class PackageManagerService extends AbstractService {
     if (cmd.isPrivate) return null;
     // allowlist: trusted packages skip the buffer (analogous to pnpm minimumReleaseAgeExclude)
     if (this._isDependencyIsolationExcluded(pkg.fullname)) return null;
-    return await this.dependencyIsolationAdapter.ensureDependencyIsolation({
-      fullname: pkg.fullname,
-      version: cmd.version,
-      publishTime: cmd.publishTime,
-    });
+    if (this.dependencyIsolationAdapter) {
+      return await this.dependencyIsolationAdapter.ensureDependencyIsolation({
+        fullname: pkg.fullname,
+        version: cmd.version,
+        publishTime: cmd.publishTime,
+      });
+    }
+    return createDefaultDependencyIsolationPolicy(config.dependencyIsolationDuration);
   }
 
   // Persist a buffer block record (type='buffer', expiredAt) and hide the version from the manifest.

--- a/app/infra/DependencyIsolationAdapter.ts
+++ b/app/infra/DependencyIsolationAdapter.ts
@@ -1,0 +1,34 @@
+import {
+  AccessLevel,
+  Inject,
+  SingletonProto,
+} from '@eggjs/tegg';
+import { EggAppConfig } from 'egg';
+import {
+  DependencyIsolationClient,
+  DependencyIsolationContext,
+  DependencyIsolationPolicy,
+} from '../common/typing';
+
+@SingletonProto({
+  accessLevel: AccessLevel.PUBLIC,
+  name: 'dependencyIsolationAdapter',
+})
+export class DependencyIsolationAdapter implements DependencyIsolationClient {
+  @Inject()
+  private readonly config: EggAppConfig;
+
+  async ensureDependencyIsolation(
+    context: DependencyIsolationContext,
+  ): Promise<DependencyIsolationPolicy | null> {
+    void context;
+    const duration = this.config.cnpmcore.dependencyIsolationDuration;
+    if (!duration || duration <= 0) return null;
+
+    const expiredAt = new Date(Date.now() + duration);
+    return {
+      expiredAt,
+      reason: `[buffer] in dependency isolation zone, release at ${expiredAt.toISOString()}`,
+    };
+  }
+}

--- a/app/infra/DependencyIsolationAdapter.ts
+++ b/app/infra/DependencyIsolationAdapter.ts
@@ -4,6 +4,7 @@ import {
   SingletonProto,
 } from '@eggjs/tegg';
 import { EggAppConfig } from 'egg';
+import { createDefaultDependencyIsolationPolicy } from '../common/DependencyIsolationUtil';
 import {
   DependencyIsolationClient,
   DependencyIsolationContext,
@@ -22,13 +23,6 @@ export class DependencyIsolationAdapter implements DependencyIsolationClient {
     context: DependencyIsolationContext,
   ): Promise<DependencyIsolationPolicy | null> {
     void context;
-    const duration = this.config.cnpmcore.dependencyIsolationDuration;
-    if (!duration || duration <= 0) return null;
-
-    const expiredAt = new Date(Date.now() + duration);
-    return {
-      expiredAt,
-      reason: `[buffer] in dependency isolation zone, release at ${expiredAt.toISOString()}`,
-    };
+    return createDefaultDependencyIsolationPolicy(this.config.cnpmcore.dependencyIsolationDuration);
   }
 }

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "@simplewebauthn/typescript-types": "^7.0.0",
     "@types/lodash": "^4.14.196",
     "@types/mime-types": "^2.1.1",
+    "@types/minimatch": "^5",
     "@types/mocha": "^10.0.1",
     "@types/mysql": "^2.15.21",
     "@types/node-rsa": "^1.1.4",

--- a/test/core/service/PackageManagerService/dependencyIsolation.test.ts
+++ b/test/core/service/PackageManagerService/dependencyIsolation.test.ts
@@ -159,6 +159,14 @@ describe('test/core/service/PackageManagerService/dependencyIsolation.test.ts', 
       assert.equal(await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0'), null);
     });
 
+    it('should use the default GMT+8 policy when the integration adapter is not registered', async () => {
+      mock(packageManagerService as any, 'dependencyIsolationAdapter', null);
+      const { packageId } = await publishVersion('foo', '1.0.0', false);
+      const block = await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0');
+      assert(block);
+      assert.match(block.reason, /release at \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+08:00$/);
+    });
+
     it('should allow integration to customize expiredAt and reason', async () => {
       const expiredAt = new Date(Date.now() + 12 * 3600 * 1000);
       mock(dependencyIsolationAdapter, 'ensureDependencyIsolation', async context => {

--- a/test/core/service/PackageManagerService/dependencyIsolation.test.ts
+++ b/test/core/service/PackageManagerService/dependencyIsolation.test.ts
@@ -7,12 +7,14 @@ import { PackageVersionBlockRepository } from '../../../../app/repository/Packag
 import { PackageVersionBlock, PACKAGE_VERSION_BLOCK_TYPE_BUFFER } from '../../../../app/core/entity/PackageVersionBlock';
 import { UserService } from '../../../../app/core/service/UserService';
 import { getScopeAndName } from '../../../../app/common/PackageUtil';
+import { DependencyIsolationAdapter } from '../../../../app/infra/DependencyIsolationAdapter';
 
 describe('test/core/service/PackageManagerService/dependencyIsolation.test.ts', () => {
   let packageManagerService: PackageManagerService;
   let packageRepository: PackageRepository;
   let packageVersionBlockRepository: PackageVersionBlockRepository;
   let userService: UserService;
+  let dependencyIsolationAdapter: DependencyIsolationAdapter;
   let publisher;
 
   beforeEach(async () => {
@@ -20,6 +22,7 @@ describe('test/core/service/PackageManagerService/dependencyIsolation.test.ts', 
     packageRepository = await app.getEggObject(PackageRepository);
     packageVersionBlockRepository = await app.getEggObject(PackageVersionBlockRepository);
     userService = await app.getEggObject(UserService);
+    dependencyIsolationAdapter = await app.getEggObject(DependencyIsolationAdapter);
     const { user } = await userService.create({
       name: 'test-user',
       password: 'this-is-password',
@@ -152,6 +155,27 @@ describe('test/core/service/PackageManagerService/dependencyIsolation.test.ts', 
 
     it('should NOT isolate when duration <= 0', async () => {
       mock(app.config.cnpmcore, 'dependencyIsolationDuration', 0);
+      const { packageId } = await publishVersion('foo', '1.0.0', false);
+      assert.equal(await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0'), null);
+    });
+
+    it('should allow integration to customize expiredAt and reason', async () => {
+      const expiredAt = new Date(Date.now() + 12 * 3600 * 1000);
+      mock(dependencyIsolationAdapter, 'ensureDependencyIsolation', async context => {
+        assert.equal(context.fullname, 'foo');
+        assert.equal(context.version, '1.0.0');
+        return { expiredAt, reason: '[custom] waiting for security scan' };
+      });
+
+      const { packageId } = await publishVersion('foo', '1.0.0', false);
+      const block = await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0');
+      assert(block);
+      assert.equal(block.expiredAt?.getTime(), expiredAt.getTime());
+      assert.equal(block.reason, '[custom] waiting for security scan');
+    });
+
+    it('should allow integration to skip dependency isolation', async () => {
+      mock(dependencyIsolationAdapter, 'ensureDependencyIsolation', async () => null);
       const { packageId } = await publishVersion('foo', '1.0.0', false);
       assert.equal(await packageVersionBlockRepository.findPackageVersionBlockExact(packageId, '1.0.0'), null);
     });


### PR DESCRIPTION
## What changed

- add a public `DependencyIsolationAdapter` that integration projects can override through the `dependencyIsolationAdapter` bean
- allow integrations to customize the dependency isolation `expiredAt` and `reason` for each package version
- allow an integration to return `null` to skip isolation for a version
- preserve the existing configured duration and buffer reason as the default behavior
- document the integration extension and cover custom/skip policies with tests

## Why

The dependency isolation duration and reason were previously hard-coded in `PackageManagerService`. Enterprise integrations need to calculate different cooling periods and user-facing reasons using their own policy systems, similar to how authentication behavior can be customized through an adapter.

## Impact

Existing integrations keep the current behavior without any changes. Integrations that need custom policy can override `DependencyIsolationAdapter.ensureDependencyIsolation()`.

## Validation

- `ut run tsc`
- `ut run lint -- --no-cache`
- `git diff --check`
- `PATH=/opt/homebrew/opt/mysql@8.0/bin:$PATH ut run test:local test/core/service/PackageManagerService/dependencyIsolation.test.ts` — 21 passing
