### PR TITLE
fix: relay synced version removals

### DIFF
--- a/app/core/service/PackageManagerService.ts
+++ b/app/core/service/PackageManagerService.ts
@@ -985,7 +985,12 @@ export class PackageManagerService extends AbstractService {
     );
   }
 
-  public async removePackageVersion(pkg: Package, pkgVersion: PackageVersion, skipRefreshPackageManifests = false) {
+  public async removePackageVersion(
+    pkg: Package,
+    pkgVersion: PackageVersion,
+    skipRefreshPackageManifests = false,
+    skipChangeEvent = false,
+  ) {
     const currentVersions = await this.packageRepository.listPackageVersionNames(pkg.packageId);
     // only one version, unpublish the package
     if (currentVersions.length === 1 && currentVersions[0] === pkgVersion.version) {
@@ -1010,6 +1015,8 @@ export class PackageManagerService extends AbstractService {
       }
       if (skipRefreshPackageManifests !== true) {
         await this.refreshPackageChangeVersionsToDists(pkg, undefined, [pkgVersion.version]);
+      }
+      if (skipChangeEvent !== true) {
         this.eventBus.emit(PACKAGE_VERSION_REMOVED, pkg.fullname, pkgVersion.version, updateTag);
       }
       return;

--- a/app/core/service/PackageSyncerService.ts
+++ b/app/core/service/PackageSyncerService.ts
@@ -855,7 +855,7 @@ data sample: ${remoteData.subarray(0, 200).toString()}`;
           const pkgVer = await this.packageRepository.findPackageVersion(pkg.packageId, version);
           if (pkgVer) {
             logs.push(`[${isoNow()}] 🚧 [${syncIndex}] Remove version ${version} for force sync history`);
-            await this.packageManagerService.removePackageVersion(pkg, pkgVer, true);
+            await this.packageManagerService.removePackageVersion(pkg, pkgVer, true, true);
             existsItem = undefined;
             existsAbbreviatedItem = undefined;
             existsVersionMap[version] = undefined;
@@ -1413,7 +1413,7 @@ data sample: ${remoteData.subarray(0, 200).toString()}`;
         const pkgVer = await this.packageRepository.findPackageVersion(pkg.packageId, version);
         if (pkgVer) {
           logs.push(`[${isoNow()}] 🚧 Remove version ${version} for force sync history`);
-          await this.packageManagerService.removePackageVersion(pkg, pkgVer, true);
+          await this.packageManagerService.removePackageVersion(pkg, pkgVer, true, true);
         }
       }
       existsVersions = [];

--- a/test/core/service/PackageSyncerService/executeTask.test.ts
+++ b/test/core/service/PackageSyncerService/executeTask.test.ts
@@ -1259,6 +1259,14 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       assert.ok(r.data);
       assert.equal(Object.keys(r.data.versions).length, 1);
       assert.ok(!r.data.versions['1.0.0'], '1.0.0 should not exists');
+      const changes = await changeRepository.query(0, 100);
+      assert.ok(
+        changes.some(
+          (change) =>
+            change.type === 'PACKAGE_VERSION_REMOVED' && change.targetName === name && change.data.version === '1.0.0',
+        ),
+        'PACKAGE_VERSION_REMOVED change should exist',
+      );
     });
 
     it('should work on unpublished package', async () => {

--- a/test/core/service/PackageSyncerService/executeTask.test.ts
+++ b/test/core/service/PackageSyncerService/executeTask.test.ts
@@ -5,10 +5,10 @@ import { app, mock } from '@eggjs/mock/bootstrap';
 import { NFSAdapter } from '../../../../app/common/adapter/NFSAdapter.ts';
 import { NPMRegistry } from '../../../../app/common/adapter/NPMRegistry.ts';
 import { RegistryType } from '../../../../app/common/enum/Registry.ts';
-import { TaskState } from '../../../../app/common/enum/Task.ts';
+import { TaskState, TaskType } from '../../../../app/common/enum/Task.ts';
 import { getScopeAndName } from '../../../../app/common/PackageUtil.ts';
 import type { Registry } from '../../../../app/core/entity/Registry.ts';
-import { Task as TaskEntity } from '../../../../app/core/entity/Task.ts';
+import { type CreateHookTask, Task as TaskEntity } from '../../../../app/core/entity/Task.ts';
 import { PackageManagerService } from '../../../../app/core/service/PackageManagerService.ts';
 import { PackageSyncerService } from '../../../../app/core/service/PackageSyncerService.ts';
 import { PackageVersionFileService } from '../../../../app/core/service/PackageVersionFileService.ts';
@@ -1205,7 +1205,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       assert.ok(log.includes('] 🚧 Syncing versions 2 => 2'));
     });
 
