### PR TITLE
fix: retrigger 3.x release

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Reimplement based on [cnpmjs.org](https://github.com/cnpm/cnpmjs.org) with TypeS
 
 ## Registry HTTP API
 
-See the [registry-api.md](docs/registry-api.md) documentation.
+Refer to the [registry-api.md](docs/registry-api.md) documentation.
 
 ## How to contribute
 


### PR DESCRIPTION
## Summary

- make a no-op README wording adjustment
- trigger a fresh 3.x release run after removing the failed `v3.84.0` tag

No runtime or workflow behavior is changed. Please merge this PR instead of rerunning the previous release run.