### PR TITLE
feat: add viceme-cli binary mirror

### DIFF
--- a/config/binaries.ts
+++ b/config/binaries.ts
@@ -993,6 +993,13 @@ const binaries = {
     repo: 'larksuite/cli',
     distUrl: 'https://github.com/larksuite/cli/releases',
   },
+  'viceme-cli': {
+    category: 'viceme-cli',
+    description: 'ViceMe CLI - Build and publish stable Skill Agents',
+    type: BinaryType.GitHub,
+    repo: 'ViceMe-AI/cli',
+    distUrl: 'https://github.com/ViceMe-AI/cli/releases',
+  },
 } as const;
 
 export interface BinaryTaskConfig {


### PR DESCRIPTION
## Summary

- register `viceme-cli` as a GitHub release binary
- mirror immutable release assets from `ViceMe-AI/cli`
- expose them under `/-/binary/viceme-cli/` after cnpmcore deployment and synchronization

## Verification

- `npm run fmtcheck`
- `npm run typecheck`
- verified the public [ViceMe-AI/cli v0.2.0 release](https://github.com/ViceMe-AI/cli/releases/tag/v0.2.0) contains macOS, Linux, and Windows assets plus SHA-256 files

## Rollout

As with `lark-cli`, the binary configuration needs to be deployed and the initial synchronization triggered after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Viceme CLI binary, including its download source and distribution configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->