### PR TITLE
fix: allow Egg typings generation during install

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     "start:foreground": "eggctl start",
     "stop": "rm -f egg.status && sleep 15 && eggctl stop"
   },
+  "allowScripts": {
+    "egg-bin": true
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:cnpm/cnpmcore.git"
@@ -133,6 +136,7 @@
     "@types/minimatch": "^5",
     "@types/mocha": "^10.0.1",
     "@types/mysql": "^2.15.21",
+    "@types/node": "^20",
     "@types/node-rsa": "^1.1.4",
     "@types/npm-package-arg": "^6.1.1",
     "@types/pg": "^8.11.10",


### PR DESCRIPTION
## Summary

- allow the `egg-bin` dependency postinstall script under npm lifecycle-script protection
- pin the project TypeScript environment to Node.js 20 types
- restore Egg/Tegg plugin typings generation in clean release installs

## Root cause

npm blocked `egg-bin@6.13.0` postinstall because it was not listed in `allowScripts`. As a result, `egg-ts-helper` did not create `typings/config/plugin.d.ts`, causing 270 Tegg/Leoric type errors during `prepublishOnly`. The unpinned Node types also caused four stream/async-iterator errors in the Node 24 release environment.

## Verification

- removed the ignored `typings/` directory and reproduced 270 TypeScript errors with `ut run prepublishOnly`
- ran the exact `egg-bin` postinstall and confirmed `typings/config/plugin.d.ts` was generated
- removed `typings/`, ran `ut rebuild`, then `ut run prepublishOnly` successfully