### PR TITLE
chore: remove leoric compatibility mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "fast-xml-parser": "^5.8.0",
     "fs-cnpm": "^2.4.1",
     "ioredis": "^5.8.2",
-    "leoric": "^2.15.0",
+    "leoric": "^2.16.0",
     "lodash-es": "^4.17.21",
     "mime-types": "^3.0.2",
     "mysql2": "^3.15.3",

--- a/test/.setup.ts
+++ b/test/.setup.ts
@@ -3,15 +3,6 @@ import { afterEach, beforeEach, vi } from 'vite-plus/test';
 import { PackageManagerService } from '../app/core/service/PackageManagerService.ts';
 import { TestUtil } from './TestUtil.ts';
 
-// egg-bin inlines dependencies in Vitest, but Leoric 2.15's ESM entry also assigns to module.exports.
-// Load its CommonJS condition so Vitest does not evaluate those incompatible module semantics together.
-// Remove this mock once cnpmcore requires a Leoric release containing https://github.com/cyjake/leoric/pull/499.
-vi.mock('leoric', async () => {
-  const { createRequire } = await import('node:module');
-  const leoric = createRequire(import.meta.url)('leoric') as typeof import('leoric');
-  return { ...leoric, default: leoric };
-});
-
 // vitest hookTimeout defaults to 10s, align with egg-bin's testTimeout (60s)
 vi.setConfig({ hookTimeout: 60_000 });
 


### PR DESCRIPTION
## Summary

- require Leoric 2.16.0, which includes the ESM/CommonJS interop fix from cyjake/leoric#499
- remove the test-wide CommonJS compatibility mock for Leoric

## Testing

- ut lint
- ut typecheck
- ut run test:local -- test/repository/util/ErrorUtil.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and reliability through an updated database library version.
  * Resolved an issue affecting test setup and application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->