### PR TITLE
fix: separate tgz and unpacked package size limits

### DIFF
--- a/app/core/service/PackageSyncerService.ts
+++ b/app/core/service/PackageSyncerService.ts
@@ -51,7 +51,7 @@ interface syncDeletePkgOptions {
 }
 
 interface PackageVersionSizeLimitExceeded {
-  name: 'size' | 'unpacked size';
+  name: 'tgz size' | 'unpacked size';
   value: number;
   limit: number;
 }
@@ -63,14 +63,14 @@ function getPackageVersionSizeLimitsExceeded(
 ) {
   const effectiveUnpackedSizeLimit = Math.max(sizeLimit, unpackedSizeLimit);
   const sizes: PackageVersionSizeLimitExceeded[] = [
-    { name: 'size', value: dist.size ?? 0, limit: sizeLimit },
+    { name: 'tgz size', value: dist.size ?? 0, limit: sizeLimit },
     { name: 'unpacked size', value: dist.unpackedSize ?? 0, limit: effectiveUnpackedSizeLimit },
   ];
   return sizes.filter(({ value, limit }) => value > limit);
 }
 
 function formatPackageVersionSizeLimitsExceeded(exceededLimits: PackageVersionSizeLimitExceeded[]) {
-  return exceededLimits.map(({ name, value, limit }) => `${name}: ${value}, allow ${name}: ${limit}`).join(', ');
+  return exceededLimits.map(({ name, value, limit }) => `${name}: ${value}, maximum ${name}: ${limit}`).join(', ');
 }
 
 function formatPackageVersionSizesExceeded(exceededLimits: PackageVersionSizeLimitExceeded[]) {

--- a/app/core/service/PackageSyncerService.ts
+++ b/app/core/service/PackageSyncerService.ts
@@ -61,9 +61,10 @@ function getPackageVersionSizeLimitsExceeded(
   sizeLimit: number,
   unpackedSizeLimit: number,
 ) {
+  const effectiveUnpackedSizeLimit = Math.max(sizeLimit, unpackedSizeLimit);
   const sizes: PackageVersionSizeLimitExceeded[] = [
     { name: 'size', value: dist.size ?? 0, limit: sizeLimit },
-    { name: 'unpacked size', value: dist.unpackedSize ?? 0, limit: unpackedSizeLimit },
+    { name: 'unpacked size', value: dist.unpackedSize ?? 0, limit: effectiveUnpackedSizeLimit },
   ];
   return sizes.filter(({ value, limit }) => value > limit);
 }

--- a/app/core/service/PackageSyncerService.ts
+++ b/app/core/service/PackageSyncerService.ts
@@ -50,6 +50,32 @@ interface syncDeletePkgOptions {
   data: Buffer;
 }
 
+interface PackageVersionSizeLimitExceeded {
+  name: 'size' | 'unpacked size';
+  value: number;
+  limit: number;
+}
+
+function getPackageVersionSizeLimitsExceeded(
+  dist: NonNullable<PackageJSONType['dist']>,
+  sizeLimit: number,
+  unpackedSizeLimit: number,
+) {
+  const sizes: PackageVersionSizeLimitExceeded[] = [
+    { name: 'size', value: dist.size ?? 0, limit: sizeLimit },
+    { name: 'unpacked size', value: dist.unpackedSize ?? 0, limit: unpackedSizeLimit },
+  ];
+  return sizes.filter(({ value, limit }) => value > limit);
+}
+
+function formatPackageVersionSizeLimitsExceeded(exceededLimits: PackageVersionSizeLimitExceeded[]) {
+  return exceededLimits.map(({ name, value, limit }) => `${name}: ${value}, allow ${name}: ${limit}`).join(', ');
+}
+
+function formatPackageVersionSizesExceeded(exceededLimits: PackageVersionSizeLimitExceeded[]) {
+  return exceededLimits.map(({ name, value }) => `${name}: ${value}`).join(', ');
+}
+
 function isoNow() {
   return new Date().toISOString();
 }
@@ -931,14 +957,21 @@ data sample: ${remoteData.subarray(0, 200).toString()}`;
         logs = [];
         continue;
       }
-      const size = dist.size ?? dist.unpackedSize;
-      if (size && size > this.config.cnpmcore.largePackageVersionSize) {
+      const size = dist.size;
+      const unpackedSize = dist.unpackedSize;
+      const exceededSizeLimits = getPackageVersionSizeLimitsExceeded(
+        dist,
+        this.config.cnpmcore.largePackageVersionSize,
+        this.config.cnpmcore.largePackageVersionUnpackedSize,
+      );
+      if (exceededSizeLimits.length > 0) {
+        const exceededSizeLimitsMessage = formatPackageVersionSizeLimitsExceeded(exceededSizeLimits);
         const allowed = await this.packageVersionFileService.isLargePackageVersionAllowed(scope, name, version);
         const whiteListVersion = this.packageVersionFileService.unpkgWhiteListVersion;
         if (!allowed) {
           largeVersionCount++;
           if (largeVersionCount > this.config.cnpmcore.largePackageVersionBlockThreshold) {
-            task.error = `Synced version ${version} fail, too many large versions (${largeVersionCount}), large package version size: ${size}, allow size: ${this.config.cnpmcore.largePackageVersionSize}, see ${UNPKG_WHITE_LIST_URL}, white list version: ${whiteListVersion}`;
+            task.error = `Synced version ${version} fail, too many large versions (${largeVersionCount}), large package version ${exceededSizeLimitsMessage}, see ${UNPKG_WHITE_LIST_URL}, white list version: ${whiteListVersion}`;
             logs.push(`[${isoNow()}] ❌ ${task.error}, log: ${logUrl}`);
             logs.push(`[${isoNow()}] ❌❌❌❌❌ ${fullname} ❌❌❌❌❌`);
             await this.taskService.finishTask(task, TaskState.Fail, logs.join('\n'));
@@ -950,21 +983,21 @@ data sample: ${remoteData.subarray(0, 200).toString()}`;
             );
             return;
           }