-    it('should sync removed versions', async () => {
+    it('should sync a removed latest version', async () => {
       app.mockHttpclient('https://registry.npmjs.org/%40cnpmcore%2Ftest-sync-package-has-two-versions', 'GET', {
         data: '{"_id":"@cnpmcore/test-sync-package-has-two-versions","_rev":"4-541287ae0a14039fea89ac08fa5ec53d","name":"@cnpmcore/test-sync-package-has-two-versions","dist-tags":{"latest":"2.0.0","next":"2.0.0"},"versions":{"1.0.0":{"name":"@cnpmcore/test-sync-package-has-two-versions","version":"1.0.0","description":"cnpmcore local test package","main":"index.js","scripts":{"test":"echo \\"hello\\""},"author":"","license":"MIT","gitHead":"60cfb1cf401f87a60a1b0dfd7ee739f98ffd7847","_id":"@cnpmcore/test-sync-package-has-two-versions@1.0.0","_nodeVersion":"16.13.1","_npmVersion":"8.1.2","dist":{"integrity":"sha512-WR0T96H8t7ss1FK8GWPPblx+usbjU4bNGRjMHS9t/oVA5DgJDxitydPSFPeIUtXciyekI7R47do9Lc3GgC4P5A==","shasum":"2ddc6ee93b92be6d64139fb1a631d2610f43e946","tarball":"https://registry.npmjs.org/@cnpmcore/test-sync-package-has-two-versions/-/test-sync-package-has-two-versions-1.0.0.tgz","fileCount":2,"unpackedSize":238,"signatures":[{"keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","sig":"MEYCIQDj5Ui2GU8nVmHFk0hCt/i3gPW9eQdOCZgKzpAlkvERwQIhAPZ0NCefLoEfOpnbdKAUr7Ng9Sy6FMnTsDxDaM2dQHNw"}]},"_npmUser":{"name":"fengmk2","email":"fengmk2@gmail.com"},"directories":{},"maintainers":[{"name":"fengmk2","email":"fengmk2@gmail.com"}],"_npmOperationalInternal":{"host":"s3://npm-registry-packages","tmp":"tmp/test-sync-package-has-two-versions_1.0.0_1639442699824_0.6948988437963031"},"_hasShrinkwrap":false},"2.0.0":{"name":"@cnpmcore/test-sync-package-has-two-versions","version":"2.0.0","description":"cnpmcore local test package","main":"index.js","scripts":{"test":"echo \\"hello\\""},"author":"","license":"MIT","gitHead":"60cfb1cf401f87a60a1b0dfd7ee739f98ffd7847","_id":"@cnpmcore/test-sync-package-has-two-versions@2.0.0","_nodeVersion":"16.13.1","_npmVersion":"8.1.2","dist":{"integrity":"sha512-qgHLQzXq+VN7q0JWibeBYrqb3Iajl4lpVuxlQstclRz4ejujfDFswBGSXmCv9FyIIdmSAe5bZo0oHQLsod3pAA==","shasum":"891eb8e08ceadbd86e75b6d66f31f7e5a28a8d68","tarball":"https://registry.npmjs.org/@cnpmcore/test-sync-package-has-two-versions/-/test-sync-package-has-two-versions-2.0.0.tgz","fileCount":2,"unpackedSize":238,"signatures":[{"keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","sig":"MEQCIAWVz7mIHF23Gq4a+Swsj2ZSdn87991HcE1+fQm8shNCAiByOIuhaZAbo9hct24qYf7FWqx6Lyluo+Rpnrn91//Ibg=="}]},"_npmUser":{"name":"fengmk2","email":"fengmk2@gmail.com"},"directories":{},"maintainers":[{"name":"fengmk2","email":"fengmk2@gmail.com"}],"_npmOperationalInternal":{"host":"s3://npm-registry-packages","tmp":"tmp/test-sync-package-has-two-versions_2.0.0_1639442732240_0.33204392278137207"},"_hasShrinkwrap":false}},"time":{"created":"2021-12-14T00:44:59.775Z","1.0.0":"2021-12-14T00:44:59.940Z","modified":"2022-05-23T02:33:52.613Z","2.0.0":"2021-12-14T00:45:32.457Z"},"maintainers":[{"email":"killa07071201@gmail.com","name":"killagu"},{"email":"fengmk2@gmail.com","name":"fengmk2"}],"description":"cnpmcore local test package","license":"MIT","readme":"ERROR: No README data found!","readmeFilename":""}',
         persist: false,
@@ -1239,6 +1239,11 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       assert.ok(log.includes('] 🟢 Synced updated 2 versions'));
       app.mockAgent().assertNoPendingInterceptors();
 
+      const pkg = await packageRepository.findPackage('@cnpmcore', 'test-sync-package-has-two-versions');
+      assert.ok(pkg);
+      await packageManagerService.savePackageTag(pkg, 'latest', '1.0.0', true);
+      mock(app.config.cnpmcore, 'hookEnable', true);
+
       app.mockHttpclient('https://registry.npmjs.org/%40cnpmcore%2Ftest-sync-package-has-two-versions', 'GET', {
         data: '{"_id":"@cnpmcore/test-sync-package-has-two-versions","_rev":"4-541287ae0a14039fea89ac08fa5ec53d","name":"@cnpmcore/test-sync-package-has-two-versions","dist-tags":{"latest":"2.0.0","next":"2.0.0"},"versions":{"2.0.0":{"name":"@cnpmcore/test-sync-package-has-two-versions","version":"2.0.0","description":"cnpmcore local test package","main":"index.js","scripts":{"test":"echo \\"hello\\""},"author":"","license":"MIT","gitHead":"60cfb1cf401f87a60a1b0dfd7ee739f98ffd7847","_id":"@cnpmcore/test-sync-package-has-two-versions@2.0.0","_nodeVersion":"16.13.1","_npmVersion":"8.1.2","dist":{"integrity":"sha512-qgHLQzXq+VN7q0JWibeBYrqb3Iajl4lpVuxlQstclRz4ejujfDFswBGSXmCv9FyIIdmSAe5bZo0oHQLsod3pAA==","shasum":"891eb8e08ceadbd86e75b6d66f31f7e5a28a8d68","tarball":"https://registry.npmjs.org/@cnpmcore/test-sync-package-has-two-versions/-/test-sync-package-has-two-versions-2.0.0.tgz","fileCount":2,"unpackedSize":238,"signatures":[{"keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","sig":"MEQCIAWVz7mIHF23Gq4a+Swsj2ZSdn87991HcE1+fQm8shNCAiByOIuhaZAbo9hct24qYf7FWqx6Lyluo+Rpnrn91//Ibg=="}]},"_npmUser":{"name":"fengmk2","email":"fengmk2@gmail.com"},"directories":{},"maintainers":[{"name":"fengmk2","email":"fengmk2@gmail.com"}],"_npmOperationalInternal":{"host":"s3://npm-registry-packages","tmp":"tmp/test-sync-package-has-two-versions_2.0.0_1639442732240_0.33204392278137207"},"_hasShrinkwrap":false}},"time":{"created":"2021-12-14T00:44:59.775Z","1.0.0":"2021-12-14T00:44:59.940Z","modified":"2022-05-23T02:33:52.613Z","2.0.0":"2021-12-14T00:45:32.457Z"},"maintainers":[{"email":"killa07071201@gmail.com","name":"killagu"},{"email":"fengmk2@gmail.com","name":"fengmk2"}],"description":"cnpmcore local test package","license":"MIT","readme":"ERROR: No README data found!","readmeFilename":""}',
         persist: false,
@@ -1259,6 +1264,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       assert.ok(r.data);
       assert.equal(Object.keys(r.data.versions).length, 1);
       assert.ok(!r.data.versions['1.0.0'], '1.0.0 should not exists');
+      assert.equal(r.data['dist-tags'].latest, '2.0.0');
       const changes = await changeRepository.query(0, 100);
       assert.ok(
         changes.some(
@@ -1267,6 +1273,12 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         ),
         'PACKAGE_VERSION_REMOVED change should exist',
       );
+      const hookTask = (await taskService.findExecuteTask(TaskType.CreateHook)) as CreateHookTask | null;
+      assert.ok(hookTask);
+      assert.deepEqual(hookTask.data.hookEvent.change, {
+        'dist-tag': 'latest',
+        version: '1.0.0',
+      });
     });
 
     it('should work on unpublished package', async () => {

--- a/test/core/service/PackageSyncerService/executeTaskWithPackument.test.ts
+++ b/test/core/service/PackageSyncerService/executeTaskWithPackument.test.ts
@@ -5,10 +5,10 @@ import { app, mock } from '@eggjs/mock/bootstrap';
 import { NFSAdapter } from '../../../../app/common/adapter/NFSAdapter.ts';
 import { NPMRegistry } from '../../../../app/common/adapter/NPMRegistry.ts';
 import { RegistryType } from '../../../../app/common/enum/Registry.ts';
-import { TaskState } from '../../../../app/common/enum/Task.ts';
+import { TaskState, TaskType } from '../../../../app/common/enum/Task.ts';
 import { getScopeAndName } from '../../../../app/common/PackageUtil.ts';
 import type { Registry } from '../../../../app/core/entity/Registry.ts';
-import { Task as TaskEntity } from '../../../../app/core/entity/Task.ts';
+import { type CreateHookTask, Task as TaskEntity } from '../../../../app/core/entity/Task.ts';
 import { PackageManagerService } from '../../../../app/core/service/PackageManagerService.ts';
 import { PackageSyncerService } from '../../../../app/core/service/PackageSyncerService.ts';
 import { PackageVersionFileService } from '../../../../app/core/service/PackageVersionFileService.ts';
@@ -1311,7 +1311,7 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
       assert.ok(log.includes('] 🚧 Syncing versions 2 => 2'));
     });
 
-    it('should sync removed versions', async () => {
+    it('should sync a removed latest version', async () => {
       app.mockHttpclient('https://registry.npmjs.org/%40cnpmcore%2Ftest-sync-package-has-two-versions', 'GET', {
         data: '{"_id":"@cnpmcore/test-sync-package-has-two-versions","_rev":"4-541287ae0a14039fea89ac08fa5ec53d","name":"@cnpmcore/test-sync-package-has-two-versions","dist-tags":{"latest":"2.0.0","next":"2.0.0"},"versions":{"1.0.0":{"name":"@cnpmcore/test-sync-package-has-two-versions","version":"1.0.0","description":"cnpmcore local test package","main":"index.js","scripts":{"test":"echo \\"hello\\""},"author":"","license":"MIT","gitHead":"60cfb1cf401f87a60a1b0dfd7ee739f98ffd7847","_id":"@cnpmcore/test-sync-package-has-two-versions@1.0.0","_nodeVersion":"16.13.1","_npmVersion":"8.1.2","dist":{"integrity":"sha512-WR0T96H8t7ss1FK8GWPPblx+usbjU4bNGRjMHS9t/oVA5DgJDxitydPSFPeIUtXciyekI7R47do9Lc3GgC4P5A==","shasum":"2ddc6ee93b92be6d64139fb1a631d2610f43e946","tarball":"https://registry.npmjs.org/@cnpmcore/test-sync-package-has-two-versions/-/test-sync-package-has-two-versions-1.0.0.tgz","fileCount":2,"unpackedSize":238,"signatures":[{"keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","sig":"MEYCIQDj5Ui2GU8nVmHFk0hCt/i3gPW9eQdOCZgKzpAlkvERwQIhAPZ0NCefLoEfOpnbdKAUr7Ng9Sy6FMnTsDxDaM2dQHNw"}]},"_npmUser":{"name":"fengmk2","email":"fengmk2@gmail.com"},"directories":{},"maintainers":[{"name":"fengmk2","email":"fengmk2@gmail.com"}],"_npmOperationalInternal":{"host":"s3://npm-registry-packages","tmp":"tmp/test-sync-package-has-two-versions_1.0.0_1639442699824_0.6948988437963031"},"_hasShrinkwrap":false},"2.0.0":{"name":"@cnpmcore/test-sync-package-has-two-versions","version":"2.0.0","description":"cnpmcore local test package","main":"index.js","scripts":{"test":"echo \\"hello\\""},"author":"","license":"MIT","gitHead":"60cfb1cf401f87a60a1b0dfd7ee739f98ffd7847","_id":"@cnpmcore/test-sync-package-has-two-versions@2.0.0","_nodeVersion":"16.13.1","_npmVersion":"8.1.2","dist":{"integrity":"sha512-qgHLQzXq+VN7q0JWibeBYrqb3Iajl4lpVuxlQstclRz4ejujfDFswBGSXmCv9FyIIdmSAe5bZo0oHQLsod3pAA==","shasum":"891eb8e08ceadbd86e75b6d66f31f7e5a28a8d68","tarball":"https://registry.npmjs.org/@cnpmcore/test-sync-package-has-two-versions/-/test-sync-package-has-two-versions-2.0.0.tgz","fileCount":2,"unpackedSize":238,"signatures":[{"keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","sig":"MEQCIAWVz7mIHF23Gq4a+Swsj2ZSdn87991HcE1+fQm8shNCAiByOIuhaZAbo9hct24qYf7FWqx6Lyluo+Rpnrn91//Ibg=="}]},"_npmUser":{"name":"fengmk2","email":"fengmk2@gmail.com"},"directories":{},"maintainers":[{"name":"fengmk2","email":"fengmk2@gmail.com"}],"_npmOperationalInternal":{"host":"s3://npm-registry-packages","tmp":"tmp/test-sync-package-has-two-versions_2.0.0_1639442732240_0.33204392278137207"},"_hasShrinkwrap":false}},"time":{"created":"2021-12-14T00:44:59.775Z","1.0.0":"2021-12-14T00:44:59.940Z","modified":"2022-05-23T02:33:52.613Z","2.0.0":"2021-12-14T00:45:32.457Z"},"maintainers":[{"email":"killa07071201@gmail.com","name":"killagu"},{"email":"fengmk2@gmail.com","name":"fengmk2"}],"description":"cnpmcore local test package","license":"MIT","readme":"ERROR: No README data found!","readmeFilename":""}',
         persist: false,
@@ -1345,6 +1345,11 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
       assert.ok(log.includes('] 🟢 Synced updated 2 versions'));
       app.mockAgent().assertNoPendingInterceptors();
 
+      const pkg = await packageRepository.findPackage('@cnpmcore', 'test-sync-package-has-two-versions');
+      assert.ok(pkg);
+      await packageManagerService.savePackageTag(pkg, 'latest', '1.0.0', true);
+      mock(app.config.cnpmcore, 'hookEnable', true);
+
       app.mockHttpclient('https://registry.npmjs.org/%40cnpmcore%2Ftest-sync-package-has-two-versions', 'GET', {
         data: '{"_id":"@cnpmcore/test-sync-package-has-two-versions","_rev":"4-541287ae0a14039fea89ac08fa5ec53d","name":"@cnpmcore/test-sync-package-has-two-versions","dist-tags":{"latest":"2.0.0","next":"2.0.0"},"versions":{"2.0.0":{"name":"@cnpmcore/test-sync-package-has-two-versions","version":"2.0.0","description":"cnpmcore local test package","main":"index.js","scripts":{"test":"echo \\"hello\\""},"author":"","license":"MIT","gitHead":"60cfb1cf401f87a60a1b0dfd7ee739f98ffd7847","_id":"@cnpmcore/test-sync-package-has-two-versions@2.0.0","_nodeVersion":"16.13.1","_npmVersion":"8.1.2","dist":{"integrity":"sha512-qgHLQzXq+VN7q0JWibeBYrqb3Iajl4lpVuxlQstclRz4ejujfDFswBGSXmCv9FyIIdmSAe5bZo0oHQLsod3pAA==","shasum":"891eb8e08ceadbd86e75b6d66f31f7e5a28a8d68","tarball":"https://registry.npmjs.org/@cnpmcore/test-sync-package-has-two-versions/-/test-sync-package-has-two-versions-2.0.0.tgz","fileCount":2,"unpackedSize":238,"signatures":[{"keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","sig":"MEQCIAWVz7mIHF23Gq4a+Swsj2ZSdn87991HcE1+fQm8shNCAiByOIuhaZAbo9hct24qYf7FWqx6Lyluo+Rpnrn91//Ibg=="}]},"_npmUser":{"name":"fengmk2","email":"fengmk2@gmail.com"},"directories":{},"maintainers":[{"name":"fengmk2","email":"fengmk2@gmail.com"}],"_npmOperationalInternal":{"host":"s3://npm-registry-packages","tmp":"tmp/test-sync-package-has-two-versions_2.0.0_1639442732240_0.33204392278137207"},"_hasShrinkwrap":false}},"time":{"created":"2021-12-14T00:44:59.775Z","1.0.0":"2021-12-14T00:44:59.940Z","modified":"2022-05-23T02:33:52.613Z","2.0.0":"2021-12-14T00:45:32.457Z"},"maintainers":[{"email":"killa07071201@gmail.com","name":"killagu"},{"email":"fengmk2@gmail.com","name":"fengmk2"}],"description":"cnpmcore local test package","license":"MIT","readme":"ERROR: No README data found!","readmeFilename":""}',
         persist: false,
@@ -1365,6 +1370,7 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
       assert.ok(r.data);
       assert.equal(Object.keys(r.data.versions).length, 1);
       assert.ok(!r.data.versions['1.0.0'], '1.0.0 should not exists');
+      assert.equal(r.data['dist-tags'].latest, '2.0.0');
       const changes = await changeRepository.query(0, 100);
       assert.ok(
         changes.some(
@@ -1373,6 +1379,12 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
         ),
         'PACKAGE_VERSION_REMOVED change should exist',
       );
+      const hookTask = (await taskService.findExecuteTask(TaskType.CreateHook)) as CreateHookTask | null;
+      assert.ok(hookTask);
+      assert.deepEqual(hookTask.data.hookEvent.change, {
+        'dist-tag': 'latest',
+        version: '1.0.0',
+      });
     });
 
     it('should work on unpublished package', async () => {

--- a/test/core/service/PackageSyncerService/executeTaskWithPackument.test.ts
+++ b/test/core/service/PackageSyncerService/executeTaskWithPackument.test.ts
@@ -16,6 +16,7 @@ import { RegistryManagerService } from '../../../../app/core/service/RegistryMan
 import { ScopeManagerService } from '../../../../app/core/service/ScopeManagerService.ts';
 import { TaskService } from '../../../../app/core/service/TaskService.ts';
 import { UserService } from '../../../../app/core/service/UserService.ts';
+import { ChangeRepository } from '../../../../app/repository/ChangeRepository.ts';
 import { HistoryTask as HistoryTaskModel } from '../../../../app/repository/model/HistoryTask.ts';
 import { Package as PackageModel } from '../../../../app/repository/model/Package.ts';
 import { PackageVersion } from '../../../../app/repository/model/PackageVersion.ts';
@@ -33,6 +34,7 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
   let scopeManagerService: ScopeManagerService;
   let userService: UserService;
   let packageVersionRepository: PackageVersionRepository;
+  let changeRepository: ChangeRepository;
 
   beforeEach(async () => {
     mock(app.config.cnpmcore.experimental, 'syncPackageWithPackument', true);
@@ -44,6 +46,7 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
     scopeManagerService = await app.getEggObject(ScopeManagerService);
     userService = await app.getEggObject(UserService);
     packageVersionRepository = await app.getEggObject(PackageVersionRepository);
+    changeRepository = await app.getEggObject(ChangeRepository);
   });
 
   describe('executeTask()', () => {
@@ -1362,6 +1365,14 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
       assert.ok(r.data);
       assert.equal(Object.keys(r.data.versions).length, 1);
       assert.ok(!r.data.versions['1.0.0'], '1.0.0 should not exists');
+      const changes = await changeRepository.query(0, 100);
+      assert.ok(
+        changes.some(
+          (change) =>
+            change.type === 'PACKAGE_VERSION_REMOVED' && change.targetName === name && change.data.version === '1.0.0',
+        ),
+        'PACKAGE_VERSION_REMOVED change should exist',
+      );
     });
 
     it('should work on unpublished package', async () => {


### PR DESCRIPTION
An upstream sync removed a package version, but cnpmcore did not add a change record. Downstream registries could not synchronize the removal.

This change separates manifest refresh control from change event control. The sync task now adds a `PACKAGE_VERSION_REMOVED` change. The unpublish hook includes the changed `latest` tag. Force history sync keeps temporary removal events disabled.

The tests remove the current `latest` version in both sync paths.

Fixes #1133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package synchronization when the latest version is removed.
  - The `latest` tag now updates correctly to the next available version.
  - Version removal notifications and related hook tasks are preserved during synchronization.
  - Force-sync operations avoid generating duplicate removal events while still refreshing package metadata.
  - Package size validation now separately checks compressed tarball and unpacked package sizes.
  - Oversized packages are skipped with clearer messages identifying which size limit was exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->