### PR TITLE
feat: build ES2022 artifacts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,7 @@ Key `AbstractController` methods:
 - ORM definitions using Leoric
 - Database schema mapping
 - No business logic
+- Every `@Attribute` property must be declared with `declare` (e.g. `declare packageId: string;`). The build targets ES2022, so a plain declaration emits a real class field that shadows Leoric's attribute accessor and makes the model throw `LeoricClassFieldError` at runtime. `declare` erases the field while keeping the decorator metadata.
 
 **Model-Entity Bridge** (`app/repository/util/`):
 
@@ -386,7 +387,7 @@ test/                # Test files (mirrors app/ structure)
 - `config/database.ts` - Database connection settings
 - `config/binaries.ts` - Binary package mirror configurations
 - `.env` - Environment-specific variables (copy from `.env.example`)
-- `tsconfig.json` - TypeScript settings (target: ES2021 for Leoric compatibility)
+- `tsconfig.json` - TypeScript settings (target: ES2022, which turns on `useDefineForClassFields`; see the Model Layer note on `declare`)
 
 ## Development Workflow
 

--- a/INTEGRATE.md
+++ b/INTEGRATE.md
@@ -45,7 +45,7 @@ npm i cnpmcore
   "extends": "@eggjs/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
-    "target": "ES2021"
+    "target": "ES2022"
   }
 }
 ```

--- a/app/repository/model/Binary.ts
+++ b/app/repository/model/Binary.ts
@@ -8,34 +8,34 @@ export class Binary extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  binaryId: string;
+  declare binaryId: string;
 
   @Attribute(DataTypes.STRING(50))
-  category: string;
+  declare category: string;
 
   @Attribute(DataTypes.STRING(700))
-  parent: string;
+  declare parent: string;
 
   @Attribute(DataTypes.STRING(200))
-  name: string;
+  declare name: string;
 
   @Attribute(DataTypes.BOOLEAN)
-  isDir: boolean;
+  declare isDir: boolean;
 
   @Attribute(DataTypes.INTEGER(11).UNSIGNED)
-  size: number;
+  declare size: number;
 
   @Attribute(DataTypes.STRING(100))
-  date: string;
+  declare date: string;
 }

--- a/app/repository/model/Change.ts
+++ b/app/repository/model/Change.ts
@@ -8,26 +8,26 @@ export class Change extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  changeId: string;
+  declare changeId: string;
 
   @Attribute(DataTypes.STRING(50))
-  type: string;
+  declare type: string;
 
   @Attribute(DataTypes.STRING(214))
-  targetName: string;
+  declare targetName: string;
 
   @Attribute(DataTypes.JSONB)
   // oxlint-disable-next-line typescript-eslint/no-explicit-any
-  data: any;
+  declare data: any;
 }

--- a/app/repository/model/Dist.ts
+++ b/app/repository/model/Dist.ts
@@ -8,31 +8,31 @@ export class Dist extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  distId: string;
+  declare distId: string;
 
   @Attribute(DataTypes.STRING(100))
-  name: string;
+  declare name: string;
 
   @Attribute(DataTypes.STRING(512))
-  path: string;
+  declare path: string;
 
   @Attribute(DataTypes.INTEGER(11).UNSIGNED)
-  size: number;
+  declare size: number;
 
   @Attribute(DataTypes.STRING(512))
-  shasum: string;
+  declare shasum: string;
 
   @Attribute(DataTypes.STRING(512))
-  integrity: string;
+  declare integrity: string;
 }

--- a/app/repository/model/HistoryTask.ts
+++ b/app/repository/model/HistoryTask.ts
@@ -9,46 +9,46 @@ export class HistoryTask extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  taskId: string;
+  declare taskId: string;
 
   @Attribute(DataTypes.STRING(20))
-  type: TaskType;
+  declare type: TaskType;
 
   @Attribute(DataTypes.STRING(20))
-  state: TaskState;
+  declare state: TaskState;
 
   @Attribute(DataTypes.STRING(214))
-  targetName: string;
+  declare targetName: string;
 
   @Attribute(DataTypes.STRING(24))
-  authorId: string;
+  declare authorId: string;
 
   @Attribute(DataTypes.STRING(100))
-  authorIp: string;
+  declare authorIp: string;
 
   @Attribute(DataTypes.JSONB)
-  data: object;
+  declare data: object;
 
   @Attribute(DataTypes.STRING(512))
-  logPath: string;
+  declare logPath: string;
 
   @Attribute(DataTypes.STRING(10))
-  logStorePosition: string;
+  declare logStorePosition: string;
 
   @Attribute(DataTypes.INTEGER)
-  attempts: number;
+  declare attempts: number;
 
   @Attribute(DataTypes.TEXT(LENGTH_VARIANTS.long))
-  error: string;
+  declare error: string;
 }

--- a/app/repository/model/Hook.ts
+++ b/app/repository/model/Hook.ts
@@ -9,39 +9,39 @@ export class Hook extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  hookId: string;
+  declare hookId: string;
 
   @Attribute(DataTypes.STRING(20))
-  type: HookType;
+  declare type: HookType;
 
   @Attribute(DataTypes.STRING(24))
-  ownerId: string;
+  declare ownerId: string;
 
   @Attribute(DataTypes.STRING(428))
-  name: string;
+  declare name: string;
 
   @Attribute(DataTypes.STRING(2048))
-  endpoint: string;
+  declare endpoint: string;
 
   @Attribute(DataTypes.STRING(200))
-  secret: string;
+  declare secret: string;
 
   @Attribute(DataTypes.STRING(24), {
     allowNull: true,
   })
-  latestTaskId: string;
+  declare latestTaskId: string;
 
   @Attribute(DataTypes.BOOLEAN)
-  enable: boolean;
+  declare enable: boolean;
 }

--- a/app/repository/model/Maintainer.ts
+++ b/app/repository/model/Maintainer.ts
@@ -8,17 +8,17 @@ export class Maintainer extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24))
-  packageId: string;
+  declare packageId: string;
 
   @Attribute(DataTypes.STRING(24))
-  userId: string;
+  declare userId: string;
 }

--- a/app/repository/model/Org.ts
+++ b/app/repository/model/Org.ts
@@ -8,20 +8,20 @@ export class Org extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24))
-  orgId: string;
+  declare orgId: string;
 
   @Attribute(DataTypes.STRING(214))
-  name: string;
+  declare name: string;
 
   @Attribute(DataTypes.STRING(10240), { allowNull: true })
-  description: string;
+  declare description: string;
 }

--- a/app/repository/model/OrgMember.ts
+++ b/app/repository/model/OrgMember.ts
@@ -8,23 +8,23 @@ export class OrgMember extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24))
-  orgMemberId: string;
+  declare orgMemberId: string;
 
   @Attribute(DataTypes.STRING(24))
-  orgId: string;
+  declare orgId: string;
 
   @Attribute(DataTypes.STRING(24))
-  userId: string;
+  declare userId: string;
 
   @Attribute(DataTypes.STRING(20))
-  role: string;
+  declare role: string;
 }

--- a/app/repository/model/Package.ts
+++ b/app/repository/model/Package.ts
@@ -9,45 +9,45 @@ export class Package extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  packageId: string;
+  declare packageId: string;
 
   @Attribute(DataTypes.STRING(24))
-  registryId: string;
+  declare registryId: string;
 
   @Attribute(DataTypes.STRING(214))
-  scope: string;
+  declare scope: string;
 
   // https://github.com/npm/npm/issues/8077#issuecomment-97258418
   // https://docs.npmjs.com/cli/v7/configuring-npm/package-json#name
   // The name must be less than or equal to 214 characters. This includes the scope for scoped packages.
   @Attribute(DataTypes.STRING(214))
-  name: string;
+  declare name: string;
 
   // cnpm private package or not, `false` meaning is the npm public registry package
   @Attribute(DataTypes.BOOLEAN)
-  isPrivate: boolean;
+  declare isPrivate: boolean;
 
   @Attribute(DataTypes.STRING(10_240))
-  description: string;
+  declare description: string;
 
   // store all abbreviated manifests into Dist store
   @EntityProperty('abbreviatedsDist.distId')
   @Attribute(DataTypes.STRING(24), { allowNull: true })
-  abbreviatedsDistId: string;
+  declare abbreviatedsDistId: string;
 
   // store all full manifests into Dist store
   @EntityProperty('manifestsDist.distId')
   @Attribute(DataTypes.STRING(24), { allowNull: true })
-  manifestsDistId: string;
+  declare manifestsDistId: string;
 }

--- a/app/repository/model/PackageDep.ts
+++ b/app/repository/model/PackageDep.ts
@@ -8,28 +8,28 @@ export class PackageDep extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24))
-  packageVersionId: string;
+  declare packageVersionId: string;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  packageDepId: string;
+  declare packageDepId: string;
 
   @Attribute(DataTypes.STRING(214))
-  scope: string;
+  declare scope: string;
 
   @Attribute(DataTypes.STRING(214))
-  name: string;
+  declare name: string;
 
   @Attribute(DataTypes.STRING(100))
-  spec: string;
+  declare spec: string;
 }

--- a/app/repository/model/PackageTag.ts
+++ b/app/repository/model/PackageTag.ts
@@ -8,27 +8,27 @@ export class PackageTag extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24))
-  packageId: string;
+  declare packageId: string;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  packageTagId: string;
+  declare packageTagId: string;
 
   @Attribute(DataTypes.STRING(214))
-  tag: string;
+  declare tag: string;
 
   // https://docs.npmjs.com/cli/v6/using-npm/semver#coercion
   // up to the max permitted length (256 characters)
   @Attribute(DataTypes.STRING(256))
-  version: string;
+  declare version: string;
 }

--- a/app/repository/model/PackageVersion.ts
+++ b/app/repository/model/PackageVersion.ts
@@ -10,51 +10,51 @@ export class PackageVersion extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24))
-  packageId: string;
+  declare packageId: string;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  packageVersionId: string;
+  declare packageVersionId: string;
 
   // https://docs.npmjs.com/cli/v6/using-npm/semver#coercion
   // up to the max permitted length (256 characters)
   @Attribute(DataTypes.STRING(256))
-  version: string;
+  declare version: string;
 
   @EntityProperty('abbreviatedDist.distId')
   @Attribute(DataTypes.STRING(24))
-  abbreviatedDistId: string;
+  declare abbreviatedDistId: string;
 
   @EntityProperty('manifestDist.distId')
   @Attribute(DataTypes.STRING(24))
-  manifestDistId: string;
+  declare manifestDistId: string;
 
   @EntityProperty('tarDist.distId')
   @Attribute(DataTypes.STRING(24))
-  tarDistId: string;
+  declare tarDistId: string;
 
   @EntityProperty('readmeDist.distId')
   @Attribute(DataTypes.STRING(24))
-  readmeDistId: string;
+  declare readmeDistId: string;
 
   @Attribute(DataTypes.DATE)
-  publishTime: Date;
+  declare publishTime: Date;
 
   @Attribute(DataTypes.STRING)
-  paddingVersion: string;
+  declare paddingVersion: string;
 
   @Attribute(DataTypes.BOOLEAN)
-  isPreRelease: boolean;
+  declare isPreRelease: boolean;
 
   static beforeCreate(instance: { version: string; paddingVersion: string; isPreRelease: boolean }) {
     if (!instance.paddingVersion) {

--- a/app/repository/model/PackageVersionBlock.ts
+++ b/app/repository/model/PackageVersionBlock.ts
@@ -8,34 +8,34 @@ export class PackageVersionBlock extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24))
-  packageId: string;
+  declare packageId: string;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  packageVersionBlockId: string;
+  declare packageVersionBlockId: string;
 
   @Attribute(DataTypes.STRING(256))
-  version: string;
+  declare version: string;
 
   @Attribute(DataTypes.TEXT(LENGTH_VARIANTS.long))
-  reason: string;
+  declare reason: string;
 
   // dependency isolation: 'buffer' = isolation buffer record (auto-releasable),
   // null = permanent block (existing semantics: security / manual / blacklist)
   @Attribute(DataTypes.STRING(16), { allowNull: true })
-  type: string | null;
+  declare type: string | null;
 
   // dependency isolation: buffer expiration time; auto-released after this when type='buffer'
   @Attribute(DataTypes.DATE, { allowNull: true })
-  expiredAt: Date | null;
+  declare expiredAt: Date | null;
 }

--- a/app/repository/model/PackageVersionDownload.ts
+++ b/app/repository/model/PackageVersionDownload.ts
@@ -8,84 +8,84 @@ export class PackageVersionDownload extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24))
-  packageId: string;
+  declare packageId: string;
 
   @Attribute(DataTypes.STRING(256))
-  version: string;
+  declare version: string;
 
   // should be YYYYMM format in number type, e.g.: 202112, 202212, 204510
   @Attribute(DataTypes.INTEGER)
-  yearMonth: number;
+  declare yearMonth: number;
 
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd01' })
-  d01: number;
+  declare d01: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd02' })
-  d02: number;
+  declare d02: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd03' })
-  d03: number;
+  declare d03: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd04' })
-  d04: number;
+  declare d04: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd05' })
-  d05: number;
+  declare d05: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd06' })
-  d06: number;
+  declare d06: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd07' })
-  d07: number;
+  declare d07: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd08' })
-  d08: number;
+  declare d08: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd09' })
-  d09: number;
+  declare d09: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd10' })
-  d10: number;
+  declare d10: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd11' })
-  d11: number;
+  declare d11: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd12' })
-  d12: number;
+  declare d12: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd13' })
-  d13: number;
+  declare d13: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd14' })
-  d14: number;
+  declare d14: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd15' })
-  d15: number;
+  declare d15: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd16' })
-  d16: number;
+  declare d16: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd17' })
-  d17: number;
+  declare d17: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd18' })
-  d18: number;
+  declare d18: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd19' })
-  d19: number;
+  declare d19: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd20' })
-  d20: number;
+  declare d20: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd21' })
-  d21: number;
+  declare d21: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd22' })
-  d22: number;
+  declare d22: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd23' })
-  d23: number;
+  declare d23: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd24' })
-  d24: number;
+  declare d24: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd25' })
-  d25: number;
+  declare d25: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd26' })
-  d26: number;
+  declare d26: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd27' })
-  d27: number;
+  declare d27: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd28' })
-  d28: number;
+  declare d28: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd29' })
-  d29: number;
+  declare d29: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd30' })
-  d30: number;
+  declare d30: number;
   @Attribute(DataTypes.INTEGER(11).UNSIGNED, { name: 'd31' })
-  d31: number;
+  declare d31: number;
 }

--- a/app/repository/model/PackageVersionFile.ts
+++ b/app/repository/model/PackageVersionFile.ts
@@ -9,35 +9,35 @@ export class PackageVersionFile extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  packageVersionFileId: string;
+  declare packageVersionFileId: string;
 
   @Attribute(DataTypes.STRING(24))
-  packageVersionId: string;
+  declare packageVersionId: string;
 
   @Attribute(DataTypes.STRING(500))
-  directory: string;
+  declare directory: string;
 
   @Attribute(DataTypes.STRING(200))
-  name: string;
+  declare name: string;
 
   @Attribute(DataTypes.STRING(200))
-  contentType: string;
+  declare contentType: string;
 
   @EntityProperty('dist.distId')
   @Attribute(DataTypes.STRING(24))
-  distId: string;
+  declare distId: string;
 
   @Attribute(DataTypes.DATE)
-  mtime: Date;
+  declare mtime: Date;
 }

--- a/app/repository/model/PackageVersionManifest.ts
+++ b/app/repository/model/PackageVersionManifest.ts
@@ -8,28 +8,28 @@ export class PackageVersionManifest extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24))
-  packageId: string;
+  declare packageId: string;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  packageVersionId: string;
+  declare packageVersionId: string;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  packageVersionManifestId: string;
+  declare packageVersionManifestId: string;
 
   @Attribute(DataTypes.JSONB)
   // oxlint-disable-next-line typescript-eslint/no-explicit-any
-  manifest: any;
+  declare manifest: any;
 }

--- a/app/repository/model/ProxyCache.ts
+++ b/app/repository/model/ProxyCache.ts
@@ -9,25 +9,25 @@ export class ProxyCache extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(214))
-  fullname: string;
+  declare fullname: string;
 
   @Attribute(DataTypes.STRING(30))
-  fileType: DIST_NAMES;
+  declare fileType: DIST_NAMES;
 
   @Attribute(DataTypes.STRING(512), {
     unique: true,
   })
-  filePath: string;
+  declare filePath: string;
 
   @Attribute(DataTypes.STRING(214))
-  version?: string;
+  declare version?: string;
 }

--- a/app/repository/model/Registry.ts
+++ b/app/repository/model/Registry.ts
@@ -9,34 +9,34 @@ export class Registry extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  registryId: string;
+  declare registryId: string;
 
   @Attribute(DataTypes.STRING(256))
-  name: string;
+  declare name: string;
 
   @Attribute(DataTypes.STRING(4096))
-  host: string;
+  declare host: string;
 
   @Attribute(DataTypes.STRING(4096), { name: 'change_stream' })
-  changeStream: string;
+  declare changeStream: string;
 
   @Attribute(DataTypes.STRING(4096), { name: 'user_prefix' })
-  userPrefix: string;
+  declare userPrefix: string;
 
   @Attribute(DataTypes.STRING(256))
-  type: RegistryType;
+  declare type: RegistryType;
 
   @Attribute(DataTypes.STRING(256), { name: 'auth_token' })
-  authToken?: string;
+  declare authToken?: string;
 }

--- a/app/repository/model/Scope.ts
+++ b/app/repository/model/Scope.ts
@@ -8,20 +8,20 @@ export class Scope extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(214))
-  name: string;
+  declare name: string;
 
   @Attribute(DataTypes.STRING(256))
-  registryId: string;
+  declare registryId: string;
 
   @Attribute(DataTypes.STRING(256))
-  scopeId: string;
+  declare scopeId: string;
 }

--- a/app/repository/model/Task.ts
+++ b/app/repository/model/Task.ts
@@ -9,52 +9,52 @@ export class Task extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  taskId: string;
+  declare taskId: string;
 
   @Attribute(DataTypes.STRING(20))
-  type: TaskType;
+  declare type: TaskType;
 
   @Attribute(DataTypes.STRING(20))
-  state: TaskState;
+  declare state: TaskState;
 
   @Attribute(DataTypes.STRING(214))
-  targetName: string;
+  declare targetName: string;
 
   @Attribute(DataTypes.STRING(24))
-  authorId: string;
+  declare authorId: string;
 
   @Attribute(DataTypes.STRING(100))
-  authorIp: string;
+  declare authorIp: string;
 
   @Attribute(DataTypes.JSONB)
   // oxlint-disable-next-line typescript-eslint/no-explicit-any
-  data: any;
+  declare data: any;
 
   @Attribute(DataTypes.STRING(512))
-  logPath: string;
+  declare logPath: string;
 
   @Attribute(DataTypes.STRING(10))
-  logStorePosition: string;
+  declare logStorePosition: string;
 
   @Attribute(DataTypes.INTEGER)
-  attempts: number;
+  declare attempts: number;
 
   @Attribute(DataTypes.TEXT(LENGTH_VARIANTS.long))
-  error: string;
+  declare error: string;
 
   @Attribute(DataTypes.STRING(48), {
     unique: true,
   })
-  bizId: string;
+  declare bizId: string;
 }

--- a/app/repository/model/Team.ts
+++ b/app/repository/model/Team.ts
@@ -8,23 +8,23 @@ export class Team extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24))
-  teamId: string;
+  declare teamId: string;
 
   @Attribute(DataTypes.STRING(24))
-  orgId: string;
+  declare orgId: string;
 
   @Attribute(DataTypes.STRING(214))
-  name: string;
+  declare name: string;
 
   @Attribute(DataTypes.STRING(10240), { allowNull: true })
-  description: string;
+  declare description: string;
 }

--- a/app/repository/model/TeamMember.ts
+++ b/app/repository/model/TeamMember.ts
@@ -8,23 +8,23 @@ export class TeamMember extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24))
-  teamMemberId: string;
+  declare teamMemberId: string;
 
   @Attribute(DataTypes.STRING(24))
-  teamId: string;
+  declare teamId: string;
 
   @Attribute(DataTypes.STRING(24))
-  userId: string;
+  declare userId: string;
 
   @Attribute(DataTypes.STRING(20))
-  role: string;
+  declare role: string;
 }

--- a/app/repository/model/TeamPackage.ts
+++ b/app/repository/model/TeamPackage.ts
@@ -8,20 +8,20 @@ export class TeamPackage extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24))
-  teamPackageId: string;
+  declare teamPackageId: string;
 
   @Attribute(DataTypes.STRING(24))
-  teamId: string;
+  declare teamId: string;
 
   @Attribute(DataTypes.STRING(24))
-  packageId: string;
+  declare packageId: string;
 }

--- a/app/repository/model/Token.ts
+++ b/app/repository/model/Token.ts
@@ -8,54 +8,54 @@ export class Token extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  tokenId: string;
+  declare tokenId: string;
 
   @Attribute(DataTypes.STRING(20))
-  tokenMark: string;
+  declare tokenMark: string;
 
   @Attribute(DataTypes.STRING(200), {
     unique: true,
   })
-  tokenKey: string;
+  declare tokenKey: string;
 
   @Attribute(DataTypes.STRING(24))
-  userId: string;
+  declare userId: string;
 
   @Attribute(DataTypes.JSONB)
-  cidrWhitelist: string[];
+  declare cidrWhitelist: string[];
 
   @Attribute(DataTypes.BOOLEAN)
-  isReadonly: boolean;
+  declare isReadonly: boolean;
 
   @Attribute(DataTypes.BOOLEAN)
-  isAutomation: boolean;
+  declare isAutomation: boolean;
 
   @Attribute(DataTypes.STRING(255))
-  type: string;
+  declare type: string;
 
   @Attribute(DataTypes.STRING(255))
-  name: string;
+  declare name: string;
 
   @Attribute(DataTypes.STRING(255))
-  description: string;
+  declare description: string;
 
   @Attribute(DataTypes.JSONB)
-  allowedScopes: string[];
+  declare allowedScopes: string[];
 
   @Attribute(DataTypes.DATE)
-  expiredAt: Date;
+  declare expiredAt: Date;
 
   @Attribute(DataTypes.DATE)
-  lastUsedAt: Date;
+  declare lastUsedAt: Date;
 }

--- a/app/repository/model/TokenPackage.ts
+++ b/app/repository/model/TokenPackage.ts
@@ -8,17 +8,17 @@ export class TokenPackage extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24))
-  tokenId: string;
+  declare tokenId: string;
 
   @Attribute(DataTypes.STRING(24))
-  packageId: string;
+  declare packageId: string;
 }

--- a/app/repository/model/Total.ts
+++ b/app/repository/model/Total.ts
@@ -8,19 +8,19 @@ export class Total extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  type: string;
+  declare type: string;
 
   @Attribute(DataTypes.BIGINT)
-  count: bigint;
+  declare count: bigint;
 }

--- a/app/repository/model/User.ts
+++ b/app/repository/model/User.ts
@@ -8,38 +8,38 @@ export class User extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  userId: string;
+  declare userId: string;
 
   @Attribute(DataTypes.STRING(100))
-  name: string;
+  declare name: string;
 
   @Attribute(DataTypes.STRING(400))
-  email: string;
+  declare email: string;
 
   @Attribute(DataTypes.STRING(100))
-  passwordSalt: string;
+  declare passwordSalt: string;
 
   @Attribute(DataTypes.STRING(512))
-  passwordIntegrity: string;
+  declare passwordIntegrity: string;
 
   @Attribute(DataTypes.STRING(100))
-  ip: string;
+  declare ip: string;
 
   // cnpm private user or not, `false` meaning is the npm public registry user
   @Attribute(DataTypes.BOOLEAN)
-  isPrivate: boolean;
+  declare isPrivate: boolean;
 
   @Attribute(DataTypes.JSONB, { allowNull: true })
-  scopes: string[];
+  declare scopes: string[];
 }

--- a/app/repository/model/WebauthnCredential.ts
+++ b/app/repository/model/WebauthnCredential.ts
@@ -8,28 +8,28 @@ export class WebauthnCredential extends Bone {
     primary: true,
     autoIncrement: true,
   })
-  id: bigint;
+  declare id: bigint;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_create' })
-  createdAt: Date;
+  declare createdAt: Date;
 
   @Attribute(DataTypes.DATE, { name: 'gmt_modified' })
-  updatedAt: Date;
+  declare updatedAt: Date;
 
   @Attribute(DataTypes.STRING(24), {
     unique: true,
   })
-  wancId: string;
+  declare wancId: string;
 
   @Attribute(DataTypes.STRING(24))
-  userId: string;
+  declare userId: string;
 
   @Attribute(DataTypes.STRING(200))
-  credentialId: string;
+  declare credentialId: string;
 
   @Attribute(DataTypes.STRING(512))
-  publicKey: string;
+  declare publicKey: string;
 
   @Attribute(DataTypes.STRING(24), { allowNull: true })
-  browserType: string;
+  declare browserType: string;
 }

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "fast-xml-parser": "^5.8.0",
     "fs-cnpm": "^2.4.1",
     "ioredis": "^5.8.2",
-    "leoric": "^2.14.0",
+    "leoric": "^2.15.0",
     "lodash-es": "^4.17.21",
     "mime-types": "^3.0.2",
     "mysql2": "^3.15.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "@eggjs/tsconfig",
   "compilerOptions": {
-    // leoric only supports ES2021
-    "target": "ES2021",
+    // ES2022 turns on `useDefineForClassFields`, so leoric model attributes must be declared
+    // with `declare` (leoric >= 2.15.0 throws LeoricClassFieldError otherwise)
+    "target": "ES2022",
     "resolveJsonModule": true,
     "useUnknownInCatchVariables": false,
     "declaration": false,


### PR DESCRIPTION
Bump the TypeScript target from ES2021 to ES2022, and bump `leoric` to `^2.15.0`.

ES2022 enables `useDefineForClassFields`, so Leoric model attributes are emitted as real class fields that shadow Leoric's attribute accessors. Leoric's own `@Model()` decorator avoids this by replacing the class with a compiled one whose constructor never runs field initializers, but `@eggjs/orm-plugin` registers models directly (`realm.models[name] = clazz; clazz.init(...)`) instead of going through `realm.define()`, so `compileModel()` never runs.

The fix is the one leoric's own error names: `declare` on every `@Attribute` property in `app/repository/model/*.ts`. That erases the field from the emit while keeping the `__decorate` and `design:type` metadata tegg needs. leoric `^2.15.0` is required because it detects the shadowing and throws `LeoricClassFieldError`, so a model missing `declare` fails loudly instead of misbehaving.

Verified locally: `typecheck`, `lint`, `fmtcheck`, `tsc`, `tsc:prod`, and the full MySQL test suite (1011 passed). The remaining failures in `test/cli/npm/*` reproduce identically on master in the same environment and are unrelated. The PostgreSQL suite was not run locally.