-          lastErrorMessage = `large package version size: ${size}, allow size: ${this.config.cnpmcore.largePackageVersionSize}, see ${UNPKG_WHITE_LIST_URL}, white list version: ${whiteListVersion}`;
+          lastErrorMessage = `large package version ${exceededSizeLimitsMessage}, see ${UNPKG_WHITE_LIST_URL}, white list version: ${whiteListVersion}`;
           logs.push(`[${isoNow()}] ⚠️ [${syncIndex}] Synced version ${version} skipped, ${lastErrorMessage}`);
           await this.taskService.appendTaskLog(task, logs.join('\n'));
           logs = [];
           continue;
         }
         logs.push(
-          `[${isoNow()}] 🚧 [${syncIndex}] Synced version ${version} size: ${size} too large, it is allowed to sync by unpkg white list, white list version: ${whiteListVersion}`,
+          `[${isoNow()}] 🚧 [${syncIndex}] Synced version ${version} ${formatPackageVersionSizesExceeded(exceededSizeLimits)} too large, it is allowed to sync by unpkg white list, white list version: ${whiteListVersion}`,
         );
       }
       const publishTimeISO = timeMap[version];
       const publishTime = publishTimeISO ? new Date(publishTimeISO) : new Date();
       const delay = Date.now() - publishTime.getTime();
       logs.push(
-        `[${isoNow()}] 🚧 [${syncIndex}] Syncing version ${version}, delay: ${delay}ms [${publishTimeISO}], tarball: ${tarball}, size: ${size}`,
+        `[${isoNow()}] 🚧 [${syncIndex}] Syncing version ${version}, delay: ${delay}ms [${publishTimeISO}], tarball: ${tarball}, size: ${size}, unpacked size: ${unpackedSize}`,
       );
       let localFile: string;
       try {
@@ -1453,14 +1486,21 @@ ${diff.addedVersions.length} added, ${diff.removedVersions.length} removed, calc
         continue;
       }
 
