### PR TITLE
docs: add swagger api docs.

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2775,7 +2775,6 @@
         "required": true,
         "description": "Package full name. Scoped names contain a literal slash, for example `@scope/pkg`. Send the slash literally; do not percent-encode it. For GET `/foo/sync`, the package-version route is selected with `versionSpec=sync`; the legacy synchronization endpoint only handles PUT `/foo/sync`.",
         "example": "@scope/pkg",
-        "allowReserved": true,
         "schema": {
           "$ref": "#/components/schemas/PackageName"
         }
@@ -2826,7 +2825,6 @@
         "required": true,
         "description": "File path inside the package, including literal slash separators, for example `lib/index.js`. Send the slashes literally; do not percent-encode them.",
         "example": "lib/index.js",
-        "allowReserved": true,
         "schema": {
           "type": "string"
         }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,2836 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "cnpmcore HTTP API",
+    "version": "4.34.1",
+    "description": "The complete HTTP API exposed by cnpmcore, including npm registry\ncompatibility endpoints and cnpmcore administration APIs.\n",
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/cnpm/cnpmcore/blob/master/LICENSE"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://localhost:7001",
+      "description": "Local development server"
+    }
+  ],
+  "security": [],
+  "tags": [
+    {
+      "name": "Registry"
+    },
+    {
+      "name": "Packages"
+    },
+    {
+      "name": "Search"
+    },
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "Organization"
+    },
+    {
+      "name": "Team"
+    },
+    {
+      "name": "Token"
+    },
+    {
+      "name": "Hook"
+    },
+    {
+      "name": "Synchronization"
+    },
+    {
+      "name": "Binary"
+    },
+    {
+      "name": "Download"
+    },
+    {
+      "name": "Administration"
+    },
+    {
+      "name": "Proxy cache"
+    },
+    {
+      "name": "WebAuthn"
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "tags": ["Registry"],
+        "summary": "Show registry information",
+        "operationId": "showRegistryInfo",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/ping": {
+      "get": {
+        "tags": ["Registry"],
+        "summary": "Check registry availability",
+        "operationId": "ping",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/binary.html": {
+      "get": {
+        "tags": ["Binary"],
+        "summary": "Show the binary browser page",
+        "operationId": "showBinaryHtml",
+        "responses": {
+          "200": {
+            "description": "HTML page.",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/-/binary": {
+      "get": {
+        "tags": ["Binary"],
+        "summary": "List binary distributions",
+        "operationId": "listBinaries",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/JsonArray"
+          }
+        }
+      }
+    },
+    "/-/binary/{binaryName}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/BinaryName"
+        }
+      ],
+      "get": {
+        "tags": ["Binary"],
+        "summary": "Show a binary distribution index",
+        "operationId": "showBinaryIndex",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Since"
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/binary/{binaryName}/{subpath}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/BinaryName"
+        },
+        {
+          "$ref": "#/components/parameters/Subpath"
+        }
+      ],
+      "get": {
+        "tags": ["Binary"],
+        "summary": "Browse a binary distribution path",
+        "operationId": "showBinary",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Since"
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/binary/{binaryName}/sync": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/BinaryName"
+        }
+      ],
+      "post": {
+        "tags": ["Binary", "Synchronization"],
+        "summary": "Synchronize a binary distribution",
+        "operationId": "syncBinary",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/_changes": {
+      "get": {
+        "tags": ["Registry"],
+        "summary": "Read registry changes",
+        "operationId": "listChanges",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Since"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/downloads/point/{range}/{fullname}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Range"
+        },
+        {
+          "$ref": "#/components/parameters/Fullname"
+        }
+      ],
+      "get": {
+        "tags": ["Download"],
+        "summary": "Get package download point data",
+        "operationId": "showPackageDownloadPoint",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/downloads/total/point/{range}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Range"
+        }
+      ],
+      "get": {
+        "tags": ["Download"],
+        "summary": "Get total download point data",
+        "operationId": "showTotalDownloadPoint",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/downloads/range/{range}/{fullname}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Range"
+        },
+        {
+          "$ref": "#/components/parameters/Fullname"
+        }
+      ],
+      "get": {
+        "tags": ["Download"],
+        "summary": "Get package download range data",
+        "operationId": "showPackageDownloads",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/downloads/{scope}/{range}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Scope"
+        },
+        {
+          "$ref": "#/components/parameters/Range"
+        }
+      ],
+      "get": {
+        "tags": ["Download"],
+        "summary": "Get scoped download data",
+        "operationId": "showTotalDownloads",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/{fullname}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        }
+      ],
+      "get": {
+        "tags": ["Packages"],
+        "summary": "Show a package",
+        "operationId": "showPackageByFullname",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Package"
+          }
+        }
+      },
+      "put": {
+        "tags": ["Packages"],
+        "summary": "Publish or replace a package manifest",
+        "operationId": "publishPackage",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Package"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/{fullname}/{versionSpec}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        },
+        {
+          "$ref": "#/components/parameters/VersionSpec"
+        }
+      ],
+      "get": {
+        "tags": ["Packages"],
+        "summary": "Show a package version or tag",
+        "operationId": "showPackageVersion",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/{fullname}/-rev/{rev}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        },
+        {
+          "$ref": "#/components/parameters/Revision"
+        }
+      ],
+      "put": {
+        "tags": ["Packages"],
+        "summary": "Update package maintainers",
+        "operationId": "updatePackage",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Packages"],
+        "summary": "Remove a package version",
+        "operationId": "removePackageVersion",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/{fullname}/-/{filenameWithVersion}.tgz": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        },
+        {
+          "$ref": "#/components/parameters/FilenameWithVersion"
+        }
+      ],
+      "options": {
+        "tags": ["Packages"],
+        "summary": "Preflight package tarball download",
+        "operationId": "packageTarballOptions",
+        "responses": {
+          "204": {
+            "$ref": "#/components/responses/Empty"
+          }
+        }
+      },
+      "get": {
+        "tags": ["Packages"],
+        "summary": "Download a package tarball",
+        "operationId": "downloadPackageTarball",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Tarball"
+          }
+        }
+      }
+    },
+    "/{fullname}/download/{fullnameWithVersion}.tgz": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        },
+        {
+          "$ref": "#/components/parameters/FullnameWithVersion"
+        }
+      ],
+      "get": {
+        "tags": ["Packages"],
+        "summary": "Download a package tarball using the legacy path",
+        "operationId": "deprecatedDownloadPackageTarball",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Tarball"
+          }
+        }
+      }
+    },
+    "/{fullname}/-/{scope}/{filenameWithVersion}.tgz": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        },
+        {
+          "$ref": "#/components/parameters/Scope"
+        },
+        {
+          "$ref": "#/components/parameters/FilenameWithVersion"
+        }
+      ],
+      "options": {
+        "tags": ["Packages"],
+        "summary": "Preflight Verdaccio-compatible tarball download",
+        "operationId": "verdaccioTarballOptions",
+        "responses": {
+          "204": {
+            "$ref": "#/components/responses/Empty"
+          }
+        }
+      },
+      "get": {
+        "tags": ["Packages"],
+        "summary": "Download a package tarball using the Verdaccio path",
+        "operationId": "downloadVerdaccioTarball",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Tarball"
+          }
+        }
+      }
+    },
+    "/{fullname}/-/{filenameWithVersion}.tgz/-rev/{rev}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        },
+        {
+          "$ref": "#/components/parameters/FilenameWithVersion"
+        },
+        {
+          "$ref": "#/components/parameters/Revision"
+        }
+      ],
+      "delete": {
+        "tags": ["Packages"],
+        "summary": "Remove a package version using a tarball URL",
+        "operationId": "removePackageVersionByTarball",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/package/{fullname}/dist-tags": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        }
+      ],
+      "get": {
+        "tags": ["Packages"],
+        "summary": "List package distribution tags",
+        "operationId": "listPackageTags",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/package/{fullname}/dist-tags/{tag}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        },
+        {
+          "$ref": "#/components/parameters/Tag"
+        }
+      ],
+      "put": {
+        "tags": ["Packages"],
+        "summary": "Set a package distribution tag",
+        "operationId": "savePackageTag",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Packages"],
+        "summary": "Remove a package distribution tag",
+        "operationId": "removePackageTag",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/package/{fullname}/blocks": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        }
+      ],
+      "put": {
+        "tags": ["Administration"],
+        "summary": "Block a package",
+        "operationId": "blockPackage",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/BlockPackage"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Administration"],
+        "summary": "Unblock a package",
+        "operationId": "unblockPackage",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "get": {
+        "tags": ["Administration"],
+        "summary": "List package blocks",
+        "operationId": "listPackageBlocks",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/JsonArray"
+          }
+        }
+      }
+    },
+    "/-/package/{fullname}/blocks/{version}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        },
+        {
+          "$ref": "#/components/parameters/Version"
+        }
+      ],
+      "put": {
+        "tags": ["Administration"],
+        "summary": "Block a package version",
+        "operationId": "blockPackageVersion",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/BlockPackage"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Administration"],
+        "summary": "Unblock a package version",
+        "operationId": "unblockPackageVersion",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/package/{fullname}/collaborators": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        }
+      ],
+      "get": {
+        "tags": ["Packages"],
+        "summary": "List package collaborators",
+        "operationId": "listCollaborators",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/JsonArray"
+          }
+        }
+      }
+    },
+    "/-/package/{fullname}/syncs": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        }
+      ],
+      "put": {
+        "tags": ["Synchronization"],
+        "summary": "Create a package synchronization task",
+        "operationId": "createSyncTask",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SyncPackage"
+        },
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/Task"
+          }
+        }
+      }
+    },
+    "/-/package/{fullname}/syncs/{taskId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        },
+        {
+          "$ref": "#/components/parameters/TaskId"
+        }
+      ],
+      "get": {
+        "tags": ["Synchronization"],
+        "summary": "Show a package synchronization task",
+        "operationId": "showSyncTask",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Task"
+          }
+        }
+      }
+    },
+    "/-/package/{fullname}/syncs/{taskId}/log": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        },
+        {
+          "$ref": "#/components/parameters/TaskId"
+        }
+      ],
+      "get": {
+        "tags": ["Synchronization"],
+        "summary": "Show a package synchronization task log",
+        "operationId": "showSyncTaskLog",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Text"
+          }
+        }
+      }
+    },
+    "/{fullname}/sync": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        }
+      ],
+      "put": {
+        "tags": ["Synchronization"],
+        "summary": "Create a legacy package synchronization task",
+        "operationId": "deprecatedCreateSyncTask",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Nodeps"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/{fullname}/sync/log/{taskId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        },
+        {
+          "$ref": "#/components/parameters/TaskId"
+        }
+      ],
+      "get": {
+        "tags": ["Synchronization"],
+        "summary": "Show a legacy synchronization task log",
+        "operationId": "deprecatedShowSyncTask",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/v1/search": {
+      "get": {
+        "tags": ["Search"],
+        "summary": "Search packages",
+        "operationId": "searchPackages",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Text"
+          },
+          {
+            "$ref": "#/components/parameters/From"
+          },
+          {
+            "$ref": "#/components/parameters/Size"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/v1/search/sync/{fullname}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        }
+      ],
+      "put": {
+        "tags": ["Search"],
+        "summary": "Synchronize a package into search",
+        "operationId": "syncSearchPackage",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Search"],
+        "summary": "Delete a package from search",
+        "operationId": "deleteSearchPackage",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/{fullname}/{versionSpec}/files": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        },
+        {
+          "$ref": "#/components/parameters/VersionSpec"
+        }
+      ],
+      "put": {
+        "tags": ["Packages", "Administration"],
+        "summary": "Synchronize package version files",
+        "operationId": "syncPackageVersionFiles",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/JsonArray"
+          }
+        }
+      },
+      "get": {
+        "tags": ["Packages"],
+        "summary": "List package version files",
+        "operationId": "listPackageVersionFiles",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Meta"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          },
+          "302": {
+            "$ref": "#/components/responses/Redirect"
+          }
+        }
+      }
+    },
+    "/{fullname}/{versionSpec}/files/{path}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        },
+        {
+          "$ref": "#/components/parameters/VersionSpec"
+        },
+        {
+          "$ref": "#/components/parameters/FilePath"
+        }
+      ],
+      "get": {
+        "tags": ["Packages"],
+        "summary": "Read a package version file",
+        "operationId": "readPackageVersionFile",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Meta"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/AnyFile"
+          },
+          "302": {
+            "$ref": "#/components/responses/Redirect"
+          }
+        }
+      }
+    },
+    "/-/proxy-cache": {
+      "get": {
+        "tags": ["Proxy cache"],
+        "summary": "List proxy cache packages",
+        "operationId": "listProxyCache",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "$ref": "#/components/parameters/PageIndex"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Proxy cache"],
+        "summary": "Truncate proxy cache",
+        "operationId": "truncateProxyCaches",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/proxy-cache/{fullname}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Fullname"
+        }
+      ],
+      "get": {
+        "tags": ["Proxy cache"],
+        "summary": "Show proxy cache entries",
+        "operationId": "showProxyCaches",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "$ref": "#/components/parameters/PageIndex"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "patch": {
+        "tags": ["Proxy cache"],
+        "summary": "Refresh proxy cache",
+        "operationId": "refreshProxyCaches",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Proxy cache"],
+        "summary": "Remove proxy cache",
+        "operationId": "removeProxyCaches",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/registry": {
+      "get": {
+        "tags": ["Registry"],
+        "summary": "List registries",
+        "operationId": "listRegistries",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "$ref": "#/components/parameters/PageIndex"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "post": {
+        "tags": ["Registry", "Administration"],
+        "summary": "Create a registry",
+        "operationId": "createRegistry",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Registry"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/registry/{id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Id"
+        }
+      ],
+      "get": {
+        "tags": ["Registry"],
+        "summary": "Show registry details",
+        "operationId": "showRegistry",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "patch": {
+        "tags": ["Registry", "Administration"],
+        "summary": "Update a registry",
+        "operationId": "updateRegistry",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Registry", "Administration"],
+        "summary": "Remove a registry",
+        "operationId": "removeRegistry",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/registry/{id}/scopes": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Id"
+        }
+      ],
+      "get": {
+        "tags": ["Registry"],
+        "summary": "List registry scopes",
+        "operationId": "showRegistryScopes",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "$ref": "#/components/parameters/PageIndex"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/registry/{id}/sync": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Id"
+        }
+      ],
+      "post": {
+        "tags": ["Registry", "Synchronization"],
+        "summary": "Create a registry synchronization task",
+        "operationId": "createRegistrySyncTask",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/scope": {
+      "post": {
+        "tags": ["Registry", "Administration"],
+        "summary": "Create a scope",
+        "operationId": "createScope",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Scope"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/scope/{id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Id"
+        }
+      ],
+      "delete": {
+        "tags": ["Registry", "Administration"],
+        "summary": "Remove a scope",
+        "operationId": "removeScope",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/org": {
+      "put": {
+        "tags": ["Organization"],
+        "summary": "Create an organization",
+        "operationId": "createOrg",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/org/{orgName}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/OrgName"
+        }
+      ],
+      "get": {
+        "tags": ["Organization"],
+        "summary": "Show an organization",
+        "operationId": "showOrg",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Organization"],
+        "summary": "Remove an organization",
+        "operationId": "removeOrg",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/org/{orgName}/member": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/OrgName"
+        }
+      ],
+      "get": {
+        "tags": ["Organization"],
+        "summary": "List organization members",
+        "operationId": "listMembers",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/JsonArray"
+          }
+        }
+      },
+      "put": {
+        "tags": ["Organization"],
+        "summary": "Add an organization member",
+        "operationId": "addMember",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/org/{orgName}/member/{username}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/OrgName"
+        },
+        {
+          "$ref": "#/components/parameters/Username"
+        }
+      ],
+      "delete": {
+        "tags": ["Organization"],
+        "summary": "Remove an organization member",
+        "operationId": "removeMember",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/org/{orgName}/member/{username}/team": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/OrgName"
+        },
+        {
+          "$ref": "#/components/parameters/Username"
+        }
+      ],
+      "get": {
+        "tags": ["Organization", "Team"],
+        "summary": "List teams for an organization member",
+        "operationId": "listUserTeams",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/JsonArray"
+          }
+        }
+      }
+    },
+    "/-/org/{username}/package": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Username"
+        }
+      ],
+      "get": {
+        "tags": ["Organization", "Packages"],
+        "summary": "List packages owned by a user",
+        "operationId": "listPackagesByUser",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/JsonArray"
+          }
+        }
+      }
+    },
+    "/-/org/{orgName}/team": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/OrgName"
+        }
+      ],
+      "put": {
+        "tags": ["Team"],
+        "summary": "Create a team",
+        "operationId": "createTeam",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "get": {
+        "tags": ["Team"],
+        "summary": "List organization teams",
+        "operationId": "listTeams",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/JsonArray"
+          }
+        }
+      }
+    },
+    "/-/team/{orgName}/{teamName}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/OrgName"
+        },
+        {
+          "$ref": "#/components/parameters/TeamName"
+        }
+      ],
+      "get": {
+        "tags": ["Team"],
+        "summary": "Show a team",
+        "operationId": "showTeam",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Team"],
+        "summary": "Remove a team",
+        "operationId": "removeTeam",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/team/{orgName}/{teamName}/user": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/OrgName"
+        },
+        {
+          "$ref": "#/components/parameters/TeamName"
+        }
+      ],
+      "get": {
+        "tags": ["Team"],
+        "summary": "List team users",
+        "operationId": "listTeamMembers",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/JsonArray"
+          }
+        }
+      },
+      "put": {
+        "tags": ["Team"],
+        "summary": "Add a team user",
+        "operationId": "addTeamMember",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Team"],
+        "summary": "Remove a team user",
+        "operationId": "removeTeamMember",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/team/{orgName}/{teamName}/member": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/OrgName"
+        },
+        {
+          "$ref": "#/components/parameters/TeamName"
+        }
+      ],
+      "get": {
+        "tags": ["Team"],
+        "summary": "List team users with roles",
+        "operationId": "listTeamMembersWithRole",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/JsonArray"
+          }
+        }
+      }
+    },
+    "/-/team/{orgName}/{teamName}/member/{username}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/OrgName"
+        },
+        {
+          "$ref": "#/components/parameters/TeamName"
+        },
+        {
+          "$ref": "#/components/parameters/Username"
+        }
+      ],
+      "patch": {
+        "tags": ["Team"],
+        "summary": "Update a team member role",
+        "operationId": "updateTeamMemberRole",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/team/{orgName}/{teamName}/package": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/OrgName"
+        },
+        {
+          "$ref": "#/components/parameters/TeamName"
+        }
+      ],
+      "get": {
+        "tags": ["Team", "Packages"],
+        "summary": "List packages accessible to a team",
+        "operationId": "listTeamPackages",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/JsonArray"
+          }
+        }
+      },
+      "put": {
+        "tags": ["Team", "Packages"],
+        "summary": "Grant team package access",
+        "operationId": "grantPackageAccess",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Team", "Packages"],
+        "summary": "Revoke team package access",
+        "operationId": "revokePackageAccess",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/v1/hooks": {
+      "get": {
+        "tags": ["Hook"],
+        "summary": "List hooks",
+        "operationId": "listHooks",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PackageFilter"
+          },
+          {
+            "$ref": "#/components/parameters/Offset"
+          },
+          {
+            "$ref": "#/components/parameters/Limit"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/HookList"
+          }
+        }
+      }
+    },
+    "/v1/hooks/hook": {
+      "post": {
+        "tags": ["Hook"],
+        "summary": "Create a hook",
+        "operationId": "createHook",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Hook"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/v1/hooks/hook/{id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Id"
+        }
+      ],
+      "get": {
+        "tags": ["Hook"],
+        "summary": "Get hook details",
+        "operationId": "getHook",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "put": {
+        "tags": ["Hook"],
+        "summary": "Update a hook",
+        "operationId": "updateHook",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/HookUpdate"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Hook"],
+        "summary": "Delete a hook",
+        "operationId": "deleteHook",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/npm/v1/tokens": {
+      "post": {
+        "tags": ["Token"],
+        "summary": "Create a classic npm token",
+        "operationId": "createToken",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "get": {
+        "tags": ["Token"],
+        "summary": "List classic npm tokens",
+        "operationId": "listTokens",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/JsonArray"
+          }
+        }
+      }
+    },
+    "/-/npm/v1/tokens/token/{tokenKey}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TokenKey"
+        }
+      ],
+      "delete": {
+        "tags": ["Token"],
+        "summary": "Delete a classic npm token",
+        "operationId": "removeToken",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/npm/v1/tokens/gat": {
+      "post": {
+        "tags": ["Token"],
+        "summary": "Create a granular access token",
+        "operationId": "createGranularToken",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "get": {
+        "tags": ["Token"],
+        "summary": "List granular access tokens",
+        "operationId": "listGranularTokens",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/JsonArray"
+          }
+        }
+      }
+    },
+    "/-/npm/v1/tokens/gat/{tokenKey}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TokenKey"
+        }
+      ],
+      "delete": {
+        "tags": ["Token"],
+        "summary": "Delete a granular access token",
+        "operationId": "removeGranularToken",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/user/org.couchdb.user:{username}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Username"
+        }
+      ],
+      "put": {
+        "tags": ["Authentication"],
+        "summary": "Create a user or log in",
+        "operationId": "loginOrCreateUser",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/User"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "get": {
+        "tags": ["Authentication"],
+        "summary": "Show a user",
+        "operationId": "showUser",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/user/token/{token}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Token"
+        }
+      ],
+      "delete": {
+        "tags": ["Authentication"],
+        "summary": "Log out and revoke a token",
+        "operationId": "logout",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/whoami": {
+      "get": {
+        "tags": ["Authentication"],
+        "summary": "Show the authenticated user name",
+        "operationId": "whoami",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/npm/v1/user": {
+      "get": {
+        "tags": ["Authentication"],
+        "summary": "Show the authenticated npm profile",
+        "operationId": "showProfile",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "post": {
+        "tags": ["Authentication"],
+        "summary": "Update the authenticated npm profile",
+        "operationId": "saveProfile",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/_view/starredByUser": {
+      "get": {
+        "tags": ["Authentication"],
+        "summary": "Npm stars compatibility endpoint",
+        "operationId": "starredByUser",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/-/admin/npm/fixPaddingVersion": {
+      "put": {
+        "tags": ["Administration"],
+        "summary": "Fix package versions without padding",
+        "operationId": "fixNoPaddingVersion",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/v1/login": {
+      "post": {
+        "tags": ["WebAuthn"],
+        "summary": "Start WebAuthn login",
+        "operationId": "webauthLogin",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/v1/login/request/session/{sessionId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/SessionId"
+        }
+      ],
+      "get": {
+        "tags": ["WebAuthn"],
+        "summary": "Get WebAuthn login request status",
+        "operationId": "webauthGetLoginSession",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      },
+      "post": {
+        "tags": ["WebAuthn"],
+        "summary": "Complete WebAuthn login request",
+        "operationId": "webauthCompleteLoginSession",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/v1/login/request/prepare/{sessionId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/SessionId"
+        }
+      ],
+      "get": {
+        "tags": ["WebAuthn"],
+        "summary": "Prepare a WebAuthn login request",
+        "operationId": "webauthPrepareLogin",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/v1/login/sso/{sessionId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/SessionId"
+        }
+      ],
+      "post": {
+        "tags": ["WebAuthn"],
+        "summary": "Complete SSO login",
+        "operationId": "webauthSsoLogin",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Json"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/v1/login/request/success": {
+      "get": {
+        "tags": ["WebAuthn"],
+        "summary": "Show successful WebAuthn login result",
+        "operationId": "webauthLoginSuccess",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    },
+    "/-/v1/login/done/session/{sessionId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/SessionId"
+        }
+      ],
+      "get": {
+        "tags": ["WebAuthn"],
+        "summary": "Finish a WebAuthn login session",
+        "operationId": "webauthLoginDone",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Json"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "token",
+        "description": "Npm/cnpmcore token sent in the Authorization header."
+      }
+    },
+    "parameters": {
+      "Fullname": {
+        "name": "fullname",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/PackageName"
+        }
+      },
+      "FullnameWithVersion": {
+        "name": "fullnameWithVersion",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Version": {
+        "name": "version",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "VersionSpec": {
+        "name": "versionSpec",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "FilenameWithVersion": {
+        "name": "filenameWithVersion",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Revision": {
+        "name": "rev",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "FilePath": {
+        "name": "path",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "BinaryName": {
+        "name": "binaryName",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 220
+        }
+      },
+      "Subpath": {
+        "name": "subpath",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "maxLength": 1024
+        }
+      },
+      "Scope": {
+        "name": "scope",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Range": {
+        "name": "range",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "OrgName": {
+        "name": "orgName",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "TeamName": {
+        "name": "teamName",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Username": {
+        "name": "username",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Id": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Token": {
+        "name": "token",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "TokenKey": {
+        "name": "tokenKey",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "TaskId": {
+        "name": "taskId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "SessionId": {
+        "name": "sessionId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 36,
+          "maxLength": 36
+        }
+      },
+      "Tag": {
+        "name": "tag",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Since": {
+        "name": "since",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Limit": {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "PageSize": {
+        "name": "pageSize",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      "PageIndex": {
+        "name": "pageIndex",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "Offset": {
+        "name": "offset",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        }
+      },
+      "From": {
+        "name": "from",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        }
+      },
+      "Size": {
+        "name": "size",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 20
+        }
+      },
+      "Text": {
+        "name": "text",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        }
+      },
+      "Nodeps": {
+        "name": "nodeps",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "Meta": {
+        "name": "meta",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "PackageFilter": {
+        "name": "package",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "requestBodies": {
+      "Json": {
+        "required": false,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/JsonObject"
+            }
+          }
+        }
+      },
+      "Package": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PackageManifest"
+            }
+          }
+        }
+      },
+      "BlockPackage": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/BlockPackage"
+            }
+          }
+        }
+      },
+      "SyncPackage": {
+        "required": false,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/SyncPackage"
+            }
+          }
+        }
+      },
+      "Registry": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Registry"
+            }
+          }
+        }
+      },
+      "Scope": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Scope"
+            }
+          }
+        }
+      },
+      "Hook": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Hook"
+            }
+          }
+        }
+      },
+      "HookUpdate": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/HookUpdate"
+            }
+          }
+        }
+      },
+      "User": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/User"
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "Json": {
+        "description": "JSON response. The exact shape depends on the operation.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/JsonValue"
+            }
+          }
+        }
+      },
+      "JsonArray": {
+        "description": "JSON array response.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/JsonValue"
+              }
+            }
+          }
+        }
+      },
+      "HookList": {
+        "description": "Hook list response.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/HookList"
+            }
+          }
+        }
+      },
+      "Package": {
+        "description": "Npm package manifest.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PackageManifest"
+            }
+          }
+        }
+      },
+      "Task": {
+        "description": "Synchronization task.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Task"
+            }
+          }
+        }
+      },
+      "Text": {
+        "description": "Plain-text response.",
+        "content": {
+          "text/plain": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Tarball": {
+        "description": "Gzip-compressed npm package tarball.",
+        "content": {
+          "application/octet-stream": {
+            "schema": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        }
+      },
+      "AnyFile": {
+        "description": "Package file content or metadata.",
+        "content": {
+          "*/*": {
+            "schema": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        }
+      },
+      "Redirect": {
+        "description": "Redirect to the package file or resource.",
+        "headers": {
+          "Location": {
+            "schema": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      },
+      "Empty": {
+        "description": "No content."
+      },
+      "Error": {
+        "description": "Error response.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "JsonValue": {},
+      "JsonObject": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "PackageName": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 428
+      },
+      "PackageManifest": {
+        "type": "object",
+        "description": "Npm package manifest. Additional npm manifest fields are preserved.",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "dist-tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "versions": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JsonObject"
+            }
+          },
+          "_attachments": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JsonObject"
+            }
+          }
+        },
+        "additionalProperties": true
+      },
+      "BlockPackage": {
+        "type": "object",
+        "required": ["reason"],
+        "properties": {
+          "reason": {
+            "type": "string",
+            "maxLength": 10240
+          }
+        }
+      },
+      "SyncPackage": {
+        "type": "object",
+        "properties": {
+          "tips": {
+            "type": "string",
+            "maxLength": 1024
+          },
+          "skipDependencies": {
+            "type": "boolean"
+          },
+          "specificVersions": {
+            "type": "string",
+            "description": "JSON encoded unique semver array"
+          },
+          "syncDownloadData": {
+            "type": "boolean"
+          },
+          "force": {
+            "type": "boolean"
+          },
+          "forceSyncHistory": {
+            "type": "boolean"
+          },
+          "registryName": {
+            "type": "string"
+          }
+        }
+      },
+      "Registry": {
+        "type": "object",
+        "required": ["name", "host", "changeStream", "type"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          "host": {
+            "type": "string",
+            "format": "uri"
+          },
+          "changeStream": {
+            "type": "string",
+            "format": "uri"
+          },
+          "userPrefix": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "authToken": {
+            "type": "string",
+            "writeOnly": true
+          }
+        }
+      },
+      "Scope": {
+        "type": "object",
+        "required": ["name", "registryId"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "registryId": {
+            "type": "string"
+          }
+        }
+      },
+      "Hook": {
+        "type": "object",
+        "required": ["endpoint", "secret", "name", "type"],
+        "properties": {
+          "endpoint": {
+            "type": "string",
+            "format": "uri"
+          },
+          "secret": {
+            "type": "string",
+            "writeOnly": true
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 428
+          },
+          "type": {
+            "type": "string",
+            "enum": ["package", "scope", "owner"]
+          }
+        }
+      },
+      "HookUpdate": {
+        "type": "object",
+        "required": ["endpoint", "secret"],
+        "properties": {
+          "endpoint": {
+            "type": "string",
+            "format": "uri"
+          },
+          "secret": {
+            "type": "string",
+            "writeOnly": true
+          }
+        }
+      },
+      "HookList": {
+        "type": "object",
+        "required": ["objects"],
+        "properties": {
+          "objects": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/JsonObject"
+            }
+          }
+        }
+      },
+      "User": {
+        "type": "object",
+        "required": ["name", "password"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["user"]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100
+          },
+          "password": {
+            "type": "string",
+            "format": "password",
+            "minLength": 8,
+            "maxLength": 100,
+            "writeOnly": true
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          }
+        }
+      },
+      "Task": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string",
+            "enum": ["waiting", "processing", "success", "error"]
+          },
+          "logUrl": {
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,6 +11,10 @@
   },
   "servers": [
     {
+      "url": "https://registry.npmmirror.com",
+      "description": "Public registry"
+    },
+    {
       "url": "http://localhost:7001",
       "description": "Local development server"
     }
@@ -18,46 +22,60 @@
   "security": [],
   "tags": [
     {
-      "name": "Registry"
+      "name": "Registry",
+      "description": "Registry metadata and package registry compatibility APIs."
     },
     {
-      "name": "Packages"
+      "name": "Packages",
+      "description": "Package manifests, versions, tarballs, and package files."
     },
     {
-      "name": "Search"
+      "name": "Search",
+      "description": "Package search endpoints."
     },
     {
-      "name": "Authentication"
+      "name": "Authentication",
+      "description": "User authentication endpoints."
     },
     {
-      "name": "Organization"
+      "name": "Organization",
+      "description": "Organization and membership management."
     },
     {
-      "name": "Team"
+      "name": "Team",
+      "description": "Team and team membership management."
     },
     {
-      "name": "Token"
+      "name": "Token",
+      "description": "Access token management."
     },
     {
-      "name": "Hook"
+      "name": "Hook",
+      "description": "Webhook management."
     },
     {
-      "name": "Synchronization"
+      "name": "Synchronization",
+      "description": "Package and registry synchronization tasks."
     },
     {
-      "name": "Binary"
+      "name": "Binary",
+      "description": "Binary distribution endpoints."
     },
     {
-      "name": "Download"
+      "name": "Download",
+      "description": "Package download statistics."
     },
     {
-      "name": "Administration"
+      "name": "Administration",
+      "description": "Administrative operations."
     },
     {
-      "name": "Proxy cache"
+      "name": "Proxy cache",
+      "description": "Proxy cache management."
     },
     {
-      "name": "WebAuthn"
+      "name": "WebAuthn",
+      "description": "WebAuthn authentication flows."
     }
   ],
   "paths": {
@@ -69,6 +87,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -81,6 +105,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -100,6 +130,12 @@
                 }
               }
             }
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -112,6 +148,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/JsonArray"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -137,6 +179,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -165,6 +213,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -190,6 +244,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -207,6 +267,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -227,6 +293,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -244,6 +316,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -264,6 +342,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -284,6 +368,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -301,6 +391,15 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Package"
+          },
+          "304": {
+            "$ref": "#/components/responses/Empty"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -317,8 +416,14 @@
           "$ref": "#/components/requestBodies/Package"
         },
         "responses": {
-          "200": {
+          "201": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -339,6 +444,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -367,6 +478,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -382,6 +499,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -402,6 +525,12 @@
         "responses": {
           "204": {
             "$ref": "#/components/responses/Empty"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -412,6 +541,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Tarball"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -432,6 +567,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Tarball"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -455,6 +596,12 @@
         "responses": {
           "204": {
             "$ref": "#/components/responses/Empty"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -465,6 +612,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Tarball"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -493,6 +646,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -510,6 +669,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -538,6 +703,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -553,6 +724,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -578,6 +755,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -593,6 +776,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -608,6 +797,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/JsonArray"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -636,6 +831,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -651,6 +852,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -673,6 +880,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/JsonArray"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -698,6 +911,12 @@
         "responses": {
           "201": {
             "$ref": "#/components/responses/Task"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -723,6 +942,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Task"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -748,6 +973,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Text"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -775,6 +1006,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -800,6 +1037,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -823,6 +1066,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -845,6 +1094,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -860,6 +1115,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -885,6 +1146,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/JsonArray"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -903,6 +1170,12 @@
           },
           "302": {
             "$ref": "#/components/responses/Redirect"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -934,6 +1207,12 @@
           },
           "302": {
             "$ref": "#/components/responses/Redirect"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -954,6 +1233,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -969,6 +1254,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -999,6 +1290,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1014,6 +1311,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1029,6 +1332,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1049,6 +1358,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1067,6 +1382,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1084,6 +1405,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1097,11 +1424,17 @@
           }
         ],
         "requestBody": {
-          "$ref": "#/components/requestBodies/Json"
+          "$ref": "#/components/requestBodies/RegistryUpdate"
         },
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1117,6 +1450,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1142,6 +1481,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1162,11 +1507,17 @@
           }
         ],
         "requestBody": {
-          "$ref": "#/components/requestBodies/Json"
+          "$ref": "#/components/requestBodies/RegistryCreateSync"
         },
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1187,6 +1538,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1209,6 +1566,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1229,6 +1592,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1251,6 +1620,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1266,6 +1641,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1288,6 +1669,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/JsonArray"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1306,6 +1693,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1331,6 +1724,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1356,6 +1755,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/JsonArray"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1378,6 +1783,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/JsonArray"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1403,6 +1814,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1418,6 +1835,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/JsonArray"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1443,6 +1866,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1458,6 +1887,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1483,6 +1918,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/JsonArray"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1501,6 +1942,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1519,6 +1966,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1544,6 +1997,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/JsonArray"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1575,6 +2034,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1600,6 +2065,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/JsonArray"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1618,6 +2089,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1636,6 +2113,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1664,6 +2147,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/HookList"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1684,6 +2173,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1706,6 +2201,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1724,6 +2225,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1739,6 +2246,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1759,6 +2272,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1774,6 +2293,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/JsonArray"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1796,6 +2321,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1816,6 +2347,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1831,6 +2368,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/JsonArray"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1853,6 +2396,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1873,6 +2422,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1888,6 +2443,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1910,6 +2471,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1927,6 +2494,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1944,6 +2517,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -1962,6 +2541,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -1976,6 +2561,12 @@
             "$ref": "#/components/responses/Json"
           },
           "403": {
+            "$ref": "#/components/responses/Error"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
             "$ref": "#/components/responses/Error"
           }
         }
@@ -2004,6 +2595,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -2019,6 +2616,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -2036,6 +2639,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       },
@@ -2049,6 +2658,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -2066,6 +2681,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -2086,6 +2707,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -2098,6 +2725,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -2115,6 +2748,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Json"
+          },
+          "default": {
+            "$ref": "#/components/responses/Error"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
           }
         }
       }
