### PR TITLE
fix: treat upstream 404 as package deleted when syncing

### DIFF
--- a/app/core/service/PackageSyncerService.ts
+++ b/app/core/service/PackageSyncerService.ts
@@ -592,6 +592,12 @@ data sample: ${remoteData.subarray(0, 200).toString()}`;
     }
 
     if (status === 404) {
+      // treat 404 as removed in remote registry, process by syncDeleteMode
+      // https://github.com/cnpm/cnpmcore/issues/1115
+      if (this.config.cnpmcore.syncDeleteOnNotFound) {
+        await this.syncDeletePkg({ task, pkg, logs, logUrl, url: remoteUrl, data: remoteData });
+        return;
+      }
       // ignore 404 status
       // https://github.com/cnpm/cnpmcore/issues/739
       task.error = `Package not found, status 404, data size: ${remoteData.length}, data sample: ${remoteData.subarray(0, 200).toString()}`;

--- a/app/port/config.ts
+++ b/app/port/config.ts
@@ -43,6 +43,14 @@ export interface CnpmcoreConfig {
    */
   syncMode: SyncMode;
   syncDeleteMode: SyncDeleteMode;
+  /**
+   * when the upstream registry responds 404 for a package, treat it as removed in remote
+   * and process by `syncDeleteMode`, default is true.
+   * Set false to ignore 404 responses (the behavior before this option, see
+   * https://github.com/cnpm/cnpmcore/issues/739), useful when the upstream registry
+   * may return transient 404s.
+   */
+  syncDeleteOnNotFound: boolean;
   syncPackageWorkerMaxConcurrentTasks: number;
   triggerHookWorkerMaxConcurrentTasks: number;
   createTriggerHookWorkerMaxConcurrentTasks: number;

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -23,6 +23,7 @@ export const cnpmcoreConfig: CnpmcoreConfig = {
   taskQueueHighWaterSize: 100,
   syncMode: env('CNPMCORE_CONFIG_SYNC_MODE', 'string', SyncMode.none) as SyncMode,
   syncDeleteMode: SyncDeleteMode.delete,
+  syncDeleteOnNotFound: env('CNPMCORE_CONFIG_SYNC_DELETE_ON_NOT_FOUND', 'boolean', true),
   syncPackageWorkerMaxConcurrentTasks: 10,
   triggerHookWorkerMaxConcurrentTasks: 10,
   createTriggerHookWorkerMaxConcurrentTasks: 10,

--- a/test/core/service/PackageSyncerService/executeTask.test.ts
+++ b/test/core/service/PackageSyncerService/executeTask.test.ts
@@ -326,6 +326,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       app.mockAgent().assertNoPendingInterceptors();
 
       // mock 404 and no unpublished
+      mock(app.config.cnpmcore, 'syncDeleteOnNotFound', false);
       app.mockHttpclient('https://registry.npmjs.org/cnpmcore-test-sync-deprecated', 'GET', {
         status: 404,
         data: '{"error":"Not found"}',
@@ -359,8 +360,117 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert.ok(log.includes('Package not found, status 404'));
+      assert.ok(log.includes(`] 🟢 Package "${name}" was removed in remote registry`));
+      assert.ok(log.includes('Package not exists, response data:'));
       app.mockAgent().assertNoPendingInterceptors();
+    });
+
+    describe('upstream response 404, https://github.com/cnpm/cnpmcore/issues/1115', () => {
+      // sync foobar success first
+      beforeEach(async () => {
+        app.mockHttpclient('https://registry.npmjs.org/foobar', 'GET', {
+          data: await TestUtil.readFixturesFile('registry.npmjs.org/foobar.json'),
+          persist: false,
+          repeats: 1,
+        });
+        app.mockHttpclient('https://registry.npmjs.org/foobar/-/foobar-1.0.0.tgz', 'GET', {
+          data: await TestUtil.readFixturesFile('registry.npmjs.org/foobar/-/foobar-1.0.0.tgz'),
+          persist: false,
+        });
+        app.mockHttpclient('https://registry.npmjs.org/foobar/-/foobar-1.1.0.tgz', 'GET', {
+          data: await TestUtil.readFixturesFile('registry.npmjs.org/foobar/-/foobar-1.1.0.tgz'),
+          persist: false,
+        });
+        await packageSyncerService.createTask('foobar', {
+          skipDependencies: true,
+        });
+        const task = await packageSyncerService.findExecuteTask();
+        assert.ok(task);
+        await packageSyncerService.executeTask(task);
+        const model = await PackageModel.findOne({ scope: '', name: 'foobar' });
+        assert.ok(model);
+        const versions = await PackageVersion.find({ packageId: model.packageId });
+        assert.equal(versions.length, 2);
+      });
+
+      it('should treat 404 as deleted and remove all versions by default', async () => {
+        app.mockHttpclient('https://registry.npmjs.org/foobar', 'GET', {
+          status: 404,
+          data: '{"error":"Not found"}',
+          persist: false,
+        });
+        await packageSyncerService.createTask('foobar', {
+          skipDependencies: true,
+        });
+        const task = await packageSyncerService.findExecuteTask();
+        assert.ok(task);
+        await packageSyncerService.executeTask(task);
+        const stream = await packageSyncerService.findTaskLog(task);
+        assert.ok(stream);
+        const log = await TestUtil.readStreamToLog(stream);
+        // console.log(log);
+        assert.ok(log.includes('] 🟢 Package "foobar" was removed in remote registry'));
+        assert.ok(log.includes('] 🟢 Delete the package since config.syncDeleteMode = delete'));
+        const model = await PackageModel.findOne({ scope: '', name: 'foobar' });
+        assert.ok(model);
+        const versions = await PackageVersion.find({ packageId: model.packageId });
+        assert.equal(versions.length, 0);
+        const { data } = await packageManagerService.listPackageFullManifests('', 'foobar');
+        assert.ok(data?.time.unpublished);
+        app.mockAgent().assertNoPendingInterceptors();
+      });
+
+      it('should block the package on 404 when syncDeleteMode = block', async () => {
+        mock(app.config.cnpmcore, 'syncDeleteMode', 'block');
+        app.mockHttpclient('https://registry.npmjs.org/foobar', 'GET', {
+          status: 404,
+          data: '{"error":"Not found"}',
+          persist: false,
+        });
+        await packageSyncerService.createTask('foobar', {
+          skipDependencies: true,
+        });
+        const task = await packageSyncerService.findExecuteTask();
+        assert.ok(task);
+        await packageSyncerService.executeTask(task);
+        const stream = await packageSyncerService.findTaskLog(task);
+        assert.ok(stream);
+        const log = await TestUtil.readStreamToLog(stream);
+        assert.ok(log.includes('] 🟢 Package "foobar" was removed in remote registry'));
+        assert.ok(log.includes('] 🟢 Block the package since config.syncDeleteMode = block'));
+        const manifests = await packageManagerService.listPackageFullManifests('', 'foobar');
+        assert.equal(manifests.blockReason, 'Removed in remote registry');
+        const model = await PackageModel.findOne({ scope: '', name: 'foobar' });
+        assert.ok(model);
+        const versions = await PackageVersion.find({ packageId: model.packageId });
+        assert.equal(versions.length, 2);
+        app.mockAgent().assertNoPendingInterceptors();
+      });
+
+      it('should ignore 404 when syncDeleteOnNotFound is disabled', async () => {
+        mock(app.config.cnpmcore, 'syncDeleteOnNotFound', false);
+        app.mockHttpclient('https://registry.npmjs.org/foobar', 'GET', {
+          status: 404,
+          data: '{"error":"Not found"}',
+          persist: false,
+        });
+        await packageSyncerService.createTask('foobar', {
+          skipDependencies: true,
+        });
+        const task = await packageSyncerService.findExecuteTask();
+        assert.ok(task);
+        await packageSyncerService.executeTask(task);
+        const stream = await packageSyncerService.findTaskLog(task);
+        assert.ok(stream);
+        const log = await TestUtil.readStreamToLog(stream);
+        assert.ok(log.includes('Package not found, status 404'));
+        assert.ok(!log.includes('was removed in remote registry'));
+        const model = await PackageModel.findOne({ scope: '', name: 'foobar' });
+        assert.ok(model);
+        const versions = await PackageVersion.find({ packageId: model.packageId });
+        assert.equal(versions.length, 2);
+        app.mockAgent().assertNoPendingInterceptors();
+      });
     });
 
     it('should ignore PositionNotEqualToLength error', async () => {

--- a/test/core/service/PackageSyncerService/executeTaskWithPackument.test.ts
+++ b/test/core/service/PackageSyncerService/executeTaskWithPackument.test.ts
@@ -596,6 +596,7 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
       app.mockAgent().assertNoPendingInterceptors();
 
       // mock 404 and no unpublished
+      mock(app.config.cnpmcore, 'syncDeleteOnNotFound', false);
       app.mockHttpclient('https://registry.npmjs.org/cnpmcore-test-sync-deprecated', 'GET', {
         status: 404,
         data: '{"error":"Not found"}',
@@ -629,7 +630,8 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
       assert.ok(stream);
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
-      assert.ok(log.includes('Package not found, status 404'));
+      assert.ok(log.includes(`] 🟢 Package "${name}" was removed in remote registry`));
+      assert.ok(log.includes('Package not exists, response data:'));
       app.mockAgent().assertNoPendingInterceptors();
     });
 


### PR DESCRIPTION
When the upstream registry responds 404 for a package manifest, the sync task now treats the package as removed in the remote registry and processes it through the same flow as a 451 response, honoring `syncDeleteMode` (delete/block/ignore). Before this change the task ignored 404 responses, so fully unpublished packages kept their stale versions and maintainer metadata on the mirror.

The new `syncDeleteOnNotFound` config (default `true`, env `CNPMCORE_CONFIG_SYNC_DELETE_ON_NOT_FOUND`) controls this. Set it to `false` to restore the ignore behavior from #739, which guards against upstream registries that return transient 404s during maintenance. Registries that worry about that case can also use `syncDeleteMode = block` for a reversible removal.

Closes #1115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable handling for packages that return “404 Not Found” during synchronization.
  - By default, missing upstream packages are treated as removed and processed according to the configured deletion mode.
  - Added an option to preserve packages and versions when upstream returns 404.

- **Bug Fixes**
  - Improved removal and access-blocking behavior for packages no longer available upstream.
  - Enhanced logging and response details for not-found packages.

- **Tests**
  - Added coverage for removal, blocking, and preservation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->