-      const size = dist.size ?? dist.unpackedSize;
-      if (size && size > this.config.cnpmcore.largePackageVersionSize) {
+      const size = dist.size;
+      const unpackedSize = dist.unpackedSize;
+      const exceededSizeLimits = getPackageVersionSizeLimitsExceeded(
+        dist,
+        this.config.cnpmcore.largePackageVersionSize,
+        this.config.cnpmcore.largePackageVersionUnpackedSize,
+      );
+      if (exceededSizeLimits.length > 0) {
+        const exceededSizeLimitsMessage = formatPackageVersionSizeLimitsExceeded(exceededSizeLimits);
         const allowed = await this.packageVersionFileService.isLargePackageVersionAllowed(scope, name, version);
         const whiteListVersion = this.packageVersionFileService.unpkgWhiteListVersion;
         if (!allowed) {
           largeVersionCount++;
           if (largeVersionCount > this.config.cnpmcore.largePackageVersionBlockThreshold) {
-            task.error = `Synced version ${version} fail, too many large versions (${largeVersionCount}), large package version size: ${size}, allow size: ${this.config.cnpmcore.largePackageVersionSize}, see ${UNPKG_WHITE_LIST_URL}, white list version: ${whiteListVersion}`;
+            task.error = `Synced version ${version} fail, too many large versions (${largeVersionCount}), large package version ${exceededSizeLimitsMessage}, see ${UNPKG_WHITE_LIST_URL}, white list version: ${whiteListVersion}`;
             logs.push(`[${isoNow()}] ❌ ${task.error}, log: ${logUrl}`);
             logs.push(`[${isoNow()}] ❌❌❌❌❌ ${fullname} ❌❌❌❌❌`);
             await this.taskService.finishTask(task, TaskState.Fail, logs.join('\n'));
@@ -1472,14 +1512,14 @@ ${diff.addedVersions.length} added, ${diff.removedVersions.length} removed, calc
             );
             return;
           }
-          lastErrorMessage = `large package version size: ${size}, allow size: ${this.config.cnpmcore.largePackageVersionSize}, see ${UNPKG_WHITE_LIST_URL}, white list version: ${whiteListVersion}`;
+          lastErrorMessage = `large package version ${exceededSizeLimitsMessage}, see ${UNPKG_WHITE_LIST_URL}, white list version: ${whiteListVersion}`;
           logs.push(`[${isoNow()}] ⚠️ [${syncIndex}] Synced version ${version} skipped, ${lastErrorMessage}`);
           await this.taskService.appendTaskLog(task, logs.join('\n'));
           logs = [];
           continue;
         }
         logs.push(
-          `[${isoNow()}] 🚧 [${syncIndex}] Synced version ${version} size: ${size} too large, it is allowed to sync by unpkg white list, white list version: ${whiteListVersion}`,
+          `[${isoNow()}] 🚧 [${syncIndex}] Synced version ${version} ${formatPackageVersionSizesExceeded(exceededSizeLimits)} too large, it is allowed to sync by unpkg white list, white list version: ${whiteListVersion}`,
         );
       }
 