@@ -2134,6 +2773,9 @@
         "name": "fullname",
         "in": "path",
         "required": true,
+        "description": "Package full name. Scoped names contain a literal slash, for example `@scope/pkg`. Send the slash literally; do not percent-encode it. For GET `/foo/sync`, the package-version route is selected with `versionSpec=sync`; the legacy synchronization endpoint only handles PUT `/foo/sync`.",
+        "example": "@scope/pkg",
+        "allowReserved": true,
         "schema": {
           "$ref": "#/components/schemas/PackageName"
         }
@@ -2182,6 +2824,9 @@
         "name": "path",
         "in": "path",
         "required": true,
+        "description": "File path inside the package, including literal slash separators, for example `lib/index.js`. Send the slashes literally; do not percent-encode them.",
+        "example": "lib/index.js",
+        "allowReserved": true,
         "schema": {
           "type": "string"
         }
@@ -2443,6 +3088,26 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/Registry"
+            }
+          }
+        }
+      },
+      "RegistryUpdate": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/RegistryUpdate"
+            }
+          }
+        }
+      },
+      "RegistryCreateSync": {
+        "required": false,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/RegistryCreateSync"
             }
           }
         }
@@ -2709,6 +3374,42 @@
           "authToken": {
             "type": "string",
             "writeOnly": true
+          }
+        }
+      },
+      "RegistryUpdate": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          },
+          "host": {
+            "type": "string",
+            "format": "uri"
+          },
+          "changeStream": {
+            "type": "string",
+            "format": "uri"
+          },
+          "userPrefix": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "authToken": {
+            "type": "string",
+            "writeOnly": true
+          }
+        }
+      },
+      "RegistryCreateSync": {
+        "type": "object",
+        "properties": {
+          "since": {
+            "type": "string"
           }
         }
       },

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,1165 @@
+openapi: 3.1.1
+info:
+  title: cnpmcore HTTP API
+  version: 4.34.1
+  description: |
+    The complete HTTP API exposed by cnpmcore, including npm registry
+    compatibility endpoints and cnpmcore administration APIs.
+  license:
+    name: MIT
+    url: https://github.com/cnpm/cnpmcore/blob/master/LICENSE
+servers:
+  - url: http://localhost:7001
+    description: Local development server
+tags:
+  - name: Registry
+  - name: Packages
+  - name: Search
+  - name: Authentication
+  - name: Organization
+  - name: Team
+  - name: Token
+  - name: Hook
+  - name: Synchronization
+  - name: Binary
+  - name: Download
+  - name: Administration
+  - name: Proxy cache
+  - name: WebAuthn
+security: []
+paths:
+  /:
+    get:
+      tags: [Registry]
+      summary: Show registry information
+      operationId: showRegistryInfo
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/ping:
+    get:
+      tags: [Registry]
+      summary: Check registry availability
+      operationId: ping
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /binary.html:
+    get:
+      tags: [Binary]
+      summary: Show the binary browser page
+      operationId: showBinaryHtml
+      responses:
+        '200':
+          description: HTML page.
+          content: { text/html: { schema: { type: string } } }
+  /-/binary:
+    get:
+      tags: [Binary]
+      summary: List binary distributions
+      operationId: listBinaries
+      responses:
+        '200': { $ref: '#/components/responses/JsonArray' }
+  /-/binary/{binaryName}:
+    parameters:
+      - { $ref: '#/components/parameters/BinaryName' }
+    get:
+      tags: [Binary]
+      summary: Show a binary distribution index
+      operationId: showBinaryIndex
+      parameters:
+        - { $ref: '#/components/parameters/Since' }
+        - { $ref: '#/components/parameters/Limit' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/binary/{binaryName}/{subpath}:
+    parameters:
+      - { $ref: '#/components/parameters/BinaryName' }
+      - { $ref: '#/components/parameters/Subpath' }
+    get:
+      tags: [Binary]
+      summary: Browse a binary distribution path
+      operationId: showBinary
+      parameters:
+        - { $ref: '#/components/parameters/Since' }
+        - { $ref: '#/components/parameters/Limit' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/binary/{binaryName}/sync:
+    parameters:
+      - { $ref: '#/components/parameters/BinaryName' }
+    post:
+      tags: [Binary, Synchronization]
+      summary: Synchronize a binary distribution
+      operationId: syncBinary
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /_changes:
+    get:
+      tags: [Registry]
+      summary: Read registry changes
+      operationId: listChanges
+      parameters:
+        - { $ref: '#/components/parameters/Since' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /downloads/point/{range}/{fullname}:
+    parameters:
+      - { $ref: '#/components/parameters/Range' }
+      - { $ref: '#/components/parameters/Fullname' }
+    get:
+      tags: [Download]
+      summary: Get package download point data
+      operationId: showPackageDownloadPoint
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /downloads/total/point/{range}:
+    parameters:
+      - { $ref: '#/components/parameters/Range' }
+    get:
+      tags: [Download]
+      summary: Get total download point data
+      operationId: showTotalDownloadPoint
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /downloads/range/{range}/{fullname}:
+    parameters:
+      - { $ref: '#/components/parameters/Range' }
+      - { $ref: '#/components/parameters/Fullname' }
+    get:
+      tags: [Download]
+      summary: Get package download range data
+      operationId: showPackageDownloads
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /downloads/{scope}/{range}:
+    parameters:
+      - { $ref: '#/components/parameters/Scope' }
+      - { $ref: '#/components/parameters/Range' }
+    get:
+      tags: [Download]
+      summary: Get scoped download data
+      operationId: showTotalDownloads
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /{fullname}:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+    get:
+      tags: [Packages]
+      summary: Show a package
+      operationId: showPackageByFullname
+      responses:
+        '200': { $ref: '#/components/responses/Package' }
+    put:
+      tags: [Packages]
+      summary: Publish or replace a package manifest
+      operationId: publishPackage
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Package' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /{fullname}/{versionSpec}:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+      - { $ref: '#/components/parameters/VersionSpec' }
+    get:
+      tags: [Packages]
+      summary: Show a package version or tag
+      operationId: showPackageVersion
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /{fullname}/-rev/{rev}:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+      - { $ref: '#/components/parameters/Revision' }
+    put:
+      tags: [Packages]
+      summary: Update package maintainers
+      operationId: updatePackage
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    delete:
+      tags: [Packages]
+      summary: Remove a package version
+      operationId: removePackageVersion
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /{fullname}/-/{filenameWithVersion}.tgz:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+      - { $ref: '#/components/parameters/FilenameWithVersion' }
+    options:
+      tags: [Packages]
+      summary: Preflight package tarball download
+      operationId: packageTarballOptions
+      responses:
+        '204': { $ref: '#/components/responses/Empty' }
+    get:
+      tags: [Packages]
+      summary: Download a package tarball
+      operationId: downloadPackageTarball
+      responses:
+        '200': { $ref: '#/components/responses/Tarball' }
+  /{fullname}/download/{fullnameWithVersion}.tgz:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+      - { $ref: '#/components/parameters/FullnameWithVersion' }
+    get:
+      tags: [Packages]
+      summary: Download a package tarball using the legacy path
+      operationId: deprecatedDownloadPackageTarball
+      responses:
+        '200': { $ref: '#/components/responses/Tarball' }
+  /{fullname}/-/{scope}/{filenameWithVersion}.tgz:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+      - { $ref: '#/components/parameters/Scope' }
+      - { $ref: '#/components/parameters/FilenameWithVersion' }
+    options:
+      tags: [Packages]
+      summary: Preflight Verdaccio-compatible tarball download
+      operationId: verdaccioTarballOptions
+      responses:
+        '204': { $ref: '#/components/responses/Empty' }
+    get:
+      tags: [Packages]
+      summary: Download a package tarball using the Verdaccio path
+      operationId: downloadVerdaccioTarball
+      responses:
+        '200': { $ref: '#/components/responses/Tarball' }
+  /{fullname}/-/{filenameWithVersion}.tgz/-rev/{rev}:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+      - { $ref: '#/components/parameters/FilenameWithVersion' }
+      - { $ref: '#/components/parameters/Revision' }
+    delete:
+      tags: [Packages]
+      summary: Remove a package version using a tarball URL
+      operationId: removePackageVersionByTarball
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/package/{fullname}/dist-tags:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+    get:
+      tags: [Packages]
+      summary: List package distribution tags
+      operationId: listPackageTags
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/package/{fullname}/dist-tags/{tag}:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+      - { $ref: '#/components/parameters/Tag' }
+    put:
+      tags: [Packages]
+      summary: Set a package distribution tag
+      operationId: savePackageTag
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    delete:
+      tags: [Packages]
+      summary: Remove a package distribution tag
+      operationId: removePackageTag
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/package/{fullname}/blocks:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+    put:
+      tags: [Administration]
+      summary: Block a package
+      operationId: blockPackage
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/BlockPackage' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    delete:
+      tags: [Administration]
+      summary: Unblock a package
+      operationId: unblockPackage
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    get:
+      tags: [Administration]
+      summary: List package blocks
+      operationId: listPackageBlocks
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/JsonArray' }
+  /-/package/{fullname}/blocks/{version}:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+      - { $ref: '#/components/parameters/Version' }
+    put:
+      tags: [Administration]
+      summary: Block a package version
+      operationId: blockPackageVersion
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/BlockPackage' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    delete:
+      tags: [Administration]
+      summary: Unblock a package version
+      operationId: unblockPackageVersion
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/package/{fullname}/collaborators:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+    get:
+      tags: [Packages]
+      summary: List package collaborators
+      operationId: listCollaborators
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/JsonArray' }
+  /-/package/{fullname}/syncs:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+    put:
+      tags: [Synchronization]
+      summary: Create a package synchronization task
+      operationId: createSyncTask
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/SyncPackage' }
+      responses:
+        '201': { $ref: '#/components/responses/Task' }
+  /-/package/{fullname}/syncs/{taskId}:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+      - { $ref: '#/components/parameters/TaskId' }
+    get:
+      tags: [Synchronization]
+      summary: Show a package synchronization task
+      operationId: showSyncTask
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Task' }
+  /-/package/{fullname}/syncs/{taskId}/log:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+      - { $ref: '#/components/parameters/TaskId' }
+    get:
+      tags: [Synchronization]
+      summary: Show a package synchronization task log
+      operationId: showSyncTaskLog
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Text' }
+  /{fullname}/sync:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+    put:
+      tags: [Synchronization]
+      summary: Create a legacy package synchronization task
+      operationId: deprecatedCreateSyncTask
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { $ref: '#/components/parameters/Nodeps' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /{fullname}/sync/log/{taskId}:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+      - { $ref: '#/components/parameters/TaskId' }
+    get:
+      tags: [Synchronization]
+      summary: Show a legacy synchronization task log
+      operationId: deprecatedShowSyncTask
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/v1/search:
+    get:
+      tags: [Search]
+      summary: Search packages
+      operationId: searchPackages
+      parameters:
+        - { $ref: '#/components/parameters/Text' }
+        - { $ref: '#/components/parameters/From' }
+        - { $ref: '#/components/parameters/Size' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/v1/search/sync/{fullname}:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+    put:
+      tags: [Search]
+      summary: Synchronize a package into search
+      operationId: syncSearchPackage
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    delete:
+      tags: [Search]
+      summary: Delete a package from search
+      operationId: deleteSearchPackage
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /{fullname}/{versionSpec}/files:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+      - { $ref: '#/components/parameters/VersionSpec' }
+    put:
+      tags: [Packages, Administration]
+      summary: Synchronize package version files
+      operationId: syncPackageVersionFiles
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/JsonArray' }
+    get:
+      tags: [Packages]
+      summary: List package version files
+      operationId: listPackageVersionFiles
+      parameters:
+        - { $ref: '#/components/parameters/Meta' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+        '302': { $ref: '#/components/responses/Redirect' }
+  /{fullname}/{versionSpec}/files/{path}:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+      - { $ref: '#/components/parameters/VersionSpec' }
+      - { $ref: '#/components/parameters/FilePath' }
+    get:
+      tags: [Packages]
+      summary: Read a package version file
+      operationId: readPackageVersionFile
+      parameters:
+        - { $ref: '#/components/parameters/Meta' }
+      responses:
+        '200': { $ref: '#/components/responses/AnyFile' }
+        '302': { $ref: '#/components/responses/Redirect' }
+  /-/proxy-cache:
+    get:
+      tags: [Proxy cache]
+      summary: List proxy cache packages
+      operationId: listProxyCache
+      parameters:
+        - { $ref: '#/components/parameters/PageSize' }
+        - { $ref: '#/components/parameters/PageIndex' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    delete:
+      tags: [Proxy cache]
+      summary: Truncate proxy cache
+      operationId: truncateProxyCaches
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/proxy-cache/{fullname}:
+    parameters:
+      - { $ref: '#/components/parameters/Fullname' }
+    get:
+      tags: [Proxy cache]
+      summary: Show proxy cache entries
+      operationId: showProxyCaches
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { $ref: '#/components/parameters/PageSize' }
+        - { $ref: '#/components/parameters/PageIndex' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    patch:
+      tags: [Proxy cache]
+      summary: Refresh proxy cache
+      operationId: refreshProxyCaches
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    delete:
+      tags: [Proxy cache]
+      summary: Remove proxy cache
+      operationId: removeProxyCaches
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/registry:
+    get:
+      tags: [Registry]
+      summary: List registries
+      operationId: listRegistries
+      parameters:
+        - { $ref: '#/components/parameters/PageSize' }
+        - { $ref: '#/components/parameters/PageIndex' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    post:
+      tags: [Registry, Administration]
+      summary: Create a registry
+      operationId: createRegistry
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Registry' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/registry/{id}:
+    parameters:
+      - { $ref: '#/components/parameters/Id' }
+    get:
+      tags: [Registry]
+      summary: Show registry details
+      operationId: showRegistry
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    patch:
+      tags: [Registry, Administration]
+      summary: Update a registry
+      operationId: updateRegistry
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    delete:
+      tags: [Registry, Administration]
+      summary: Remove a registry
+      operationId: removeRegistry
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/registry/{id}/scopes:
+    parameters:
+      - { $ref: '#/components/parameters/Id' }
+    get:
+      tags: [Registry]
+      summary: List registry scopes
+      operationId: showRegistryScopes
+      parameters:
+        - { $ref: '#/components/parameters/PageSize' }
+        - { $ref: '#/components/parameters/PageIndex' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/registry/{id}/sync:
+    parameters:
+      - { $ref: '#/components/parameters/Id' }
+    post:
+      tags: [Registry, Synchronization]
+      summary: Create a registry synchronization task
+      operationId: createRegistrySyncTask
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/scope:
+    post:
+      tags: [Registry, Administration]
+      summary: Create a scope
+      operationId: createScope
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Scope' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/scope/{id}:
+    parameters:
+      - { $ref: '#/components/parameters/Id' }
+    delete:
+      tags: [Registry, Administration]
+      summary: Remove a scope
+      operationId: removeScope
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/org:
+    put:
+      tags: [Organization]
+      summary: Create an organization
+      operationId: createOrg
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/org/{orgName}:
+    parameters:
+      - { $ref: '#/components/parameters/OrgName' }
+    get:
+      tags: [Organization]
+      summary: Show an organization
+      operationId: showOrg
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    delete:
+      tags: [Organization]
+      summary: Remove an organization
+      operationId: removeOrg
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/org/{orgName}/member:
+    parameters:
+      - { $ref: '#/components/parameters/OrgName' }
+    get:
+      tags: [Organization]
+      summary: List organization members
+      operationId: listMembers
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/JsonArray' }
+    put:
+      tags: [Organization]
+      summary: Add an organization member
+      operationId: addMember
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/org/{orgName}/member/{username}:
+    parameters:
+      - { $ref: '#/components/parameters/OrgName' }
+      - { $ref: '#/components/parameters/Username' }
+    delete:
+      tags: [Organization]
+      summary: Remove an organization member
+      operationId: removeMember
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/org/{orgName}/member/{username}/team:
+    parameters:
+      - { $ref: '#/components/parameters/OrgName' }
+      - { $ref: '#/components/parameters/Username' }
+    get:
+      tags: [Organization, Team]
+      summary: List teams for an organization member
+      operationId: listUserTeams
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/JsonArray' }
+  /-/org/{username}/package:
+    parameters:
+      - { $ref: '#/components/parameters/Username' }
+    get:
+      tags: [Organization, Packages]
+      summary: List packages owned by a user
+      operationId: listPackagesByUser
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/JsonArray' }
+  /-/org/{orgName}/team:
+    parameters:
+      - { $ref: '#/components/parameters/OrgName' }
+    put:
+      tags: [Team]
+      summary: Create a team
+      operationId: createTeam
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    get:
+      tags: [Team]
+      summary: List organization teams
+      operationId: listTeams
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/JsonArray' }
+  /-/team/{orgName}/{teamName}:
+    parameters:
+      - { $ref: '#/components/parameters/OrgName' }
+      - { $ref: '#/components/parameters/TeamName' }
+    get:
+      tags: [Team]
+      summary: Show a team
+      operationId: showTeam
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    delete:
+      tags: [Team]
+      summary: Remove a team
+      operationId: removeTeam
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/team/{orgName}/{teamName}/user:
+    parameters:
+      - { $ref: '#/components/parameters/OrgName' }
+      - { $ref: '#/components/parameters/TeamName' }
+    get:
+      tags: [Team]
+      summary: List team users
+      operationId: listTeamMembers
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/JsonArray' }
+    put:
+      tags: [Team]
+      summary: Add a team user
+      operationId: addTeamMember
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    delete:
+      tags: [Team]
+      summary: Remove a team user
+      operationId: removeTeamMember
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/team/{orgName}/{teamName}/member:
+    parameters:
+      - { $ref: '#/components/parameters/OrgName' }
+      - { $ref: '#/components/parameters/TeamName' }
+    get:
+      tags: [Team]
+      summary: List team users with roles
+      operationId: listTeamMembersWithRole
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/JsonArray' }
+  /-/team/{orgName}/{teamName}/member/{username}:
+    parameters:
+      - { $ref: '#/components/parameters/OrgName' }
+      - { $ref: '#/components/parameters/TeamName' }
+      - { $ref: '#/components/parameters/Username' }
+    patch:
+      tags: [Team]
+      summary: Update a team member role
+      operationId: updateTeamMemberRole
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/team/{orgName}/{teamName}/package:
+    parameters:
+      - { $ref: '#/components/parameters/OrgName' }
+      - { $ref: '#/components/parameters/TeamName' }
+    get:
+      tags: [Team, Packages]
+      summary: List packages accessible to a team
+      operationId: listTeamPackages
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/JsonArray' }
+    put:
+      tags: [Team, Packages]
+      summary: Grant team package access
+      operationId: grantPackageAccess
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    delete:
+      tags: [Team, Packages]
+      summary: Revoke team package access
+      operationId: revokePackageAccess
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /v1/hooks:
+    get:
+      tags: [Hook]
+      summary: List hooks
+      operationId: listHooks
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { $ref: '#/components/parameters/PackageFilter' }
+        - { $ref: '#/components/parameters/Offset' }
+        - { $ref: '#/components/parameters/Limit' }
+      responses:
+        '200': { $ref: '#/components/responses/HookList' }
+  /v1/hooks/hook:
+    post:
+      tags: [Hook]
+      summary: Create a hook
+      operationId: createHook
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Hook' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /v1/hooks/hook/{id}:
+    parameters:
+      - { $ref: '#/components/parameters/Id' }
+    get:
+      tags: [Hook]
+      summary: Get hook details
+      operationId: getHook
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    put:
+      tags: [Hook]
+      summary: Update a hook
+      operationId: updateHook
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/HookUpdate' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    delete:
+      tags: [Hook]
+      summary: Delete a hook
+      operationId: deleteHook
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/npm/v1/tokens:
+    post:
+      tags: [Token]
+      summary: Create a classic npm token
+      operationId: createToken
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    get:
+      tags: [Token]
+      summary: List classic npm tokens
+      operationId: listTokens
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/JsonArray' }
+  /-/npm/v1/tokens/token/{tokenKey}:
+    parameters:
+      - { $ref: '#/components/parameters/TokenKey' }
+    delete:
+      tags: [Token]
+      summary: Delete a classic npm token
+      operationId: removeToken
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/npm/v1/tokens/gat:
+    post:
+      tags: [Token]
+      summary: Create a granular access token
+      operationId: createGranularToken
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    get:
+      tags: [Token]
+      summary: List granular access tokens
+      operationId: listGranularTokens
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/JsonArray' }
+  /-/npm/v1/tokens/gat/{tokenKey}:
+    parameters:
+      - { $ref: '#/components/parameters/TokenKey' }
+    delete:
+      tags: [Token]
+      summary: Delete a granular access token
+      operationId: removeGranularToken
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/user/org.couchdb.user:{username}:
+    parameters:
+      - { $ref: '#/components/parameters/Username' }
+    put:
+      tags: [Authentication]
+      summary: Create a user or log in
+      operationId: loginOrCreateUser
+      requestBody: { $ref: '#/components/requestBodies/User' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    get:
+      tags: [Authentication]
+      summary: Show a user
+      operationId: showUser
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/user/token/{token}:
+    parameters:
+      - { $ref: '#/components/parameters/Token' }
+    delete:
+      tags: [Authentication]
+      summary: Log out and revoke a token
+      operationId: logout
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/whoami:
+    get:
+      tags: [Authentication]
+      summary: Show the authenticated user name
+      operationId: whoami
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/npm/v1/user:
+    get:
+      tags: [Authentication]
+      summary: Show the authenticated npm profile
+      operationId: showProfile
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    post:
+      tags: [Authentication]
+      summary: Update the authenticated npm profile
+      operationId: saveProfile
+      security: [{ bearerAuth: [] }]
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/_view/starredByUser:
+    get:
+      tags: [Authentication]
+      summary: Npm stars compatibility endpoint
+      operationId: starredByUser
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+        '403': { $ref: '#/components/responses/Error' }
+  /-/admin/npm/fixPaddingVersion:
+    put:
+      tags: [Administration]
+      summary: Fix package versions without padding
+      operationId: fixNoPaddingVersion
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - name: id
+          in: query
+          schema: { type: integer, minimum: 0 }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/v1/login:
+    post:
+      tags: [WebAuthn]
+      summary: Start WebAuthn login
+      operationId: webauthLogin
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/v1/login/request/session/{sessionId}:
+    parameters:
+      - { $ref: '#/components/parameters/SessionId' }
+    get:
+      tags: [WebAuthn]
+      summary: Get WebAuthn login request status
+      operationId: webauthGetLoginSession
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+    post:
+      tags: [WebAuthn]
+      summary: Complete WebAuthn login request
+      operationId: webauthCompleteLoginSession
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/v1/login/request/prepare/{sessionId}:
+    parameters:
+      - { $ref: '#/components/parameters/SessionId' }
+    get:
+      tags: [WebAuthn]
+      summary: Prepare a WebAuthn login request
+      operationId: webauthPrepareLogin
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/v1/login/sso/{sessionId}:
+    parameters:
+      - { $ref: '#/components/parameters/SessionId' }
+    post:
+      tags: [WebAuthn]
+      summary: Complete SSO login
+      operationId: webauthSsoLogin
+      requestBody: { $ref: '#/components/requestBodies/Json' }
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/v1/login/request/success:
+    get:
+      tags: [WebAuthn]
+      summary: Show successful WebAuthn login result
+      operationId: webauthLoginSuccess
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+  /-/v1/login/done/session/{sessionId}:
+    parameters:
+      - { $ref: '#/components/parameters/SessionId' }
+    get:
+      tags: [WebAuthn]
+      summary: Finish a WebAuthn login session
+      operationId: webauthLoginDone
+      responses:
+        '200': { $ref: '#/components/responses/Json' }
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: token
+      description: Npm/cnpmcore token sent in the Authorization header.
+  parameters:
+    Fullname: { name: fullname, in: path, required: true, schema: { $ref: '#/components/schemas/PackageName' } }
+    FullnameWithVersion: { name: fullnameWithVersion, in: path, required: true, schema: { type: string } }
+    Version: { name: version, in: path, required: true, schema: { type: string } }
+    VersionSpec: { name: versionSpec, in: path, required: true, schema: { type: string } }
+    FilenameWithVersion: { name: filenameWithVersion, in: path, required: true, schema: { type: string } }
+    Revision: { name: rev, in: path, required: true, schema: { type: string } }
+    FilePath: { name: path, in: path, required: true, schema: { type: string } }
+    BinaryName: { name: binaryName, in: path, required: true, schema: { type: string, minLength: 1, maxLength: 220 } }
+    Subpath: { name: subpath, in: path, required: true, schema: { type: string, maxLength: 1024 } }
+    Scope: { name: scope, in: path, required: true, schema: { type: string } }
+    Range: { name: range, in: path, required: true, schema: { type: string } }
+    OrgName: { name: orgName, in: path, required: true, schema: { type: string } }
+    TeamName: { name: teamName, in: path, required: true, schema: { type: string } }
+    Username: { name: username, in: path, required: true, schema: { type: string } }
+    Id: { name: id, in: path, required: true, schema: { type: string } }
+    Token: { name: token, in: path, required: true, schema: { type: string } }
+    TokenKey: { name: tokenKey, in: path, required: true, schema: { type: string } }
+    TaskId: { name: taskId, in: path, required: true, schema: { type: string } }
+    SessionId: { name: sessionId, in: path, required: true, schema: { type: string, minLength: 36, maxLength: 36 } }
+    Tag: { name: tag, in: path, required: true, schema: { type: string } }
+    Since: { name: since, in: query, required: false, schema: { type: string } }
+    Limit: { name: limit, in: query, required: false, schema: { type: integer, minimum: 1 } }
+    PageSize: { name: pageSize, in: query, required: false, schema: { type: integer, minimum: 1, maximum: 100 } }
+    PageIndex: { name: pageIndex, in: query, required: false, schema: { type: integer, minimum: 0 } }
+    Offset: { name: offset, in: query, required: false, schema: { type: integer, minimum: 0, default: 0 } }
+    From: { name: from, in: query, required: false, schema: { type: integer, minimum: 0, default: 0 } }
+    Size: { name: size, in: query, required: false, schema: { type: integer, minimum: 1, default: 20 } }
+    Text: { name: text, in: query, required: true, schema: { type: string, minLength: 1, maxLength: 256 } }
+    Nodeps: { name: nodeps, in: query, required: false, schema: { type: boolean } }
+    Meta: { name: meta, in: query, required: false, schema: { type: boolean } }
+    PackageFilter: { name: package, in: query, required: false, schema: { type: string } }
+  requestBodies:
+    Json: { required: false, content: { application/json: { schema: { $ref: '#/components/schemas/JsonObject' } } } }
+    Package:
+      { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/PackageManifest' } } } }
+    BlockPackage:
+      { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/BlockPackage' } } } }
+    SyncPackage:
+      { required: false, content: { application/json: { schema: { $ref: '#/components/schemas/SyncPackage' } } } }
+    Registry: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/Registry' } } } }
+    Scope: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/Scope' } } } }
+    Hook: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/Hook' } } } }
+    HookUpdate:
+      { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/HookUpdate' } } } }
+    User: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/User' } } } }
+  responses:
+    Json:
+      description: JSON response. The exact shape depends on the operation.
+      content: { application/json: { schema: { $ref: '#/components/schemas/JsonValue' } } }
+    JsonArray:
+      description: JSON array response.
+      content: { application/json: { schema: { type: array, items: { $ref: '#/components/schemas/JsonValue' } } } }
+    HookList:
+      description: Hook list response.
+      content: { application/json: { schema: { $ref: '#/components/schemas/HookList' } } }
+    Package:
+      description: Npm package manifest.
+      content: { application/json: { schema: { $ref: '#/components/schemas/PackageManifest' } } }
+    Task:
+      description: Synchronization task.
+      content: { application/json: { schema: { $ref: '#/components/schemas/Task' } } }
+    Text:
+      description: Plain-text response.
+      content: { text/plain: { schema: { type: string } } }
+    Tarball:
+      description: Gzip-compressed npm package tarball.
+      content: { application/octet-stream: { schema: { type: string, format: binary } } }
+    AnyFile:
+      description: Package file content or metadata.
+      content: { '*/*': { schema: { type: string, format: binary } } }
+    Redirect:
+      description: Redirect to the package file or resource.
+      headers: { Location: { schema: { type: string, format: uri } } }
+    Empty: { description: No content. }
+    Error:
+      description: Error response.
+      content: { application/json: { schema: { $ref: '#/components/schemas/Error' } } }
+  schemas:
+    JsonValue: {}
+    JsonObject: { type: object, additionalProperties: true }
+    PackageName: { type: string, minLength: 1, maxLength: 428 }
+    PackageManifest:
+      type: object
+      description: Npm package manifest. Additional npm manifest fields are preserved.
+      required: [name]
+      properties:
+        name: { type: string }
+        version: { type: string }
+        description: { type: string }
+        dist-tags: { type: object, additionalProperties: { type: string } }
+        versions: { type: object, additionalProperties: { $ref: '#/components/schemas/JsonObject' } }
+        _attachments: { type: object, additionalProperties: { $ref: '#/components/schemas/JsonObject' } }
+      additionalProperties: true
+    BlockPackage:
+      type: object
+      required: [reason]
+      properties:
+        reason: { type: string, maxLength: 10240 }
+    SyncPackage:
+      type: object
+      properties:
+        tips: { type: string, maxLength: 1024 }
+        skipDependencies: { type: boolean }
+        specificVersions: { type: string, description: JSON encoded unique semver array }
+        syncDownloadData: { type: boolean }
+        force: { type: boolean }
+        forceSyncHistory: { type: boolean }
+        registryName: { type: string }
+    Registry:
+      type: object
+      required: [name, host, changeStream, type]
+      properties:
+        name: { type: string, minLength: 1, maxLength: 256 }
+        host: { type: string, format: uri }
+        changeStream: { type: string, format: uri }
+        userPrefix: { type: string }
+        type: { type: string }
+        authToken: { type: string, writeOnly: true }
+    Scope:
+      type: object
+      required: [name, registryId]
+      properties:
+        name: { type: string }
+        registryId: { type: string }
+    Hook:
+      type: object
+      required: [endpoint, secret, name, type]
+      properties:
+        endpoint: { type: string, format: uri }
+        secret: { type: string, writeOnly: true }
+        name: { type: string, maxLength: 428 }
+        type: { type: string, enum: [package, scope, owner] }
+    HookUpdate:
+      type: object
+      required: [endpoint, secret]
+      properties:
+        endpoint: { type: string, format: uri }
+        secret: { type: string, writeOnly: true }
+    HookList:
+      type: object
+      required: [objects]
+      properties:
+        objects:
+          type: array
+          items: { $ref: '#/components/schemas/JsonObject' }
+    User:
+      type: object
+      required: [name, password]
+      properties:
+        type: { type: string, enum: [user] }
+        name: { type: string, minLength: 1, maxLength: 100 }
+        password: { type: string, format: password, minLength: 8, maxLength: 100, writeOnly: true }
+        email: { type: string, format: email }
+    Task:
+      type: object
+      properties:
+        ok: { type: boolean }
+        id: { type: string }
+        type: { type: string }
+        state: { type: string, enum: [waiting, processing, success, error] }
+        logUrl: { type: string, format: uri }
+    Error:
+      type: object
+      properties:
+        error: { type: string }
+        reason: { type: string }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1231,7 +1231,6 @@ components:
         `versionSpec=sync`; the legacy synchronization endpoint only handles
         PUT `/foo/sync`.
       example: '@scope/pkg'
-      allowReserved: true
       schema: { $ref: '#/components/schemas/PackageName' }
     FullnameWithVersion: { name: fullnameWithVersion, in: path, required: true, schema: { type: string } }
     Version: { name: version, in: path, required: true, schema: { type: string } }
@@ -1247,7 +1246,6 @@ components:
         example `lib/index.js`. Send the slashes literally; do not
         percent-encode them.
       example: lib/index.js
-      allowReserved: true
       schema: { type: string }
     BinaryName: { name: binaryName, in: path, required: true, schema: { type: string, minLength: 1, maxLength: 220 } }
     Subpath: { name: subpath, in: path, required: true, schema: { type: string, maxLength: 1024 } }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -9,23 +9,39 @@ info:
     name: MIT
     url: https://github.com/cnpm/cnpmcore/blob/master/LICENSE
 servers:
+  - url: https://registry.npmmirror.com
+    description: Public registry
   - url: http://localhost:7001
     description: Local development server
 tags:
   - name: Registry
+    description: Registry metadata and package registry compatibility APIs.
   - name: Packages
+    description: Package manifests, versions, tarballs, and package files.
   - name: Search
+    description: Package search endpoints.
   - name: Authentication
+    description: User authentication endpoints.
   - name: Organization
+    description: Organization and membership management.
   - name: Team
+    description: Team and team membership management.
   - name: Token
+    description: Access token management.
   - name: Hook
+    description: Webhook management.
   - name: Synchronization
+    description: Package and registry synchronization tasks.
   - name: Binary
+    description: Binary distribution endpoints.
   - name: Download
+    description: Package download statistics.
   - name: Administration
+    description: Administrative operations.
   - name: Proxy cache
+    description: Proxy cache management.
   - name: WebAuthn
+    description: WebAuthn authentication flows.
 security: []
 paths:
   /:
@@ -34,6 +50,8 @@ paths:
       summary: Show registry information
       operationId: showRegistryInfo
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/ping:
     get:
@@ -41,6 +59,8 @@ paths:
       summary: Check registry availability
       operationId: ping
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /binary.html:
     get:
@@ -48,6 +68,8 @@ paths:
       summary: Show the binary browser page
       operationId: showBinaryHtml
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200':
           description: HTML page.
           content: { text/html: { schema: { type: string } } }
@@ -57,6 +79,8 @@ paths:
       summary: List binary distributions
       operationId: listBinaries
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/JsonArray' }
   /-/binary/{binaryName}:
     parameters:
@@ -69,6 +93,8 @@ paths:
         - { $ref: '#/components/parameters/Since' }
         - { $ref: '#/components/parameters/Limit' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/binary/{binaryName}/{subpath}:
     parameters:
@@ -82,6 +108,8 @@ paths:
         - { $ref: '#/components/parameters/Since' }
         - { $ref: '#/components/parameters/Limit' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/binary/{binaryName}/sync:
     parameters:
@@ -93,6 +121,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/Json' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /_changes:
     get:
@@ -102,6 +132,8 @@ paths:
       parameters:
         - { $ref: '#/components/parameters/Since' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /downloads/point/{range}/{fullname}:
     parameters:
@@ -112,6 +144,8 @@ paths:
       summary: Get package download point data
       operationId: showPackageDownloadPoint
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /downloads/total/point/{range}:
     parameters:
@@ -121,6 +155,8 @@ paths:
       summary: Get total download point data
       operationId: showTotalDownloadPoint
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /downloads/range/{range}/{fullname}:
     parameters:
@@ -131,6 +167,8 @@ paths:
       summary: Get package download range data
       operationId: showPackageDownloads
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /downloads/{scope}/{range}:
     parameters:
@@ -141,6 +179,8 @@ paths:
       summary: Get scoped download data
       operationId: showTotalDownloads
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /{fullname}:
     parameters:
@@ -150,7 +190,10 @@ paths:
       summary: Show a package
       operationId: showPackageByFullname
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Package' }
+        '304': { $ref: '#/components/responses/Empty' }
     put:
       tags: [Packages]
       summary: Publish or replace a package manifest
@@ -158,7 +201,9 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/Package' }
       responses:
-        '200': { $ref: '#/components/responses/Json' }
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
+        '201': { $ref: '#/components/responses/Json' }
   /{fullname}/{versionSpec}:
     parameters:
       - { $ref: '#/components/parameters/Fullname' }
@@ -168,6 +213,8 @@ paths:
       summary: Show a package version or tag
       operationId: showPackageVersion
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /{fullname}/-rev/{rev}:
     parameters:
@@ -180,6 +227,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/Json' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     delete:
       tags: [Packages]
@@ -187,6 +236,8 @@ paths:
       operationId: removePackageVersion
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /{fullname}/-/{filenameWithVersion}.tgz:
     parameters:
@@ -197,12 +248,16 @@ paths:
       summary: Preflight package tarball download
       operationId: packageTarballOptions
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '204': { $ref: '#/components/responses/Empty' }
     get:
       tags: [Packages]
       summary: Download a package tarball
       operationId: downloadPackageTarball
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Tarball' }
   /{fullname}/download/{fullnameWithVersion}.tgz:
     parameters:
@@ -213,6 +268,8 @@ paths:
       summary: Download a package tarball using the legacy path
       operationId: deprecatedDownloadPackageTarball
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Tarball' }
   /{fullname}/-/{scope}/{filenameWithVersion}.tgz:
     parameters:
@@ -224,12 +281,16 @@ paths:
       summary: Preflight Verdaccio-compatible tarball download
       operationId: verdaccioTarballOptions
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '204': { $ref: '#/components/responses/Empty' }
     get:
       tags: [Packages]
       summary: Download a package tarball using the Verdaccio path
       operationId: downloadVerdaccioTarball
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Tarball' }
   /{fullname}/-/{filenameWithVersion}.tgz/-rev/{rev}:
     parameters:
@@ -242,6 +303,8 @@ paths:
       operationId: removePackageVersionByTarball
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/package/{fullname}/dist-tags:
     parameters:
@@ -251,6 +314,8 @@ paths:
       summary: List package distribution tags
       operationId: listPackageTags
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/package/{fullname}/dist-tags/{tag}:
     parameters:
@@ -263,6 +328,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/Json' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     delete:
       tags: [Packages]
@@ -270,6 +337,8 @@ paths:
       operationId: removePackageTag
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/package/{fullname}/blocks:
     parameters:
@@ -281,6 +350,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/BlockPackage' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     delete:
       tags: [Administration]
@@ -288,6 +359,8 @@ paths:
       operationId: unblockPackage
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     get:
       tags: [Administration]
@@ -295,6 +368,8 @@ paths:
       operationId: listPackageBlocks
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/JsonArray' }
   /-/package/{fullname}/blocks/{version}:
     parameters:
@@ -307,6 +382,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/BlockPackage' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     delete:
       tags: [Administration]
@@ -314,6 +391,8 @@ paths:
       operationId: unblockPackageVersion
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/package/{fullname}/collaborators:
     parameters:
@@ -324,6 +403,8 @@ paths:
       operationId: listCollaborators
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/JsonArray' }
   /-/package/{fullname}/syncs:
     parameters:
@@ -335,6 +416,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/SyncPackage' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '201': { $ref: '#/components/responses/Task' }
   /-/package/{fullname}/syncs/{taskId}:
     parameters:
@@ -346,6 +429,8 @@ paths:
       operationId: showSyncTask
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Task' }
   /-/package/{fullname}/syncs/{taskId}/log:
     parameters:
@@ -357,6 +442,8 @@ paths:
       operationId: showSyncTaskLog
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Text' }
   /{fullname}/sync:
     parameters:
@@ -369,6 +456,8 @@ paths:
       parameters:
         - { $ref: '#/components/parameters/Nodeps' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /{fullname}/sync/log/{taskId}:
     parameters:
@@ -380,6 +469,8 @@ paths:
       operationId: deprecatedShowSyncTask
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/v1/search:
     get:
@@ -391,6 +482,8 @@ paths:
         - { $ref: '#/components/parameters/From' }
         - { $ref: '#/components/parameters/Size' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/v1/search/sync/{fullname}:
     parameters:
@@ -401,6 +494,8 @@ paths:
       operationId: syncSearchPackage
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     delete:
       tags: [Search]
@@ -408,6 +503,8 @@ paths:
       operationId: deleteSearchPackage
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /{fullname}/{versionSpec}/files:
     parameters:
@@ -419,6 +516,8 @@ paths:
       operationId: syncPackageVersionFiles
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/JsonArray' }
     get:
       tags: [Packages]
@@ -427,6 +526,8 @@ paths:
       parameters:
         - { $ref: '#/components/parameters/Meta' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
         '302': { $ref: '#/components/responses/Redirect' }
   /{fullname}/{versionSpec}/files/{path}:
@@ -441,6 +542,8 @@ paths:
       parameters:
         - { $ref: '#/components/parameters/Meta' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/AnyFile' }
         '302': { $ref: '#/components/responses/Redirect' }
   /-/proxy-cache:
@@ -452,6 +555,8 @@ paths:
         - { $ref: '#/components/parameters/PageSize' }
         - { $ref: '#/components/parameters/PageIndex' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     delete:
       tags: [Proxy cache]
@@ -459,6 +564,8 @@ paths:
       operationId: truncateProxyCaches
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/proxy-cache/{fullname}:
     parameters:
@@ -472,6 +579,8 @@ paths:
         - { $ref: '#/components/parameters/PageSize' }
         - { $ref: '#/components/parameters/PageIndex' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     patch:
       tags: [Proxy cache]
@@ -479,6 +588,8 @@ paths:
       operationId: refreshProxyCaches
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     delete:
       tags: [Proxy cache]
@@ -486,6 +597,8 @@ paths:
       operationId: removeProxyCaches
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/registry:
     get:
@@ -496,6 +609,8 @@ paths:
         - { $ref: '#/components/parameters/PageSize' }
         - { $ref: '#/components/parameters/PageIndex' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     post:
       tags: [Registry, Administration]
@@ -504,6 +619,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/Registry' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/registry/{id}:
     parameters:
@@ -513,14 +630,18 @@ paths:
       summary: Show registry details
       operationId: showRegistry
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     patch:
       tags: [Registry, Administration]
       summary: Update a registry
       operationId: updateRegistry
       security: [{ bearerAuth: [] }]
-      requestBody: { $ref: '#/components/requestBodies/Json' }
+      requestBody: { $ref: '#/components/requestBodies/RegistryUpdate' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     delete:
       tags: [Registry, Administration]
@@ -528,6 +649,8 @@ paths:
       operationId: removeRegistry
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/registry/{id}/scopes:
     parameters:
@@ -540,6 +663,8 @@ paths:
         - { $ref: '#/components/parameters/PageSize' }
         - { $ref: '#/components/parameters/PageIndex' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/registry/{id}/sync:
     parameters:
@@ -549,8 +674,10 @@ paths:
       summary: Create a registry synchronization task
       operationId: createRegistrySyncTask
       security: [{ bearerAuth: [] }]
-      requestBody: { $ref: '#/components/requestBodies/Json' }
+      requestBody: { $ref: '#/components/requestBodies/RegistryCreateSync' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/scope:
     post:
@@ -560,6 +687,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/Scope' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/scope/{id}:
     parameters:
@@ -570,6 +699,8 @@ paths:
       operationId: removeScope
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/org:
     put:
@@ -579,6 +710,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/Json' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/org/{orgName}:
     parameters:
@@ -589,6 +722,8 @@ paths:
       operationId: showOrg
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     delete:
       tags: [Organization]
@@ -596,6 +731,8 @@ paths:
       operationId: removeOrg
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/org/{orgName}/member:
     parameters:
@@ -606,6 +743,8 @@ paths:
       operationId: listMembers
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/JsonArray' }
     put:
       tags: [Organization]
@@ -614,6 +753,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/Json' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/org/{orgName}/member/{username}:
     parameters:
@@ -625,6 +766,8 @@ paths:
       operationId: removeMember
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/org/{orgName}/member/{username}/team:
     parameters:
@@ -636,6 +779,8 @@ paths:
       operationId: listUserTeams
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/JsonArray' }
   /-/org/{username}/package:
     parameters:
@@ -646,6 +791,8 @@ paths:
       operationId: listPackagesByUser
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/JsonArray' }
   /-/org/{orgName}/team:
     parameters:
@@ -657,6 +804,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/Json' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     get:
       tags: [Team]
@@ -664,6 +813,8 @@ paths:
       operationId: listTeams
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/JsonArray' }
   /-/team/{orgName}/{teamName}:
     parameters:
@@ -675,6 +826,8 @@ paths:
       operationId: showTeam
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     delete:
       tags: [Team]
@@ -682,6 +835,8 @@ paths:
       operationId: removeTeam
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/team/{orgName}/{teamName}/user:
     parameters:
@@ -693,6 +848,8 @@ paths:
       operationId: listTeamMembers
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/JsonArray' }
     put:
       tags: [Team]
@@ -701,6 +858,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/Json' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     delete:
       tags: [Team]
@@ -709,6 +868,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/Json' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/team/{orgName}/{teamName}/member:
     parameters:
@@ -720,6 +881,8 @@ paths:
       operationId: listTeamMembersWithRole
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/JsonArray' }
   /-/team/{orgName}/{teamName}/member/{username}:
     parameters:
@@ -733,6 +896,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/Json' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/team/{orgName}/{teamName}/package:
     parameters:
@@ -744,6 +909,8 @@ paths:
       operationId: listTeamPackages
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/JsonArray' }
     put:
       tags: [Team, Packages]
@@ -752,6 +919,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/Json' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     delete:
       tags: [Team, Packages]
@@ -760,6 +929,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/Json' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /v1/hooks:
     get:
@@ -772,6 +943,8 @@ paths:
         - { $ref: '#/components/parameters/Offset' }
         - { $ref: '#/components/parameters/Limit' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/HookList' }
   /v1/hooks/hook:
     post:
@@ -781,6 +954,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/Hook' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /v1/hooks/hook/{id}:
     parameters:
@@ -791,6 +966,8 @@ paths:
       operationId: getHook
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     put:
       tags: [Hook]
@@ -799,6 +976,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/HookUpdate' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     delete:
       tags: [Hook]
@@ -806,6 +985,8 @@ paths:
       operationId: deleteHook
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/npm/v1/tokens:
     post:
@@ -815,6 +996,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/Json' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     get:
       tags: [Token]
@@ -822,6 +1005,8 @@ paths:
       operationId: listTokens
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/JsonArray' }
   /-/npm/v1/tokens/token/{tokenKey}:
     parameters:
@@ -832,6 +1017,8 @@ paths:
       operationId: removeToken
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/npm/v1/tokens/gat:
     post:
@@ -841,6 +1028,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/Json' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     get:
       tags: [Token]
@@ -848,6 +1037,8 @@ paths:
       operationId: listGranularTokens
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/JsonArray' }
   /-/npm/v1/tokens/gat/{tokenKey}:
     parameters:
@@ -858,6 +1049,8 @@ paths:
       operationId: removeGranularToken
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/user/org.couchdb.user:{username}:
     parameters:
@@ -868,6 +1061,8 @@ paths:
       operationId: loginOrCreateUser
       requestBody: { $ref: '#/components/requestBodies/User' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     get:
       tags: [Authentication]
@@ -875,6 +1070,8 @@ paths:
       operationId: showUser
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/user/token/{token}:
     parameters:
@@ -885,6 +1082,8 @@ paths:
       operationId: logout
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/whoami:
     get:
@@ -893,6 +1092,8 @@ paths:
       operationId: whoami
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/npm/v1/user:
     get:
@@ -901,6 +1102,8 @@ paths:
       operationId: showProfile
       security: [{ bearerAuth: [] }]
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     post:
       tags: [Authentication]
@@ -909,6 +1112,8 @@ paths:
       security: [{ bearerAuth: [] }]
       requestBody: { $ref: '#/components/requestBodies/Json' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/_view/starredByUser:
     get:
@@ -916,6 +1121,8 @@ paths:
       summary: Npm stars compatibility endpoint
       operationId: starredByUser
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
         '403': { $ref: '#/components/responses/Error' }
   /-/admin/npm/fixPaddingVersion:
@@ -929,6 +1136,8 @@ paths:
           in: query
           schema: { type: integer, minimum: 0 }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/v1/login:
     post:
@@ -937,6 +1146,8 @@ paths:
       operationId: webauthLogin
       requestBody: { $ref: '#/components/requestBodies/Json' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/v1/login/request/session/{sessionId}:
     parameters:
@@ -946,6 +1157,8 @@ paths:
       summary: Get WebAuthn login request status
       operationId: webauthGetLoginSession
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
     post:
       tags: [WebAuthn]
@@ -953,6 +1166,8 @@ paths:
       operationId: webauthCompleteLoginSession
       requestBody: { $ref: '#/components/requestBodies/Json' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/v1/login/request/prepare/{sessionId}:
     parameters:
@@ -962,6 +1177,8 @@ paths:
       summary: Prepare a WebAuthn login request
       operationId: webauthPrepareLogin
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/v1/login/sso/{sessionId}:
     parameters:
@@ -972,6 +1189,8 @@ paths:
       operationId: webauthSsoLogin
       requestBody: { $ref: '#/components/requestBodies/Json' }
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/v1/login/request/success:
     get:
@@ -979,6 +1198,8 @@ paths:
       summary: Show successful WebAuthn login result
       operationId: webauthLoginSuccess
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
   /-/v1/login/done/session/{sessionId}:
     parameters:
@@ -988,6 +1209,8 @@ paths:
       summary: Finish a WebAuthn login session
       operationId: webauthLoginDone
       responses:
+        default: { $ref: '#/components/responses/Error' }
+        '4XX': { $ref: '#/components/responses/Error' }
         '200': { $ref: '#/components/responses/Json' }
 components:
   securitySchemes:
@@ -997,13 +1220,35 @@ components:
       bearerFormat: token
       description: Npm/cnpmcore token sent in the Authorization header.
   parameters:
-    Fullname: { name: fullname, in: path, required: true, schema: { $ref: '#/components/schemas/PackageName' } }
+    Fullname:
+      name: fullname
+      in: path
+      required: true
+      description: >-
+        Package full name. Scoped names contain a literal slash, for example
+        `@scope/pkg`. Send the slash literally; do not percent-encode it.
+        For GET `/foo/sync`, the package-version route is selected with
+        `versionSpec=sync`; the legacy synchronization endpoint only handles
+        PUT `/foo/sync`.
+      example: '@scope/pkg'
+      allowReserved: true
+      schema: { $ref: '#/components/schemas/PackageName' }
     FullnameWithVersion: { name: fullnameWithVersion, in: path, required: true, schema: { type: string } }
     Version: { name: version, in: path, required: true, schema: { type: string } }
     VersionSpec: { name: versionSpec, in: path, required: true, schema: { type: string } }
     FilenameWithVersion: { name: filenameWithVersion, in: path, required: true, schema: { type: string } }
     Revision: { name: rev, in: path, required: true, schema: { type: string } }
-    FilePath: { name: path, in: path, required: true, schema: { type: string } }
+    FilePath:
+      name: path
+      in: path
+      required: true
+      description: >-
+        File path inside the package, including literal slash separators, for
+        example `lib/index.js`. Send the slashes literally; do not
+        percent-encode them.
+      example: lib/index.js
+      allowReserved: true
+      schema: { type: string }
     BinaryName: { name: binaryName, in: path, required: true, schema: { type: string, minLength: 1, maxLength: 220 } }
     Subpath: { name: subpath, in: path, required: true, schema: { type: string, maxLength: 1024 } }
     Scope: { name: scope, in: path, required: true, schema: { type: string } }
@@ -1037,6 +1282,13 @@ components:
     SyncPackage:
       { required: false, content: { application/json: { schema: { $ref: '#/components/schemas/SyncPackage' } } } }
     Registry: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/Registry' } } } }
+    RegistryUpdate:
+      { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/RegistryUpdate' } } } }
+    RegistryCreateSync:
+      {
+        required: false,
+        content: { application/json: { schema: { $ref: '#/components/schemas/RegistryCreateSync' } } },
+      }
     Scope: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/Scope' } } } }
     Hook: { required: true, content: { application/json: { schema: { $ref: '#/components/schemas/Hook' } } } }
     HookUpdate:
@@ -1115,6 +1367,19 @@ components:
         userPrefix: { type: string }
         type: { type: string }
         authToken: { type: string, writeOnly: true }
+    RegistryUpdate:
+      type: object
+      properties:
+        name: { type: string, minLength: 1, maxLength: 256 }
+        host: { type: string, format: uri }
+        changeStream: { type: string, format: uri }
+        userPrefix: { type: string }
+        type: { type: string }
+        authToken: { type: string, writeOnly: true }
+    RegistryCreateSync:
+      type: object
+      properties:
+        since: { type: string }
     Scope:
       type: object
       required: [name, registryId]

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "typecheck": "tsc --noEmit",
     "fmt": "vp fmt",
     "fmtcheck": "vp fmt --check",
+    "api-docs:lint": "redocly lint docs/openapi.yaml",
+    "api-docs:build": "redocly bundle docs/openapi.yaml --output docs/openapi.json && vp fmt docs/openapi.json",
     "test:postgresql": "npm run test:local:postgresql",
     "pretest:local:postgresql": "bash prepare-database-postgresql.sh",
     "test:local:postgresql": "CNPMCORE_DATABASE_TYPE=PostgreSQL egg-bin test",
@@ -129,6 +131,7 @@
     "@eggjs/mock": "^7.0.2-beta.2",
     "@eggjs/tsconfig": "^3.1.2-beta.2",
     "@elastic/elasticsearch-mock": "^2.1.0",
+    "@redocly/cli": "^2.43.2",
     "@simplewebauthn/typescript-types": "^7.4.0",
     "@types/ioredis-mock": "^8.2.6",
     "@types/lodash-es": "^4.17.12",
@@ -146,7 +149,8 @@
     "ioredis-mock": "^8.13.1",
     "typescript": "^7.0.0",
     "vite-plus": "0.2.4",
-    "vitest": "4.1.10"
+    "vitest": "4.1.10",
+    "yaml": "^2.9.0"
   },
   "optionalDependencies": {
     "s3-cnpmcore": "^1.1.2"

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,7 @@
+extends:
+  - recommended
+rules:
+  no-ambiguous-paths: off
+  no-server-example.com: off
+  operation-4xx-response: off
+  tag-description: off

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,2 +1,6 @@
 extends:
   - recommended
+
+rules:
+  no-ambiguous-paths: off
+  no-server-example.com: off

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,7 +1,2 @@
 extends:
   - recommended
-rules:
-  no-ambiguous-paths: off
-  no-server-example.com: off
-  operation-4xx-response: off
-  tag-description: off


### PR DESCRIPTION
现在的文字版的接口文档不便使用。之后是通过装饰器来生成swagger还是仅通过手动维护YMAL可以待定。

虽然现在AI生成这种东西很方便，有现成还是更好。后面是自己导入postman还是导入apifox（比如： https://b7jg582yhb.apifox.cn/ ）或者类似scalar都可以。将来也可以直接在项目里提供一个页面用来发送请求。

YMAL内容由AI生成，几个常用的接口试了一下没什么问题。作为临时方案够用。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive OpenAPI 3.1.1 specifications in JSON and YAML formats for the HTTP API.
  * Documented authentication, packages, registries, search, synchronization, administration, organizations, teams, hooks, tokens, proxy caching, binaries, and WebAuthn.
  * Added reusable request, response, parameter, security, and schema definitions.

* **Chores**
  * Added tooling and scripts to validate and bundle the API documentation.
  * Added configuration for consistent API documentation quality checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->