### PR TITLE
docs: guide security reports to GitHub advisories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,17 +14,39 @@ The cnpmcore OSS team and community take all security vulnerabilities seriously.
 Thank you for improving the security of our open source software.
 We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.
 
-Report security vulnerabilities by emailing the cnpmcore security team at:
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+### Preferred: GitHub Security Advisories
+
+Report vulnerabilities through GitHub's private vulnerability reporting:
+
+https://github.com/cnpm/cnpmcore/security/advisories/new
+
+The report stays private between you and the maintainers, keeps the whole discussion in one place,
+and lets us credit you on the published advisory and request a CVE when the fix ships.
+
+Include as much of the following as you can:
+
+- The type of issue, and the affected version or commit.
+- Full paths of the source files related to the issue.
+- Step-by-step instructions to reproduce it, including any proof-of-concept or exploit code.
+- The impact of the issue, and how an attacker might exploit it.
+
+### Alternative: email
+
+If you cannot use GitHub Security Advisories, email the cnpmcore security team at:
 
 ```
 fengmk2+cnpmcoresecurity@gmail.com
 killa07071201@gmail.com
+smith3816@gmail.com
+elrrrrrrr@gmail.com
 ```
 
-The lead maintainer will acknowledge your email within 48 hours,
-and will send a more detailed response within 72 hours indicating the next steps in handling your report.
-After the initial reply to your report,
-the security team will endeavor to keep you informed of the progress towards a fix and full announcement,
+We will acknowledge your report within 48 hours,
+and will send a more detailed response within 72 hours indicating the next steps in handling it.
+After that first reply,
+the security team will keep you informed of the progress towards a fix and full announcement,
 and may ask for additional information or guidance.
 
 Report security vulnerabilities in third-party modules to the person or team maintaining the module.
@@ -39,3 +61,5 @@ process, involving the following steps:
 - Audit code to find any potential similar problems.
 - Prepare fixes for all releases still under maintenance. These fixes
   will be released as fast as possible to NPM.
+- Publish a GitHub Security Advisory once the fix is out, crediting the reporter
+  unless they ask to stay anonymous.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Currently being supported with security updates.
+We give security updates to these versions:
 
 | Version  | Supported          |
 | -------- | ------------------ |
@@ -10,9 +10,10 @@ Currently being supported with security updates.
 
 ## Reporting a Vulnerability
 
-The cnpmcore OSS team and community take all security vulnerabilities seriously.
-Thank you for improving the security of our open source software.
-We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.
+The cnpmcore team and the community give full attention to all security vulnerabilities.
+Thank you for your work to make our open source software more secure.
+We value your effort and your responsible disclosure.
+We will give you credit for your contribution.
 
 **Do not report security vulnerabilities in public GitHub issues, discussions, or pull requests.**
 
@@ -56,17 +57,18 @@ We will then tell you the next steps.
 The security team will tell you about the progress of the fix and the announcement.
 The team can also ask you for more information.
 
-Report security vulnerabilities in third-party modules to the person or team maintaining the module.
+Report a vulnerability in a third-party module to the person or the team that maintains the module.
 
 ## Disclosure Policy
 
-When the security team receives a security bug report, they will assign it
-to a primary handler. This person will coordinate the fix and release
-process, involving the following steps:
+The security team assigns each report to a primary handler.
+The primary handler controls the fix and the release.
+The handler does these steps:
 
-- Confirm the problem and determine the affected versions.
-- Audit code to find any potential similar problems.
-- Prepare fixes for all releases still under maintenance. These fixes
-  will be released as fast as possible to NPM.
+- Confirm the problem.
+- Find the versions that have the problem.
+- Examine the code to find related problems.
+- Prepare a fix for each release that we maintain.
+- Release the fixes to NPM as soon as possible.
 - Publish a GitHub Security Advisory after we release the fix.
   Give credit to the reporter, unless the reporter asks to stay anonymous.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ We give security updates to these versions:
 | -------- | ------------------ |
 | >= 3.0.0 | :white_check_mark: |
 
-## Reporting a Vulnerability
+## Report a Vulnerability
 
 The cnpmcore team and the community give full attention to all security vulnerabilities.
 Thank you for your work to make our open source software more secure.