@@ -1487,7 +1527,7 @@ ${diff.addedVersions.length} added, ${diff.removedVersions.length} removed, calc
       const publishTime = publishTimeISO ? new Date(publishTimeISO) : new Date();
       const delay = Date.now() - publishTime.getTime();
       logs.push(
-        `[${isoNow()}] 🚧 [${syncIndex}] Syncing version ${version}, delay: ${delay}ms [${publishTimeISO}], tarball: ${tarball}, size: ${size}`,
+        `[${isoNow()}] 🚧 [${syncIndex}] Syncing version ${version}, delay: ${delay}ms [${publishTimeISO}], tarball: ${tarball}, size: ${size}, unpacked size: ${unpackedSize}`,
       );
       let localFile: string;
       try {

--- a/app/port/config.ts
+++ b/app/port/config.ts
@@ -163,12 +163,14 @@ export interface CnpmcoreConfig {
    */
   enableSyncUnpkgFilesWhiteList: boolean;
   /**
-   * maximum tgz file size for a package version, default is MAX_SAFE_INTEGER
+   * This value sets the maximum tgz file size for one package version.
+   * The default is Number.MAX_SAFE_INTEGER.
    */
   largePackageVersionSize: number;
   /**
-   * maximum unpacked size for a package version, default is 256MB.
-   * largePackageVersionSize is used when it is greater than this value.
+   * This value sets the maximum unpacked size for one package version.
+   * The default is 256 MiB.
+   * The service uses the greater of the two size limits as the unpacked size limit.
    */
   largePackageVersionUnpackedSize: number;
   /**

--- a/app/port/config.ts
+++ b/app/port/config.ts
@@ -163,9 +163,13 @@ export interface CnpmcoreConfig {
    */
   enableSyncUnpkgFilesWhiteList: boolean;
   /**
-   * allow large package version size, default is MAX_SAFE_INTEGER
+   * maximum tgz file size for a package version, default is MAX_SAFE_INTEGER
    */
   largePackageVersionSize: number;
+  /**
+   * maximum unpacked size for a package version, default is 256MB
+   */
+  largePackageVersionUnpackedSize: number;
   /**
    * When the number of oversized versions exceeds this threshold, the sync task will fail.
    * Oversized versions within the threshold will be skipped and the rest will still be synced.

--- a/app/port/config.ts
+++ b/app/port/config.ts
@@ -167,7 +167,8 @@ export interface CnpmcoreConfig {
    */
   largePackageVersionSize: number;
   /**
-   * maximum unpacked size for a package version, default is 256MB
+   * maximum unpacked size for a package version, default is 256MB.
+   * largePackageVersionSize is used when it is greater than this value.
    */
   largePackageVersionUnpackedSize: number;
   /**

--- a/app/repository/PackageRepository.ts
+++ b/app/repository/PackageRepository.ts
@@ -159,7 +159,8 @@ export type AbbreviatedKey =
 
 export interface DistType {
   tarball: string;
-  size: number;
+  size?: number;
+  unpackedSize?: number;
   shasum: string;
   integrity: string;
   [key: string]: unknown;

--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -58,6 +58,7 @@ export const cnpmcoreConfig: CnpmcoreConfig = {
   enableSyncUnpkgFiles: true,
   enableSyncUnpkgFilesWhiteList: false,
   largePackageVersionSize: Number.MAX_SAFE_INTEGER,
+  largePackageVersionUnpackedSize: 256 * 1024 * 1024,
   largePackageVersionBlockThreshold: 3,
   strictSyncSpecivicVersion: false,
   enableElasticsearch: env('CNPMCORE_CONFIG_ENABLE_ES', 'boolean', false),

--- a/test/core/service/PackageSyncerService/executeTask.test.ts
+++ b/test/core/service/PackageSyncerService/executeTask.test.ts
@@ -2468,11 +2468,11 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       // console.log(log);
       assert.match(
         log,
-        /Synced version 2.0.0 skipped, large package version size: 104857601, allow size: 104857600, see https:\/\/github\.com\/cnpm\/unpkg-white-list/,
+        /Synced version 2.0.0 skipped, large package version tgz size: 104857601, maximum tgz size: 104857600, see https:\/\/github\.com\/cnpm\/unpkg-white-list/,
       );
     });
 
-    it('should sync unpacked package within the separate size limit', async () => {
+    it('should sync package when unpacked size is below its limit', async () => {
       app.mockHttpclient('https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz', 'GET', {
         data: await TestUtil.readFixturesFile('registry.npmjs.org/foobar/-/foobar-1.0.0.tgz'),
         persist: false,
@@ -2512,7 +2512,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       app.mockAgent().assertNoPendingInterceptors();
     });
 
-    it('should mock large package version size skip by unpackedSize when under threshold', async () => {
+    it('should skip package when unpacked size exceeds its limit', async () => {
       mock.error(NPMRegistry.prototype, 'downloadTarball');
       mock.data(NPMRegistry.prototype, 'getFullManifestsBuffer', {
         data: Buffer.from(
@@ -2544,7 +2544,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       // console.log(log);
       assert.match(
         log,
-        /Synced version 2.0.0 skipped, large package version unpacked size: 104857601, allow unpacked size: 104857600, see https:\/\/github\.com\/cnpm\/unpkg-white-list/,
+        /Synced version 2.0.0 skipped, large package version unpacked size: 104857601, maximum unpacked size: 104857600, see https:\/\/github\.com\/cnpm\/unpkg-white-list/,
       );
     });
 
@@ -2628,7 +2628,10 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
       assert.match(log, /🟢 Synced updated 1 versions, removed 0 versions/);
-      assert.match(log, /Synced version 2.0.0 size: 104857601 too large, it is allowed to sync by unpkg white list/);
+      assert.match(
+        log,
+        /Synced version 2.0.0 tgz size: 104857601 too large, it is allowed to sync by unpkg white list/,
+      );
       app.mockAgent().assertNoPendingInterceptors();
     });
 

--- a/test/core/service/PackageSyncerService/executeTask.test.ts
+++ b/test/core/service/PackageSyncerService/executeTask.test.ts
@@ -2472,6 +2472,46 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       );
     });
 
+    it('should sync unpacked package within the separate size limit', async () => {
+      app.mockHttpclient('https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz', 'GET', {
+        data: await TestUtil.readFixturesFile('registry.npmjs.org/foobar/-/foobar-1.0.0.tgz'),
+        persist: false,
+      });
+      mock.data(NPMRegistry.prototype, 'getFullManifestsBuffer', {
+        data: Buffer.from(
+          JSON.stringify({
+            maintainers: [{ name: 'fengmk2', email: 'fengmk2@gmai.com' }],
+            versions: {
+              '2.0.0': {
+                version: '2.0.0',
+                dist: {
+                  tarball: 'https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz',
+                  unpackedSize: 100 * 1024 * 1024 + 1,
+                },
+              },
+            },
+          }),
+        ),
+        res: {},
+        headers: {},
+      });
+      mock(app.config.cnpmcore, 'largePackageVersionSize', 80 * 1024 * 1024);
+      mock(app.config.cnpmcore, 'largePackageVersionUnpackedSize', 256 * 1024 * 1024);
+      mock.error(PackageVersionFileService.prototype, 'isLargePackageVersionAllowed');
+      const name = 'cnpmcore-test-sync-deprecated';
+      await packageSyncerService.createTask(name);
+      const task = await packageSyncerService.findExecuteTask();
+      assert.ok(task);
+      assert.equal(task.targetName, name);
+      await packageSyncerService.executeTask(task);
+      const stream = await packageSyncerService.findTaskLog(task);
+      assert.ok(stream);
+      const log = await TestUtil.readStreamToLog(stream);
+      assert.match(log, /🟢 Synced updated 1 versions, removed 0 versions/);
+      assert.doesNotMatch(log, /Synced version 2.0.0 skipped/);
+      app.mockAgent().assertNoPendingInterceptors();
+    });
+
     it('should mock large package version size skip by unpackedSize when under threshold', async () => {
       mock.error(NPMRegistry.prototype, 'downloadTarball');
       mock.data(NPMRegistry.prototype, 'getFullManifestsBuffer', {
@@ -2490,7 +2530,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         headers: {},
       });
       mock(app.config.cnpmcore, 'enableSyncUnpkgFilesWhiteList', true);
-      mock(app.config.cnpmcore, 'largePackageVersionSize', 100 * 1024 * 1024);
+      mock(app.config.cnpmcore, 'largePackageVersionUnpackedSize', 100 * 1024 * 1024);
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
@@ -2503,7 +2543,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
       // console.log(log);
       assert.match(
         log,
-        /Synced version 2.0.0 skipped, large package version size: 104857601, allow size: 104857600, see https:\/\/github\.com\/cnpm\/unpkg-white-list/,
+        /Synced version 2.0.0 skipped, large package version unpacked size: 104857601, allow unpacked size: 104857600, see https:\/\/github\.com\/cnpm\/unpkg-white-list/,
       );
     });
 

--- a/test/core/service/PackageSyncerService/executeTask.test.ts
+++ b/test/core/service/PackageSyncerService/executeTask.test.ts
@@ -2530,6 +2530,7 @@ describe('test/core/service/PackageSyncerService/executeTask.test.ts', () => {
         headers: {},
       });
       mock(app.config.cnpmcore, 'enableSyncUnpkgFilesWhiteList', true);
+      mock(app.config.cnpmcore, 'largePackageVersionSize', 80 * 1024 * 1024);
       mock(app.config.cnpmcore, 'largePackageVersionUnpackedSize', 100 * 1024 * 1024);
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);

--- a/test/core/service/PackageSyncerService/executeTaskWithPackument.test.ts
+++ b/test/core/service/PackageSyncerService/executeTaskWithPackument.test.ts
@@ -2396,7 +2396,7 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
       );
     });
 
-    it('should sync unpacked package within the separate size limit', async () => {
+    it('should use tgz size limit as minimum unpacked size limit', async () => {
       app.mockHttpclient('https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz', 'GET', {
         data: await TestUtil.readFixturesFile('registry.npmjs.org/foobar/-/foobar-1.0.0.tgz'),
         persist: false,
@@ -2419,8 +2419,8 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
         res: {},
         headers: {},
       });
-      mock(app.config.cnpmcore, 'largePackageVersionSize', 80 * 1024 * 1024);
-      mock(app.config.cnpmcore, 'largePackageVersionUnpackedSize', 256 * 1024 * 1024);
+      mock(app.config.cnpmcore, 'largePackageVersionSize', 256 * 1024 * 1024);
+      mock(app.config.cnpmcore, 'largePackageVersionUnpackedSize', 80 * 1024 * 1024);
       mock.error(PackageVersionFileService.prototype, 'isLargePackageVersionAllowed');
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
@@ -2454,6 +2454,7 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
         headers: {},
       });
       mock(app.config.cnpmcore, 'enableSyncUnpkgFilesWhiteList', true);
+      mock(app.config.cnpmcore, 'largePackageVersionSize', 80 * 1024 * 1024);
       mock(app.config.cnpmcore, 'largePackageVersionUnpackedSize', 100 * 1024 * 1024);
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);

--- a/test/core/service/PackageSyncerService/executeTaskWithPackument.test.ts
+++ b/test/core/service/PackageSyncerService/executeTaskWithPackument.test.ts
@@ -2396,6 +2396,46 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
       );
     });
 
+    it('should sync unpacked package within the separate size limit', async () => {
+      app.mockHttpclient('https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz', 'GET', {
+        data: await TestUtil.readFixturesFile('registry.npmjs.org/foobar/-/foobar-1.0.0.tgz'),
+        persist: false,
+      });
+      mock.data(NPMRegistry.prototype, 'getFullManifestsBuffer', {
+        data: Buffer.from(
+          JSON.stringify({
+            maintainers: [{ name: 'fengmk2', email: 'fengmk2@gmai.com' }],
+            versions: {
+              '2.0.0': {
+                version: '2.0.0',
+                dist: {
+                  tarball: 'https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz',
+                  unpackedSize: 100 * 1024 * 1024 + 1,
+                },
+              },
+            },
+          }),
+        ),
+        res: {},
+        headers: {},
+      });
+      mock(app.config.cnpmcore, 'largePackageVersionSize', 80 * 1024 * 1024);
+      mock(app.config.cnpmcore, 'largePackageVersionUnpackedSize', 256 * 1024 * 1024);
+      mock.error(PackageVersionFileService.prototype, 'isLargePackageVersionAllowed');
+      const name = 'cnpmcore-test-sync-deprecated';
+      await packageSyncerService.createTask(name);
+      const task = await packageSyncerService.findExecuteTask();
+      assert.ok(task);
+      assert.equal(task.targetName, name);
+      await packageSyncerService.executeTask(task);
+      const stream = await packageSyncerService.findTaskLog(task);
+      assert.ok(stream);
+      const log = await TestUtil.readStreamToLog(stream);
+      assert.match(log, /🟢 Synced updated 1 versions, removed 0 versions/);
+      assert.doesNotMatch(log, /Synced version 2.0.0 skipped/);
+      app.mockAgent().assertNoPendingInterceptors();
+    });
+
     it('should mock large package version size skip by unpackedSize when under threshold', async () => {
       mock.error(NPMRegistry.prototype, 'downloadTarball');
       mock.data(NPMRegistry.prototype, 'getFullManifestsBuffer', {
@@ -2414,7 +2454,7 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
         headers: {},
       });
       mock(app.config.cnpmcore, 'enableSyncUnpkgFilesWhiteList', true);
-      mock(app.config.cnpmcore, 'largePackageVersionSize', 100 * 1024 * 1024);
+      mock(app.config.cnpmcore, 'largePackageVersionUnpackedSize', 100 * 1024 * 1024);
       const name = 'cnpmcore-test-sync-deprecated';
       await packageSyncerService.createTask(name);
       const task = await packageSyncerService.findExecuteTask();
@@ -2427,7 +2467,7 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
       // console.log(log);
       assert.match(
         log,
-        /Synced version 2.0.0 skipped, large package version size: 104857601, allow size: 104857600, see https:\/\/github\.com\/cnpm\/unpkg-white-list/,
+        /Synced version 2.0.0 skipped, large package version unpacked size: 104857601, allow unpacked size: 104857600, see https:\/\/github\.com\/cnpm\/unpkg-white-list/,
       );
     });
 

--- a/test/core/service/PackageSyncerService/executeTaskWithPackument.test.ts
+++ b/test/core/service/PackageSyncerService/executeTaskWithPackument.test.ts
@@ -2392,11 +2392,11 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
       // console.log(log);
       assert.match(
         log,
-        /Synced version 2.0.0 skipped, large package version size: 104857601, allow size: 104857600, see https:\/\/github\.com\/cnpm\/unpkg-white-list/,
+        /Synced version 2.0.0 skipped, large package version tgz size: 104857601, maximum tgz size: 104857600, see https:\/\/github\.com\/cnpm\/unpkg-white-list/,
       );
     });
 
-    it('should use tgz size limit as minimum unpacked size limit', async () => {
+    it('should use the greater limit for unpacked size', async () => {
       app.mockHttpclient('https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz', 'GET', {
         data: await TestUtil.readFixturesFile('registry.npmjs.org/foobar/-/foobar-1.0.0.tgz'),
         persist: false,
@@ -2436,7 +2436,7 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
       app.mockAgent().assertNoPendingInterceptors();
     });
 
-    it('should mock large package version size skip by unpackedSize when under threshold', async () => {
+    it('should skip package when unpacked size exceeds its limit', async () => {
       mock.error(NPMRegistry.prototype, 'downloadTarball');
       mock.data(NPMRegistry.prototype, 'getFullManifestsBuffer', {
         data: Buffer.from(
@@ -2468,7 +2468,7 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
       // console.log(log);
       assert.match(
         log,
-        /Synced version 2.0.0 skipped, large package version unpacked size: 104857601, allow unpacked size: 104857600, see https:\/\/github\.com\/cnpm\/unpkg-white-list/,
+        /Synced version 2.0.0 skipped, large package version unpacked size: 104857601, maximum unpacked size: 104857600, see https:\/\/github\.com\/cnpm\/unpkg-white-list/,
       );
     });
 
@@ -2552,7 +2552,10 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
       const log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
       assert.match(log, /🟢 Synced updated 1 versions, removed 0 versions/);
-      assert.match(log, /Synced version 2.0.0 size: 104857601 too large, it is allowed to sync by unpkg white list/);
+      assert.match(
+        log,
+        /Synced version 2.0.0 tgz size: 104857601 too large, it is allowed to sync by unpkg white list/,
+      );
       app.mockAgent().assertNoPendingInterceptors();
     });
 
@@ -2647,7 +2650,7 @@ describe('test/core/service/PackageSyncerService/executeTaskWithPackument.test.t
       log = await TestUtil.readStreamToLog(stream);
       // console.log(log);
       // large version should be skipped, not fail the task
-      assert.match(log, /Synced version 99.0.0-beta.0 skipped, large package version size: 104857601/);
+      assert.match(log, /Synced version 99.0.0-beta.0 skipped, large package version tgz size: 104857601/);
       // other versions should be synced successfully
       data = await packageManagerService.listPackageFullManifests('', name);
       assert(data.data?.versions['0.0.0']);


### PR DESCRIPTION
This change separates the tgz size limit from the unpacked package size limit.

`largePackageVersionSize` continues to control the tgz file size. The new `largePackageVersionUnpackedSize` option controls the unpacked size. The service uses a 256 MiB default limit for the unpacked size.

The sync service checks both limits. The service log identifies each limit that the package exceeds. This change lets valid compressed packages sync when only their unpacked size exceeds the tgz limit.

This change relates to #1134.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate limits for package tarballs and unpacked contents.
  * Package synchronization now evaluates and reports both sizes.
  * Added a default 256 MB limit for unpacked package contents.
  * Unpacked-size limits are normalized to respect the tarball-size limit.

* **Bug Fixes**
  * Improved rejection and whitelist messages to identify exceeded limits.

* **Tests**
  * Added coverage for independent and combined size-limit scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->