### PR TITLE
fix(playwright): mirror browsers required by @playwright/cli

### DIFF
--- a/app/common/adapter/binary/PlaywrightBinary.ts
+++ b/app/common/adapter/binary/PlaywrightBinary.ts
@@ -7,6 +7,7 @@ import { BinaryType } from '../../enum/Binary.ts';
 import { AbstractBinary, BinaryAdapter, type BinaryItem, type FetchResult } from './AbstractBinary.ts';
 
 const PACKAGE_URL = 'https://registry.npmjs.com/playwright-core';
+const PLAYWRIGHT_CLI_PACKAGE_URL = 'https://registry.npmjs.com/@playwright%2fcli/latest';
 // playwright.azureedge.net is deprecated and returns 400 for the new
 // `builds/cft/*` namespace; cdn.playwright.dev serves both the legacy
 // `builds/*` and the CFT paths. See https://github.com/cnpm/cnpmcore/issues/1033
@@ -330,7 +331,12 @@ export class PlaywrightBinary extends AbstractBinary {
 
   async fetch(dir: string): Promise<FetchResult | undefined> {
     if (!this.dirItems) {
-      const packageData = await this.requestJSON(PACKAGE_URL);
+      const [packageData, playwrightCliPackageData] = await Promise.all([
+        this.requestJSON(PACKAGE_URL),
+        this.requestJSON(PLAYWRIGHT_CLI_PACKAGE_URL).catch((err) => {
+          this.logger.warn('[PlaywrightBinary.fetch:error] @playwright/cli package data request failed: %s', err);
+        }),
+      ]);
       const nowDateISO = new Date().toISOString();
       const buildDirs: BinaryItem[] = [];
       for (const browserName of Object.keys(DOWNLOAD_PATHS)) {
@@ -386,6 +392,14 @@ export class PlaywrightBinary extends AbstractBinary {
         .filter((version) => version.match(/^(?:\d+\.\d+\.\d+)(?:-beta-\d+)?$/))
         // select recently update 20 items
         .slice(-20);
+      // @playwright/cli can pin an alpha playwright-core release. Include that
+      // exact version when discovering browser revisions without mirroring all
+      // daily alpha driver archives.
+      const browserPackageVersions = new Set(packageVersions);
+      const cliPlaywrightCoreVersion = playwrightCliPackageData?.dependencies?.['playwright-core'];
+      if (typeof cliPlaywrightCoreVersion === 'string') {
+        browserPackageVersions.add(cliPlaywrightCoreVersion);
+      }
       // Add driver to dirItems
       this.dirItems['/builds/driver/'] = [];
       const hasBetaVersions = packageVersions.some((version) => version.includes('-beta-'));
@@ -425,7 +439,7 @@ export class PlaywrightBinary extends AbstractBinary {
         revisionOverrides?: Record<string, string>;
       }[] = [];
       await Promise.all(
-        packageVersions.map((version) =>
+        Array.from(browserPackageVersions, (version) =>
           this.requestJSON(`https://unpkg.com/playwright-core@${version}/browsers.json`)
             .then((data) => {
               // browsers: [

--- a/app/repository/PackageVersionBlockRepository.ts
+++ b/app/repository/PackageVersionBlockRepository.ts
@@ -43,7 +43,7 @@ export class PackageVersionBlockRepository extends AbstractRepository {
     return null;
   }
 
-  async listPackageVersionBlocks(packageId: string) {
+  async listPackageVersionBlocks(packageId: string): Promise<PackageVersionBlockModel[]> {
     return await this.PackageVersionBlock.find({ packageId });
   }
 

--- a/app/repository/PackageVersionDownloadRepository.ts
+++ b/app/repository/PackageVersionDownloadRepository.ts
@@ -48,7 +48,7 @@ export class PackageVersionDownloadRepository extends AbstractRepository {
     );
   }
 
-  async query(packageId: string, start: Date, end: Date) {
+  async query(packageId: string, start: Date, end: Date): Promise<PackageVersionDownloadModel[]> {
     const startYearMonth = start.getFullYear() * 100 + start.getMonth() + 1;
     const endYearMonth = end.getFullYear() * 100 + end.getMonth() + 1;
     const models = await this.PackageVersionDownload.find({

--- a/app/repository/ProxyCacheRepository.ts
+++ b/app/repository/ProxyCacheRepository.ts
@@ -48,7 +48,7 @@ export class ProxyCacheRepository extends AbstractRepository {
   }
 
   // used by update & delete all cache
-  async findProxyCaches(fullname: string, version?: string) {
+  async findProxyCaches(fullname: string, version?: string): Promise<ProxyModeCachedFilesModel[]> {
     const models = version
       ? await this.ProxyCache.find({ fullname, version })
       : await this.ProxyCache.find({ fullname });

--- a/app/repository/util/ModelConvertor.ts
+++ b/app/repository/util/ModelConvertor.ts
@@ -15,6 +15,7 @@ interface BonePatchInfo {
   createdAt?: Date;
 }
 type PatchedBone = LeoricBone & BonePatchInfo;
+type LeoricUpdateChanges = Parameters<LeoricBone['update']>[0];
 
 export class ModelConvertor {
   static async convertEntityToModel<T extends PatchedBone>(
@@ -44,7 +45,7 @@ export class ModelConvertor {
   }
 
   static convertEntityToChanges<T extends LeoricBone>(entity: object, ModelClazz: EggProtoImplClass<T>) {
-    const changes: Record<string, unknown> = {};
+    const changes: LeoricUpdateChanges = {};
     const metadata = ModelMetadataUtil.getModelMetadata(ModelClazz);
     if (!metadata) {
       throw new Error(`Model ${ModelClazz.name} has no metadata`);

--- a/app/repository/util/leoric.ts
+++ b/app/repository/util/leoric.ts
@@ -1,6 +1,8 @@
 import leoric from 'leoric';
 
-const { DataTypes, Bone, LENGTH_VARIANTS } = leoric;
+const DataTypes: typeof import('leoric').DataTypes = leoric.DataTypes;
+const Bone: typeof import('leoric').Bone = leoric.Bone;
+const LENGTH_VARIANTS: typeof import('leoric').LENGTH_VARIANTS = leoric.LENGTH_VARIANTS;
 
 export { DataTypes, Bone, LENGTH_VARIANTS };
 

--- a/test/.setup.ts
+++ b/test/.setup.ts
@@ -3,6 +3,15 @@ import { afterEach, beforeEach, vi } from 'vite-plus/test';
 import { PackageManagerService } from '../app/core/service/PackageManagerService.ts';
 import { TestUtil } from './TestUtil.ts';
 
+// egg-bin inlines dependencies in Vitest, but Leoric 2.15's ESM entry also assigns to module.exports.
+// Load its CommonJS condition so Vitest does not evaluate those incompatible module semantics together.
+// Remove this mock once cnpmcore requires a Leoric release containing https://github.com/cyjake/leoric/pull/499.
+vi.mock('leoric', async () => {
+  const { createRequire } = await import('node:module');
+  const leoric = createRequire(import.meta.url)('leoric') as typeof import('leoric');
+  return { ...leoric, default: leoric };
+});
+
 // vitest hookTimeout defaults to 10s, align with egg-bin's testTimeout (60s)
 vi.setConfig({ hookTimeout: 60_000 });
 

--- a/test/common/adapter/binary/PlaywrightBinary.test.ts
+++ b/test/common/adapter/binary/PlaywrightBinary.test.ts
@@ -5,6 +5,15 @@ import { app } from '@eggjs/mock/bootstrap';
 import { PlaywrightBinary } from '../../../../app/common/adapter/binary/PlaywrightBinary.ts';
 import { TestUtil } from '../../../../test/TestUtil.ts';
 
+const PLAYWRIGHT_CLI_PACKAGE_URL = 'https://registry.npmjs.com/@playwright%2fcli/latest';
+
+function mockPlaywrightCli(data: Record<string, unknown> = {}) {
+  app.mockHttpclient(PLAYWRIGHT_CLI_PACKAGE_URL, 'GET', {
+    data,
+    persist: false,
+  });
+}
+
 describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
   let binary: PlaywrightBinary;
   beforeEach(async () => {
@@ -17,6 +26,7 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('registry.npmjs.com/playwright-core.json'),
         persist: false,
       });
+      mockPlaywrightCli();
       app
         .mockAgent()
         .get('https://unpkg.com')
@@ -48,6 +58,7 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
         data: await TestUtil.readFixturesFile('registry.npmjs.com/playwright-core.json'),
         persist: false,
       });
+      mockPlaywrightCli();
       app
         .mockAgent()
         .get('https://unpkg.com')
@@ -113,11 +124,88 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
       assert.equal(linuxArm64.url, 'https://cdn.playwright.dev/builds/chromium/1155/chromium-linux-arm64.zip');
     });
 
+    // https://github.com/cnpm/cnpmcore/issues/1123
+    it('should mirror the alpha browser version required by @playwright/cli', async () => {
+      const cliPlaywrightVersion = '1.63.0-alpha-2026-08-05';
+      app.mockHttpclient('https://registry.npmjs.com/playwright-core', 'GET', {
+        data: {
+          versions: {
+            '1.62.1': {},
+            [cliPlaywrightVersion]: {},
+          },
+        },
+        persist: false,
+      });
+      mockPlaywrightCli({
+        dependencies: {
+          'playwright-core': cliPlaywrightVersion,
+        },
+      });
+
+      const mockAgent = app.mockAgent().get('https://unpkg.com');
+      mockAgent
+        .intercept({
+          method: 'GET',
+          path: '/playwright-core@1.62.1/browsers.json',
+        })
+        .reply(200, {
+          browsers: [
+            {
+              name: 'chromium',
+              revision: '1234',
+              browserVersion: '151.0.7922.34',
+            },
+            {
+              name: 'chromium-headless-shell',
+              revision: '1234',
+              browserVersion: '151.0.7922.34',
+            },
+          ],
+        });
+      mockAgent
+        .intercept({
+          method: 'GET',
+          path: `/playwright-core@${cliPlaywrightVersion}/browsers.json`,
+        })
+        .reply(200, {
+          browsers: [
+            {
+              name: 'chromium',
+              revision: '1237',
+              browserVersion: '152.0.7977.8',
+            },
+            {
+              name: 'chromium-headless-shell',
+              revision: '1237',
+              browserVersion: '152.0.7977.8',
+            },
+          ],
+        });
+
+      const cftResult = await binary.fetch('/builds/cft/');
+      assert.ok(cftResult);
+      assert.ok(
+        cftResult.items.some((item) => item.name === '152.0.7977.8/'),
+        'cft/ should include the browser version pinned by @playwright/cli',
+      );
+
+      const linuxResult = await binary.fetch('/builds/cft/152.0.7977.8/linux64/');
+      assert.ok(linuxResult);
+      assert.deepEqual(linuxResult.items.map((item) => item.name).sort(), [
+        'chrome-headless-shell-linux64.zip',
+        'chrome-linux64.zip',
+      ]);
+      for (const item of linuxResult.items) {
+        assert.match(item.url, /^https:\/\/cdn\.playwright\.dev\/builds\/cft\/152\.0\.7977\.8\/linux64\//);
+      }
+    });
+
     it('should fetch subdir: /builds/, /builds/chromium/ work', async () => {
       app.mockHttpclient('https://registry.npmjs.com/playwright-core', 'GET', {
         data: await TestUtil.readFixturesFile('registry.npmjs.com/playwright-core.json'),
         persist: false,
       });
+      mockPlaywrightCli();
       app
         .mockAgent()
         .get('https://unpkg.com')

--- a/test/common/adapter/binary/PlaywrightBinary.test.ts
+++ b/test/common/adapter/binary/PlaywrightBinary.test.ts
@@ -18,6 +18,7 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
   let binary: PlaywrightBinary;
   beforeEach(async () => {
     binary = await app.getEggObject(PlaywrightBinary);
+    await binary.initFetch();
   });
 
   describe('fetch()', () => {

--- a/test/common/adapter/binary/PlaywrightBinary.test.ts
+++ b/test/common/adapter/binary/PlaywrightBinary.test.ts
@@ -201,6 +201,29 @@ describe('test/common/adapter/binary/PlaywrightBinary.test.ts', () => {
       }
     });
 
+    it('should fall back to stable versions when @playwright/cli metadata is unavailable', async () => {
+      app.mockHttpclient('https://registry.npmjs.com/playwright-core', 'GET', {
+        data: await TestUtil.readFixturesFile('registry.npmjs.com/playwright-core.json'),
+        persist: false,
+      });
+      app.mockHttpclient(PLAYWRIGHT_CLI_PACKAGE_URL, () => {
+        throw new Error('mock @playwright/cli metadata request error');
+      });
+      app
+        .mockAgent()
+        .get('https://unpkg.com')
+        .intercept({
+          method: 'GET',
+          path: /browsers\.json/,
+        })
+        .reply(200, await TestUtil.readFixturesFile('unpkg.com/playwright-core-browsers.json'))
+        .persist();
+
+      const result = await binary.fetch('/builds/cft/');
+      assert.ok(result);
+      assert.ok(result.items.some((item) => item.name === '133.0.6943.16/'));
+    });
+
     it('should fetch subdir: /builds/, /builds/chromium/ work', async () => {
       app.mockHttpclient('https://registry.npmjs.com/playwright-core', 'GET', {
         data: await TestUtil.readFixturesFile('registry.npmjs.com/playwright-core.json'),

--- a/test/port/controller/HomeController/showTotal.test.ts
+++ b/test/port/controller/HomeController/showTotal.test.ts
@@ -133,8 +133,7 @@ describe('test/port/controller/HomeController/showTotal.test.ts', () => {
           yearMonth: yesterdayYearMonthInt,
         });
       }
-      // @ts-expect-error dynamic key
-      row[`d${yesterdayDate}`] = 1;
+      Reflect.set(row, `d${yesterdayDate}`, 1);
       await row.save();
 
       row = await PackageVersionDownload.findOne({
@@ -148,8 +147,7 @@ describe('test/port/controller/HomeController/showTotal.test.ts', () => {
           yearMonth: lastWeekYearMonthInt,
         });
       }
-      // @ts-expect-error dynamic key
-      row[`d${lastWeekDate}`] = 1;
+      Reflect.set(row, `d${lastWeekDate}`, 1);
       await row.save();
 
       row = await PackageVersionDownload.findOne({
@@ -163,8 +161,7 @@ describe('test/port/controller/HomeController/showTotal.test.ts', () => {
           yearMonth: lastMonthYearMonthInt,
         });
       }
-      // @ts-expect-error dynamic key
-      row[`d${lastMonthDate}`] = 1;
+      Reflect.set(row, `d${lastMonthDate}`, 1);
       await row.save();
 
       row = await PackageVersionDownload.findOne({
@@ -178,8 +175,7 @@ describe('test/port/controller/HomeController/showTotal.test.ts', () => {
           yearMonth: lastYearYearMonthInt,
         });
       }
-      // @ts-expect-error dynamic key
-      row[`d${lastYearDate}`] = 1;
+      Reflect.set(row, `d${lastYearDate}`, 1);
       await row.save();
 
       await app.runSchedule(UpdateTotalDataPath);


### PR DESCRIPTION
## Summary

- fetch the current `@playwright/cli` package metadata during Playwright binary discovery
- add its exact `playwright-core` dependency to browser metadata candidates
- keep alpha versions out of driver archive discovery, avoiding unsupported daily alpha driver downloads
- add a regression test for Chromium `152.0.7977.8` from `playwright-core@1.63.0-alpha-2026-08-05`
- keep the test suite compatible with Leoric 2.15 while its ESM packaging fix is released upstream

## Root cause

`@playwright/cli@latest` pins an alpha `playwright-core` release, while `PlaywrightBinary` only selected stable and numeric beta releases. The alpha version's `browsers.json` was never read, so its CFT browser version never entered the mirror sync tree even when the sync worker was healthy.

During CI, the newly published Leoric 2.15.0 also exposed an unrelated ESM packaging incompatibility with Vitest. This branch adapts to its updated types and loads its CommonJS condition in test setup. The upstream fix is tracked in https://github.com/cyjake/leoric/pull/499.

Closes #1123

## Validation

- [x] `ut lint`
- [x] `ut build`
- [x] `ut execute egg-bin test test/common/adapter/binary/PlaywrightBinary.test.ts` (4 passed)
- [x] `ut execute egg-bin test test/port/controller/HomeController/showTotal.test.ts` (6 passed)
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser discovery now includes versions pinned to alpha Playwright CLI releases.
  * Stable browser data remains available when Playwright CLI metadata cannot be retrieved.

* **Bug Fixes**
  * Improved resilience of browser metadata fetching when CLI metadata requests fail.

* **Tests**
  * Added coverage for alpha-pinned browser versions and metadata fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->