### PR TITLE
test: use Vite+ PR 2346 preview

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# vite-plus preview build registry bridge
+registry=https://registry-bridge.viteplus.dev/

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "coffee": "^5.5.1",
     "ioredis-mock": "^8.13.1",
     "typescript": "^7.0.0",
-    "vite-plus": "0.2.9",
+    "vite-plus": "0.0.0-commit.2922dfcdcd815aece6e87dd1d007facb25db20cc",
     "vitest": "4.1.10",
     "yaml": "^2.9.0"
   },
@@ -159,7 +159,7 @@
     "@aws-sdk/xml-builder": {
       "fast-xml-parser": "$fast-xml-parser"
     },
-    "vite": "npm:@voidzero-dev/vite-plus-core@0.2.9",
+    "vite": "npm:@voidzero-dev/vite-plus-core@0.0.0-commit.2922dfcdcd815aece6e87dd1d007facb25db20cc",
     "vitest": "4.1.10"
   },
   "engines": {


### PR DESCRIPTION
Test the current Vite+ preview from voidzero-dev/vite-plus#2346 in cnpmcore.

This change pins `vite-plus` and `@voidzero-dev/vite-plus-core` to commit build `2922dfc`. It adds the registry bridge configuration that npm needs.

The local preview CLI reports commit build `2922dfc`. `vp install`, `vp check`, and `vp run build` pass.

GitHub CI runs the MySQL and PostgreSQL test suites.