@@ -40,7 +40,7 @@ Give as much of this information as you can:
 - The impact of the issue.
 - The method that an attacker can use to exploit the issue.
 
-### Alternative: email
+### Alternative: Email
 
 If you cannot use GitHub Security Advisories, send an email to the cnpmcore security team:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,8 +43,8 @@ smith3816@gmail.com
 elrrrrrrr@gmail.com
 ```
 
-We will acknowledge your report within 48 hours,
-and will send a more detailed response within 72 hours indicating the next steps in handling it.
+We will acknowledge your report and process it as soon as possible,
+then reply with the next steps in handling it.
 After that first reply,
 the security team will keep you informed of the progress towards a fix and full announcement,
 and may ask for additional information or guidance.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,27 +14,34 @@ The cnpmcore OSS team and community take all security vulnerabilities seriously.
 Thank you for improving the security of our open source software.
 We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.
 
-**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+**Do not report security vulnerabilities in public GitHub issues, discussions, or pull requests.**
 
 ### Preferred: GitHub Security Advisories
 
-Report vulnerabilities through GitHub's private vulnerability reporting:
+Send your report with GitHub private vulnerability reporting:
 
 https://github.com/cnpm/cnpmcore/security/advisories/new
 
-The report stays private between you and the maintainers, keeps the whole discussion in one place,
-and lets us credit you on the published advisory and request a CVE when the fix ships.
+A private report has these advantages:
 
-Include as much of the following as you can:
+- Only you and the maintainers can read the report.
+- All of the discussion stays in one place.
+- We can give you credit in the advisory when we publish it.
+- We can request a CVE when we release the fix.
 
-- The type of issue, and the affected version or commit.
-- Full paths of the source files related to the issue.
-- Step-by-step instructions to reproduce it, including any proof-of-concept or exploit code.
-- The impact of the issue, and how an attacker might exploit it.
+Give as much of this information as you can:
+
+- The type of the issue.
+- The version or the commit that has the issue.
+- The full path of each source file that relates to the issue.
+- The steps to reproduce the issue.
+- The proof-of-concept code or the exploit code, if you have it.
+- The impact of the issue.
+- The method that an attacker can use to exploit the issue.
 
 ### Alternative: email
 
-If you cannot use GitHub Security Advisories, email the cnpmcore security team at:
+If you cannot use GitHub Security Advisories, send an email to the cnpmcore security team:
 
 ```
 fengmk2+cnpmcoresecurity@gmail.com
@@ -43,11 +50,11 @@ smith3816@gmail.com
 elrrrrrrr@gmail.com
 ```
 
-We will acknowledge your report and process it as soon as possible,
-then reply with the next steps in handling it.
-After that first reply,
-the security team will keep you informed of the progress towards a fix and full announcement,
-and may ask for additional information or guidance.
+We will confirm that we received your report.
+We will process the report as soon as possible.
+We will then tell you the next steps.
+The security team will tell you about the progress of the fix and the announcement.
+The team can also ask you for more information.
 
 Report security vulnerabilities in third-party modules to the person or team maintaining the module.
 
@@ -61,5 +68,5 @@ process, involving the following steps:
 - Audit code to find any potential similar problems.
 - Prepare fixes for all releases still under maintenance. These fixes
   will be released as fast as possible to NPM.
-- Publish a GitHub Security Advisory once the fix is out, crediting the reporter
-  unless they ask to stay anonymous.
+- Publish a GitHub Security Advisory after we release the fix.
+  Give credit to the reporter, unless the reporter asks to stay anonymous.


### PR DESCRIPTION
Point reporters at https://github.com/cnpm/cnpmcore/security/advisories/new instead of email as the first step. Private vulnerability reporting is already enabled on the repo, so the link works for anyone.

- GitHub Security Advisories is now the preferred channel, with a short list of what to include in a report.
- Email stays as the fallback; adds `smith3816@gmail.com` and `elrrrrrrr@gmail.com` to the contact list.
- States that public issues, discussions, and PRs are not for vulnerability reports.
- Disclosure policy now ends with publishing the advisory and crediting the reporter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the vulnerability reporting policy to prioritize private security advisories over public reports.
  * Added guidance on submitting vulnerability details and reproduction steps.
  * Updated the alternative email reporting process and response expectations.
  * Clarified post-fix disclosure and reporter crediting practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->