### PR TITLE
fix: retrigger 3.x release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,5 @@ jobs:
   release:
     name: NPM
     uses: node-modules/github-actions/.github/workflows/npm-release.yml@master
-    with:
-      # Fail before semantic-release creates the release commit and tag if
-      # compilation fails. Keep this in sync with the reusable workflow default.
-      install: npm i --no-package-lock --no-fund --force && rm -rf package-lock.json && npm run prepublishOnly
     secrets:
       GIT_TOKEN: ${{ secrets.GIT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
     name: NPM
     uses: node-modules/github-actions/.github/workflows/npm-release.yml@master
     with:
-      # Keep the release dependency tree consistent with CI, and fail before
-      # semantic-release creates the release commit and tag if compilation fails.
-      install: npx --yes utoo@1.1.3 && npx --yes utoo@1.1.3 run prepublishOnly
+      # Fail before semantic-release creates the release commit and tag if
+      # compilation fails. Keep this in sync with the reusable workflow default.
+      install: npm i --no-package-lock --no-fund --force && rm -rf package-lock.json && npm run prepublishOnly
     secrets:
       GIT_TOKEN: ${{ secrets.GIT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,5 +14,9 @@ jobs:
   release:
     name: NPM
     uses: node-modules/github-actions/.github/workflows/npm-release.yml@master
+    with:
+      # Keep the release dependency tree consistent with CI, and fail before
+      # semantic-release creates the release commit and tag if compilation fails.
+      install: npx --yes utoo@1.1.3 && npx --yes utoo@1.1.3 run prepublishOnly
     secrets:
       GIT_TOKEN: ${{ secrets.GIT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Reimplement based on [cnpmjs.org](https://github.com/cnpm/cnpmjs.org) with TypeS
 
 ## Registry HTTP API
 
-See [registry-api.md](docs/registry-api.md)
+See the [registry-api.md](docs/registry-api.md) documentation.
 
 ## How to contribute
 


### PR DESCRIPTION
## Summary

- clarify the Registry HTTP API documentation link in README
- retrigger the 3.x release after cleaning up the failed `v3.84.0` tag

No release workflow or runtime code is changed.